### PR TITLE
Include moderator in review toolbox

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -5549,6 +5549,7 @@ class FaultTreeApp:
                 "name": r.name,
                 "description": r.description,
                 "mode": r.mode,
+                "moderator": r.moderator,
                 "approved": r.approved,
                 "participants": [asdict(p) for p in r.participants],
                 "comments": [asdict(c) for c in r.comments],
@@ -5621,7 +5622,17 @@ class FaultTreeApp:
             for rd in reviews_data:
                 participants = [ReviewParticipant(**p) for p in rd.get("participants", [])]
                 comments = [ReviewComment(**c) for c in rd.get("comments", [])]
-                self.reviews.append(ReviewData(name=rd.get("name", ""), description=rd.get("description", ""), mode=rd.get("mode", "peer"), participants=participants, comments=comments, approved=rd.get("approved", False)))
+                self.reviews.append(
+                    ReviewData(
+                        name=rd.get("name", ""),
+                        description=rd.get("description", ""),
+                        mode=rd.get("mode", "peer"),
+                        moderator=rd.get("moderator", ""),
+                        participants=participants,
+                        comments=comments,
+                        approved=rd.get("approved", False),
+                    )
+                )
             current = data.get("current_review")
             self.review_data = None
             for r in self.reviews:
@@ -5633,7 +5644,15 @@ class FaultTreeApp:
             if rd:
                 participants = [ReviewParticipant(**p) for p in rd.get("participants", [])]
                 comments = [ReviewComment(**c) for c in rd.get("comments", [])]
-                review = ReviewData(name=rd.get("name", "Review 1"), description=rd.get("description", ""), mode=rd.get("mode", "peer"), participants=participants, comments=comments, approved=rd.get("approved", False))
+                review = ReviewData(
+                    name=rd.get("name", "Review 1"),
+                    description=rd.get("description", ""),
+                    mode=rd.get("mode", "peer"),
+                    moderator=rd.get("moderator", ""),
+                    participants=participants,
+                    comments=comments,
+                    approved=rd.get("approved", False),
+                )
                 self.reviews = [review]
                 self.review_data = review
             else:
@@ -5927,12 +5946,16 @@ class FaultTreeApp:
             name = simpledialog.askstring("Review Name", "Enter unique review name:")
             if not name:
                 return
+            moderator = simpledialog.askstring("Moderator", "Enter moderator name:")
+            if not moderator:
+                return
             if any(r.name == name for r in self.reviews):
                 messagebox.showerror("Review", "Name already exists")
                 return
             scope = ReviewScopeDialog(self.root, self)
             fta_ids, fmea_names = scope.result if scope.result else ([], [])
