### PR TITLE
Fix component persistence for FMEA entries

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -4710,8 +4710,8 @@ class FaultTreeApp:
             comp = self.comp_var.get()
             if self.node.parents:
                 self.node.parents[0].user_name = comp
-            else:
-                self.node.fmea_component = comp
+            # Always store the component name so it can be restored on load
+            self.node.fmea_component = comp
             self.node.description = self.mode_var.get()
             self.node.fmea_effect = self.effect_text.get("1.0", "end-1c")
             self.node.fmea_cause = self.cause_text.get("1.0", "end-1c")


### PR DESCRIPTION
## Summary
- ensure component name for an FMEA entry is stored even when it is derived from a base event parent

## Testing
- `python3 -m py_compile FreeCTA.py`


------
https://chatgpt.com/codex/tasks/task_b_6879469ab0cc8325b1ee9af830bc01b1