### PR TITLE
Fix diff colors and complete FMEA table in comparison

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -6240,8 +6240,8 @@ class FaultTreeApp:
                 if fmea["name"] in allowed_fmeas:
                     fmea_node_ids.update(be.unique_id for be in fmea["entries"])
         else:
-            for fmea in self.fmeas:
-                fmea_node_ids.update(be.unique_id for be in fmea["entries"])
+            # When no FMEA was selected, do not offer FMEA-related targets
+            fmea_node_ids = set()
 
         for node in nodes:
             label = node.user_name or node.description or f"Node {node.unique_id}"


### PR DESCRIPTION
## Summary
- compare text using character level diff for proper highlighting
- display full FMEA table when comparing versions
- keep review combo targets limited to selected FMEAs

## Testing
- `python3 -m py_compile FreeCTA.py review_toolbox.py`


------
https://chatgpt.com/codex/tasks/task_b_687cd41251588325af4a57c4fa26da8a