### PR TITLE
Add review descriptions

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -5511,6 +5511,7 @@ class FaultTreeApp:
         for r in self.reviews:
             reviews.append({
                 "name": r.name,
+                "description": r.description,
                 "mode": r.mode,
                 "approved": r.approved,
                 "participants": [asdict(p) for p in r.participants],
@@ -5584,7 +5585,7 @@ class FaultTreeApp:
             for rd in reviews_data:
                 participants = [ReviewParticipant(**p) for p in rd.get("participants", [])]
                 comments = [ReviewComment(**c) for c in rd.get("comments", [])]
-                self.reviews.append(ReviewData(name=rd.get("name", ""), mode=rd.get("mode", "peer"), participants=participants, comments=comments, approved=rd.get("approved", False)))
+                self.reviews.append(ReviewData(name=rd.get("name", ""), description=rd.get("description", ""), mode=rd.get("mode", "peer"), participants=participants, comments=comments, approved=rd.get("approved", False)))
             current = data.get("current_review")
             self.review_data = None
             for r in self.reviews:
@@ -5596,7 +5597,7 @@ class FaultTreeApp:
             if rd:
                 participants = [ReviewParticipant(**p) for p in rd.get("participants", [])]
                 comments = [ReviewComment(**c) for c in rd.get("comments", [])]
-                review = ReviewData(name=rd.get("name", "Review 1"), mode=rd.get("mode", "peer"), participants=participants, comments=comments, approved=rd.get("approved", False))
+                review = ReviewData(name=rd.get("name", "Review 1"), description=rd.get("description", ""), mode=rd.get("mode", "peer"), participants=participants, comments=comments, approved=rd.get("approved", False))
                 self.reviews = [review]
                 self.review_data = review
             else:
@@ -5892,7 +5893,8 @@ class FaultTreeApp:
             if any(r.name == name for r in self.reviews):
                 messagebox.showerror("Review", "Name already exists")
                 return
-            review = ReviewData(name=name, mode='peer', participants=parts, comments=[])
+            desc = simpledialog.askstring("Description", "Enter review description:")
+            review = ReviewData(name=name, description=desc or "", mode='peer', participants=parts, comments=[])
             self.reviews.append(review)
             self.review_data = review
             self.current_user = parts[0].name
@@ -5908,7 +5910,8 @@ class FaultTreeApp:
             if any(r.name == name for r in self.reviews):
                 messagebox.showerror("Review", "Name already exists")
                 return
-            review = ReviewData(name=name, mode='joint', participants=participants, comments=[])
+            desc = simpledialog.askstring("Description", "Enter review description:")
+            review = ReviewData(name=name, description=desc or "", mode='joint', participants=participants, comments=[])
             self.reviews.append(review)
             self.review_data = review
             self.current_user = participants[0].name
@@ -5994,7 +5997,8 @@ class FaultTreeApp:
             if any(r.name == name for r in self.reviews):
                 messagebox.showerror("Review", "Name already exists")
                 return
-            review = ReviewData(name=name, mode='peer', participants=parts, comments=[])
+            desc = simpledialog.askstring("Description", "Enter review description:")
+            review = ReviewData(name=name, description=desc or "", mode='peer', participants=parts, comments=[])
             self.reviews.append(review)
             self.review_data = review
             self.current_user = parts[0].name
@@ -6010,7 +6014,8 @@ class FaultTreeApp:
             if any(r.name == name for r in self.reviews):
                 messagebox.showerror("Review", "Name already exists")
                 return
-            review = ReviewData(name=name, mode='joint', participants=participants, comments=[])
+            desc = simpledialog.askstring("Description", "Enter review description:")
+            review = ReviewData(name=name, description=desc or "", mode='joint', participants=participants, comments=[])
             self.reviews.append(review)
             self.review_data = review
             self.current_user = participants[0].name
@@ -6090,7 +6095,15 @@ class FaultTreeApp:
         dialog = ParticipantDialog(self.root, joint=False)
         if dialog.result:
             parts = dialog.result
-            self.review_data = ReviewData(mode='peer', participants=parts, comments=[])
+            name = simpledialog.askstring("Review Name", "Enter unique review name:")
+            if not name:
+                return
+            if any(r.name == name for r in self.reviews):
+                messagebox.showerror("Review", "Name already exists")
+                return
+            desc = simpledialog.askstring("Description", "Enter review description:")
+            self.review_data = ReviewData(name=name, description=desc or "", mode='peer', participants=parts, comments=[])
+            self.reviews.append(self.review_data)
             self.current_user = parts[0].name
             self.open_review_toolbox()
 
@@ -6098,7 +6111,15 @@ class FaultTreeApp:
         dialog = ParticipantDialog(self.root, joint=True)
         if dialog.result:
             participants = dialog.result
-            self.review_data = ReviewData(mode='joint', participants=participants, comments=[])
+            name = simpledialog.askstring("Review Name", "Enter unique review name:")
+            if not name:
+                return
+            if any(r.name == name for r in self.reviews):
+                messagebox.showerror("Review", "Name already exists")
+                return
+            desc = simpledialog.askstring("Description", "Enter review description:")
+            self.review_data = ReviewData(name=name, description=desc or "", mode='joint', participants=participants, comments=[])
+            self.reviews.append(self.review_data)
             self.current_user = participants[0].name
             self.open_review_toolbox()
 
@@ -6174,7 +6195,15 @@ class FaultTreeApp:
         dialog = ParticipantDialog(self.root, joint=False)
         if dialog.result:
             parts = dialog.result
-            self.review_data = ReviewData(mode='peer', participants=parts, comments=[])
+            name = simpledialog.askstring("Review Name", "Enter unique review name:")
+            if not name:
+                return
+            if any(r.name == name for r in self.reviews):
+                messagebox.showerror("Review", "Name already exists")
+                return
+            desc = simpledialog.askstring("Description", "Enter review description:")
+            self.review_data = ReviewData(name=name, description=desc or "", mode='peer', participants=parts, comments=[])
+            self.reviews.append(self.review_data)
             self.current_user = parts[0].name
             self.open_review_toolbox()
 
@@ -6182,7 +6211,15 @@ class FaultTreeApp:
         dialog = ParticipantDialog(self.root, joint=True)
         if dialog.result:
             participants = dialog.result
-            self.review_data = ReviewData(mode='joint', participants=participants, comments=[])
+            name = simpledialog.askstring("Review Name", "Enter unique review name:")
+            if not name:
+                return
+            if any(r.name == name for r in self.reviews):
+                messagebox.showerror("Review", "Name already exists")
+                return
+            desc = simpledialog.askstring("Description", "Enter review description:")
+            self.review_data = ReviewData(name=name, description=desc or "", mode='joint', participants=participants, comments=[])
+            self.reviews.append(self.review_data)
             self.current_user = participants[0].name
             self.open_review_toolbox()
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository contains a graphical fault tree analysis tool. The latest update
 
 Launch the review features from the **Review** menu:
 
-* **Start Peer Review** – create reviewers, give the review a unique name and begin commenting.
-* **Start Joint Review** – add participants with reviewer or approver roles and a unique review name. Approvers can approve only after all reviewers are done and comments resolved.
+* **Start Peer Review** – create reviewers, give the review a unique name and optional description, then begin commenting.
+* **Start Joint Review** – add participants with reviewer or approver roles along with a unique review name and description. Approvers can approve only after all reviewers are done and comments resolved.
 * **Open Review Toolbox** – manage comments. Selecting a comment focuses the related element and shows the text below the list. A drop-down at the top lists every saved review with its approval status.
 * **Compare Versions** – view earlier approved versions and highlight differences on the diagram.
 * **Set Current User** – choose who you are when adding comments. The toolbox also provides a drop-down selector.
@@ -16,4 +16,4 @@ Nodes with unresolved comments show a small yellow circle to help locate feedbac
 
 Comments can be attached to FMEA entries and individual requirements. Resolving a comment prompts for a short explanation which is shown with the original text.
 
-Review information (participants, comments, review names and approval state) is saved as part of the model file and restored on load.
+Review information (participants, comments, review names, descriptions and approval state) is saved as part of the model file and restored on load.

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -24,6 +24,7 @@ class ReviewComment:
 @dataclass
 class ReviewData:
     name: str = ""
+    description: str = ""
     mode: str = "peer"  # 'peer' or 'joint'
     participants: List[ReviewParticipant] = field(default_factory=list)
     comments: List[ReviewComment] = field(default_factory=list)
@@ -85,6 +86,8 @@ class ReviewToolbox(tk.Toplevel):
         self.review_combo.bind("<<ComboboxSelected>>", self.on_review_change)
         self.status_var = tk.StringVar()
         tk.Label(review_frame, textvariable=self.status_var).pack(side=tk.LEFT, padx=5)
+        self.desc_var = tk.StringVar()
+        tk.Label(self, textvariable=self.desc_var, wraplength=400, justify="left").pack(fill=tk.X, padx=5)
 
         user_frame = tk.Frame(self)
         user_frame.pack(fill=tk.X)
@@ -127,9 +130,11 @@ class ReviewToolbox(tk.Toplevel):
         if self.app.review_data:
             self.review_var.set(self.app.review_data.name)
             self.status_var.set("approved" if self.app.review_data.approved else "open")
+            self.desc_var.set(self.app.review_data.description)
         else:
             self.review_var.set("")
             self.status_var.set("")
+            self.desc_var.set("")
 
     def on_review_change(self, event=None):
         name = self.review_var.get()
@@ -138,6 +143,10 @@ class ReviewToolbox(tk.Toplevel):
                 self.app.review_data = r
                 break
         self.status_var.set("approved" if self.app.review_data and self.app.review_data.approved else "open")
+        if self.app.review_data:
+            self.desc_var.set(self.app.review_data.description)
+        else:
+            self.desc_var.set("")
         self.refresh_comments()
         self.update_buttons()
         try:


### PR DESCRIPTION
## Summary
- allow specifying review description when starting a review
- display selected review description in the toolbox
- persist descriptions when saving and loading models
- update docs about review creation

## Testing
- `python -m py_compile review_toolbox.py FreeCTA.py`

------
https://chatgpt.com/codex/tasks/task_b_687b2e0ff26c8325a98ec39e61d071d9