### PR TITLE
Fix review comment target handling

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -4825,7 +4825,8 @@ class FaultTreeApp:
                 return
             req = self.node.safety_requirements[sel[0]]
             self.app.selected_node = self.node
-            self.app.comment_target = ("requirement", req.get("id"))
+            # include the node id as well so the toolbox has full context
+            self.app.comment_target = ("requirement", self.node.unique_id, req.get("id"))
             self.app.open_review_toolbox()
 
         def comment_fmea(self):
@@ -4840,7 +4841,7 @@ class FaultTreeApp:
                 return
             req = self.node.safety_requirements[sel[0]]
             self.app.selected_node = self.node
-            self.app.comment_target = ("requirement", req.get("id"))
+            self.app.comment_target = ("requirement", self.node.unique_id, req.get("id"))
             self.app.open_review_toolbox()
 
         def comment_requirement(self):
@@ -4850,7 +4851,7 @@ class FaultTreeApp:
                 return
             req = self.node.safety_requirements[sel[0]]
             self.app.selected_node = self.node
-            self.app.comment_target = ("requirement", req.get("id"))
+            self.app.comment_target = ("requirement", self.node.unique_id, req.get("id"))
             self.app.open_review_toolbox()
 
         def add_safety_requirement(self):

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -3,6 +3,7 @@ from tkinter import simpledialog, messagebox, ttk
 from dataclasses import dataclass, field
 from typing import List
 import sys
+import json
 
 # Access the drawing helper defined in the main application if available.
 fta_drawing_helper = getattr(sys.modules.get('__main__'), 'fta_drawing_helper', None)
@@ -363,7 +364,9 @@ class ReviewToolbox(tk.Toplevel):
             self.app.selected_node = node
             self.app.focus_on_node(node)
         if target[0] == 'requirement':
-            self.app.comment_target = ('requirement', target[2])
+            # store both node id and requirement id so add_comment can
+            # create the ReviewComment correctly
+            self.app.comment_target = ('requirement', target[1], target[2])
         elif target[0] == 'fmea':
             self.app.comment_target = ('fmea', target[1])
 


### PR DESCRIPTION
## Summary
- import `json` in Review Toolbox
- store node id alongside requirement id when selecting comment target
- fix `comment_requirement` helpers to pass node id and requirement id

## Testing
- `python3 -m py_compile review_toolbox.py FreeCTA.py`


------
https://chatgpt.com/codex/tasks/task_b_687b40cc7eb883259ab2552ef81fd153