### PR TITLE
Limit comment targets to selected review scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Launch the review features from the **Review** menu:
 * **Merge Review Comments** – combine feedback from another saved model into the current one so parallel reviews can be consolidated.
 * **Compare Versions** – view earlier approved versions. Differences are listed with a short description and small before/after images of changed FTA nodes.
 * **Set Current User** – choose who you are when adding comments. The toolbox also provides a drop-down selector.
+* The target selector within the toolbox only lists nodes and FMEA items that were chosen when the review was created, so comments can only be attached to the scoped elements.
 
 Nodes with unresolved comments show a small yellow circle to help locate feedback quickly. Differences between versions are outlined in blue when comparing.
 


### PR DESCRIPTION
## Summary
- filter review targets based on the FTAs and FMEAs chosen when creating a review
- document that the review toolbox only lists scoped items

## Testing
- `python -m py_compile FreeCTA.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_687c2a9bb19c8325928570eca7cdfd49