### PR TITLE
Fix FMEA peer failure mode addition bug

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -4825,11 +4825,19 @@ class FaultTreeApp:
             elif node:
                 # gather all failure modes under the same component/parent
                 if node.parents:
-                    parent = node.parents[0]
-                    related = [be for be in basic_events if be.parents and be.parents[0] == parent]
+                    parent_id = node.parents[0].unique_id
+                    related = [
+                        be
+                        for be in basic_events
+                        if be.parents and be.parents[0].unique_id == parent_id
+                    ]
                 else:
                     comp = getattr(node, "fmea_component", "")
-                    related = [be for be in basic_events if not be.parents and getattr(be, "fmea_component", "") == comp]
+                    related = [
+                        be
+                        for be in basic_events
+                        if not be.parents and getattr(be, "fmea_component", "") == comp
+                    ]
                 if node not in related:
                     related.append(node)
                 existing_ids = {be.unique_id for be in entries}


### PR DESCRIPTION
## Summary
- ensure peer failure modes are gathered by comparing parent unique ids

## Testing
- `python3 -m py_compile FreeCTA.py`

------
https://chatgpt.com/codex/tasks/task_b_687937b5ee1c8325a007c0a4b431a5fb