-            review = ReviewData(name=name, mode='peer', participants=parts, comments=[],
+            review = ReviewData(name=name, mode='peer', moderator=moderator,
+                               participants=parts, comments=[],
                                fta_ids=fta_ids, fmea_names=fmea_names)
             self.reviews.append(review)
             self.review_data = review
@@ -5947,12 +5970,16 @@ class FaultTreeApp:
             name = simpledialog.askstring("Review Name", "Enter unique review name:")
             if not name:
                 return
+            moderator = simpledialog.askstring("Moderator", "Enter moderator name:")
+            if not moderator:
+                return
             if any(r.name == name for r in self.reviews):
                 messagebox.showerror("Review", "Name already exists")
                 return
             scope = ReviewScopeDialog(self.root, self)
             fta_ids, fmea_names = scope.result if scope.result else ([], [])
-            review = ReviewData(name=name, mode='joint', participants=participants, comments=[],
+            review = ReviewData(name=name, mode='joint', moderator=moderator,
+                               participants=participants, comments=[],
                                fta_ids=fta_ids, fmea_names=fmea_names)
             self.reviews.append(review)
             self.review_data = review
@@ -5992,10 +6019,17 @@ class FaultTreeApp:
             comments = [ReviewComment(**c) for c in rd.get("comments", [])]
             review = next((r for r in self.reviews if r.name == rd.get("name", "")), None)
             if review is None:
-                review = ReviewData(name=rd.get("name", ""), description=rd.get("description", ""),
-                                    mode=rd.get("mode", "peer"), participants=participants,
-                                    comments=comments, approved=rd.get("approved", False),
-                                    fta_ids=rd.get("fta_ids", []), fmea_names=rd.get("fmea_names", []))
+                review = ReviewData(
+                    name=rd.get("name", ""),
+                    description=rd.get("description", ""),
+                    mode=rd.get("mode", "peer"),
+                    moderator=rd.get("moderator", ""),
+                    participants=participants,
+                    comments=comments,
+                    approved=rd.get("approved", False),
+                    fta_ids=rd.get("fta_ids", []),
+                    fmea_names=rd.get("fmea_names", []),
+                )
                 self.reviews.append(review)
                 continue
             for p in participants:
@@ -6022,10 +6056,17 @@ class FaultTreeApp:
             comments = [ReviewComment(**c) for c in rd.get("comments", [])]
             review = next((r for r in self.reviews if r.name == rd.get("name", "")), None)
             if review is None:
-                review = ReviewData(name=rd.get("name", ""), description=rd.get("description", ""),
-                                    mode=rd.get("mode", "peer"), participants=participants,
-                                    comments=comments, approved=rd.get("approved", False),
-                                    fta_ids=rd.get("fta_ids", []), fmea_names=rd.get("fmea_names", []))
+                review = ReviewData(
+                    name=rd.get("name", ""),
+                    description=rd.get("description", ""),
+                    mode=rd.get("mode", "peer"),
+                    moderator=rd.get("moderator", ""),
+                    participants=participants,
+                    comments=comments,
+                    approved=rd.get("approved", False),
+                    fta_ids=rd.get("fta_ids", []),
+                    fmea_names=rd.get("fmea_names", []),
+                )
                 self.reviews.append(review)
                 continue
             for p in participants:
@@ -6052,10 +6093,17 @@ class FaultTreeApp:
             comments = [ReviewComment(**c) for c in rd.get("comments", [])]
             review = next((r for r in self.reviews if r.name == rd.get("name", "")), None)
             if review is None:
-                review = ReviewData(name=rd.get("name", ""), description=rd.get("description", ""),
-                                    mode=rd.get("mode", "peer"), participants=participants,
-                                    comments=comments, approved=rd.get("approved", False),
-                                    fta_ids=rd.get("fta_ids", []), fmea_names=rd.get("fmea_names", []))
+                review = ReviewData(
+                    name=rd.get("name", ""),
+                    description=rd.get("description", ""),
+                    mode=rd.get("mode", "peer"),
+                    moderator=rd.get("moderator", ""),
+                    participants=participants,
+                    comments=comments,
+                    approved=rd.get("approved", False),
+                    fta_ids=rd.get("fta_ids", []),
+                    fmea_names=rd.get("fmea_names", []),
+                )
                 self.reviews.append(review)
                 continue
             for p in participants:
@@ -6082,10 +6130,17 @@ class FaultTreeApp:
             comments = [ReviewComment(**c) for c in rd.get("comments", [])]
             review = next((r for r in self.reviews if r.name == rd.get("name", "")), None)
             if review is None:
-                review = ReviewData(name=rd.get("name", ""), description=rd.get("description", ""),
-                                    mode=rd.get("mode", "peer"), participants=participants,
-                                    comments=comments, approved=rd.get("approved", False),
-                                    fta_ids=rd.get("fta_ids", []), fmea_names=rd.get("fmea_names", []))
+                review = ReviewData(
+                    name=rd.get("name", ""),
+                    description=rd.get("description", ""),
+                    mode=rd.get("mode", "peer"),
+                    moderator=rd.get("moderator", ""),
+                    participants=participants,
+                    comments=comments,
+                    approved=rd.get("approved", False),
+                    fta_ids=rd.get("fta_ids", []),
+                    fmea_names=rd.get("fmea_names", []),
+                )
                 self.reviews.append(review)
                 continue
             for p in participants:
@@ -6112,10 +6167,17 @@ class FaultTreeApp:
             comments = [ReviewComment(**c) for c in rd.get("comments", [])]
             review = next((r for r in self.reviews if r.name == rd.get("name", "")), None)
             if review is None:
-                review = ReviewData(name=rd.get("name", ""), description=rd.get("description", ""),
-                                    mode=rd.get("mode", "peer"), participants=participants,
-                                    comments=comments, approved=rd.get("approved", False),
-                                    fta_ids=rd.get("fta_ids", []), fmea_names=rd.get("fmea_names", []))
+                review = ReviewData(
+                    name=rd.get("name", ""),
+                    description=rd.get("description", ""),
+                    mode=rd.get("mode", "peer"),
+                    moderator=rd.get("moderator", ""),
+                    participants=participants,
+                    comments=comments,
+                    approved=rd.get("approved", False),
+                    fta_ids=rd.get("fta_ids", []),
+                    fmea_names=rd.get("fmea_names", []),
+                )
                 self.reviews.append(review)
                 continue
             for p in participants:
@@ -6142,10 +6204,17 @@ class FaultTreeApp:
             comments = [ReviewComment(**c) for c in rd.get("comments", [])]
             review = next((r for r in self.reviews if r.name == rd.get("name", "")), None)
             if review is None:
-                review = ReviewData(name=rd.get("name", ""), description=rd.get("description", ""),
-                                    mode=rd.get("mode", "peer"), participants=participants,
-                                    comments=comments, approved=rd.get("approved", False),
-                                    fta_ids=rd.get("fta_ids", []), fmea_names=rd.get("fmea_names", []))
+                review = ReviewData(
+                    name=rd.get("name", ""),
+                    description=rd.get("description", ""),
+                    mode=rd.get("mode", "peer"),
+                    moderator=rd.get("moderator", ""),
+                    participants=participants,
+                    comments=comments,
+                    approved=rd.get("approved", False),
+                    fta_ids=rd.get("fta_ids", []),
+                    fmea_names=rd.get("fmea_names", []),
+                )
                 self.reviews.append(review)
                 continue
             for p in participants:

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -32,6 +32,7 @@ class ReviewData:
     name: str = ""
     description: str = ""
     mode: str = "peer"  # 'peer' or 'joint'
+    moderator: str = ""
     participants: List[ReviewParticipant] = field(default_factory=list)
     comments: List[ReviewComment] = field(default_factory=list)
     fta_ids: List[int] = field(default_factory=list)
@@ -130,6 +131,8 @@ class ReviewToolbox(tk.Toplevel):
         tk.Label(review_frame, textvariable=self.status_var).pack(side=tk.LEFT, padx=5)
         self.desc_var = tk.StringVar()
         tk.Label(self, textvariable=self.desc_var, wraplength=400, justify="left").pack(fill=tk.X, padx=5)
+        self.mod_var = tk.StringVar()
+        tk.Label(self, textvariable=self.mod_var).pack(fill=tk.X, padx=5)
 
         user_frame = tk.Frame(self)
         user_frame.pack(fill=tk.X)
@@ -184,10 +187,12 @@ class ReviewToolbox(tk.Toplevel):
             self.review_var.set(self.app.review_data.name)
             self.status_var.set("approved" if self.app.review_data.approved else "open")
             self.desc_var.set(self.app.review_data.description)
+            self.mod_var.set(f"Moderator: {self.app.review_data.moderator}")
         else:
             self.review_var.set("")
             self.status_var.set("")
             self.desc_var.set("")
+            self.mod_var.set("")
 
     def on_review_change(self, event=None):
         name = self.review_var.get()
@@ -198,8 +203,10 @@ class ReviewToolbox(tk.Toplevel):
         self.status_var.set("approved" if self.app.review_data and self.app.review_data.approved else "open")
         if self.app.review_data:
             self.desc_var.set(self.app.review_data.description)
+            self.mod_var.set(f"Moderator: {self.app.review_data.moderator}")
         else:
             self.desc_var.set("")
+            self.mod_var.set("")
         self.refresh_comments()
         self.refresh_targets()
         self.update_buttons()


### PR DESCRIPTION
## Summary
- add `moderator` attribute to `ReviewData`
- prompt for moderator when starting peer or joint review
- export and load moderator info with models
- display moderator in the review toolbox UI

## Testing
- `python3 -m py_compile FreeCTA.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_687b4423359c8325903e433d0670522f