### PR TITLE
Fix diff colors and review target filtering

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -6240,8 +6240,8 @@ class FaultTreeApp:
                 if fmea["name"] in allowed_fmeas:
                     fmea_node_ids.update(be.unique_id for be in fmea["entries"])
         else:
-            for fmea in self.fmeas:
-                fmea_node_ids.update(be.unique_id for be in fmea["entries"])
+            # When no FMEA was selected, do not offer FMEA-related targets
+            fmea_node_ids = set()
 
         for node in nodes:
             label = node.user_name or node.description or f"Node {node.unique_id}"

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -680,7 +680,7 @@ class VersionCompareDialog(tk.Toplevel):
 
     def insert_diff(self, old, new):
         """Insert a colorized diff between old and new strings."""
-        diff = difflib.ndiff(list(old), list(new))
+        diff = difflib.ndiff(old.splitlines(keepends=True), new.splitlines(keepends=True))
         for token in diff:
             if token.startswith("- "):
                 self.log_text.insert(tk.END, token[2:], "removed")


### PR DESCRIPTION
## Summary
- highlight removed/added text in version comparison using line-based diff
- only show FMEA-related targets when the review includes FMEAs

## Testing
- `python3 -m py_compile FreeCTA.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_687cd41251588325af4a57c4fa26da8a