### PR TITLE
Add review toolbox for peer and joint reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-"# FreeCTA" 
+# FreeCTA
+
+This repository contains a graphical fault tree analysis tool. The latest update adds a **Review Toolbox** supporting peer and joint review workflows.
+
+## Review Toolbox
+
+Launch the review features from the **Review** menu:
+
+* **Start Peer Review** – every participant can add comments to any node.
+* **Start Joint Review** – define reviewers and approvers. Approvers may only approve once all reviewers have marked their work complete and all comments are resolved.
+* **Open Review Toolbox** – opens a window to add and resolve comments. Selecting a comment focuses the related node.
+* **Set Current User** – choose which participant you are when entering comments.
+
+Review information (participants, comments, approval state) is saved as part of the model file and restored on load.

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -1,0 +1,112 @@
+import tkinter as tk
+from tkinter import simpledialog, messagebox, ttk
+from dataclasses import dataclass, asdict
+from typing import List, Dict
+
+@dataclass
+class ReviewParticipant:
+    name: str
+    email: str
+    role: str  # 'reviewer' or 'approver'
+    done: bool = False
+
+@dataclass
+class ReviewComment:
+    comment_id: int
+    node_id: int
+    text: str
+    reviewer: str
+    resolved: bool = False
+
+@dataclass
+class ReviewData:
+    mode: str  # 'peer' or 'joint'
+    participants: List[ReviewParticipant]
+    comments: List[ReviewComment]
+    approved: bool = False
+
+class ReviewToolbox(tk.Toplevel):
+    def __init__(self, master, app):
+        super().__init__(master)
+        self.title("Review Toolbox")
+        self.app = app
+        self.protocol("WM_DELETE_WINDOW", self.on_close)
+
+        self.comment_list = tk.Listbox(self, width=50)
+        self.comment_list.pack(fill=tk.BOTH, expand=True)
+        self.comment_list.bind("<<ListboxSelect>>", self.on_select)
+
+        btn_frame = tk.Frame(self)
+        btn_frame.pack(fill=tk.X)
+        tk.Button(btn_frame, text="Add Comment", command=self.add_comment).pack(side=tk.LEFT)
+        tk.Button(btn_frame, text="Resolve", command=self.resolve_comment).pack(side=tk.LEFT)
+        tk.Button(btn_frame, text="Mark Done", command=self.mark_done).pack(side=tk.LEFT)
+        tk.Button(btn_frame, text="Approve", command=self.approve).pack(side=tk.LEFT)
+
+        self.refresh_comments()
+
+    def on_close(self):
+        self.app.review_window = None
+        self.destroy()
+
+    def refresh_comments(self):
+        self.comment_list.delete(0, tk.END)
+        if not self.app.review_data:
+            return
+        for c in self.app.review_data.comments:
+            node = self.app.find_node_by_id_all(c.node_id)
+            node_name = node.name if node else f"ID {c.node_id}"
+            status = "(resolved)" if c.resolved else ""
+            self.comment_list.insert(tk.END, f"{c.comment_id}: {node_name} - {c.reviewer} {status}")
+
+    def on_select(self, event):
+        if not self.app.review_data:
+            return
+        selection = self.comment_list.curselection()
+        if selection:
+            c = self.app.review_data.comments[selection[0]]
+            node = self.app.find_node_by_id_all(c.node_id)
+            if node:
+                self.app.focus_on_node(node)
+
+    def add_comment(self):
+        if not self.app.selected_node:
+            messagebox.showwarning("Add Comment", "Select a node first")
+            return
+        reviewer = self.app.current_user
+        text = simpledialog.askstring("Comment", "Enter comment:")
+        if not text:
+            return
+        comment_id = len(self.app.review_data.comments) + 1
+        c = ReviewComment(comment_id, self.app.selected_node.unique_id, text, reviewer)
+        self.app.review_data.comments.append(c)
+        self.refresh_comments()
+
+    def resolve_comment(self):
+        idx = self.comment_list.curselection()
+        if not idx:
+            return
+        c = self.app.review_data.comments[idx[0]]
+        c.resolved = True
+        self.refresh_comments()
+
+    def mark_done(self):
+        user = self.app.current_user
+        for p in self.app.review_data.participants:
+            if p.name == user:
+                p.done = True
+        messagebox.showinfo("Review", "Marked as done")
+
+    def approve(self):
+        if self.app.review_data.mode == 'joint':
+            all_done = all(p.done for p in self.app.review_data.participants if p.role == 'reviewer')
+            if not all_done:
+                messagebox.showwarning("Approve", "Not all reviewers are done")
+                return
+        unresolved = [c for c in self.app.review_data.comments if not c.resolved]
+        if unresolved:
+            messagebox.showwarning("Approve", "There are unresolved comments")
+            return
+        self.app.review_data.approved = True
+        messagebox.showinfo("Approve", "Review approved")
+


### PR DESCRIPTION
## Summary
- add graphical review toolbox for peer and joint reviews
- show review menu with options to start or open reviews and set current user
- persist reviewers, comments and approval state in saved models
- highlight nodes with unresolved comments
- document review workflow in README

## Testing
- `python3 -m py_compile FreeCTA.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_687a479762b8832581f7750bdbc36998