### PR TITLE
Add review scope selection and merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ This repository contains a graphical fault tree analysis tool. The latest update
 
 Launch the review features from the **Review** menu:
 
-* **Start Peer Review** – create reviewers, give the review a unique name and optional description, then begin commenting.
-* **Start Joint Review** – add participants with reviewer or approver roles along with a unique review name and description. Approvers can approve only after all reviewers are done and comments resolved.
+* **Start Peer Review** – create reviewers, choose which FTAs and FMEAs to review and give the review a unique name and optional description. A document window listing the selected elements opens so comments can be added immediately.
+* **Start Joint Review** – add participants with reviewer or approver roles, select the elements to be reviewed and enter a unique review name and description. Approvers can approve only after all reviewers are done and comments resolved.
 * **Open Review Toolbox** – manage comments. Selecting a comment focuses the related element and shows the text below the list. A drop-down at the top lists every saved review with its approval status.
+* **Merge Review Comments** – combine feedback from another saved model into the current one so parallel reviews can be consolidated.
 * **Compare Versions** – view earlier approved versions and highlight differences on the diagram.
 * **Set Current User** – choose who you are when adding comments. The toolbox also provides a drop-down selector.
 


### PR DESCRIPTION
## Summary
- extend review creation to pick FTA/FMEA scope and show document window
- allow merging review comments from another model
- add menu entry for merging comments
- document new review features

## Testing
- `python3 -m py_compile FreeCTA.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_687b33755db8832588279dc445d5b83c