### PR TITLE
Fix version comparison display

### DIFF
--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -730,7 +730,10 @@ class VersionCompareDialog(tk.Toplevel):
                 else:
                     status[nid] = "existing"
 
-        FaultTreeNodeCls = getattr(sys.modules.get('FreeCTA'), 'FaultTreeNode', None)
+        module = sys.modules.get(self.app.__class__.__module__)
+        FaultTreeNodeCls = getattr(module, 'FaultTreeNode', None)
+        if not FaultTreeNodeCls and self.app.top_events:
+            FaultTreeNodeCls = type(self.app.top_events[0])
         if not FaultTreeNodeCls:
             return
 


### PR DESCRIPTION
## Summary
- ensure FaultTreeNode class is found when comparing versions

## Testing
- `python3 -m py_compile FreeCTA.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_687c1e4372cc8325ae60619d5ca4fb53