### PR TITLE
Clarify version comparison colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Launch the review features from the **Review** menu:
 * **Set Current User** – choose who you are when adding comments. The toolbox also provides a drop-down selector.
 * The target selector within the toolbox only lists nodes and FMEA items that were chosen when the review was created, so comments can only be attached to the scoped elements.
 
-Nodes with unresolved comments show a small yellow circle to help locate feedback quickly. Differences between versions are outlined in blue when comparing.
+Nodes with unresolved comments show a small yellow circle to help locate feedback quickly.
+
+When comparing versions, added nodes and connections are drawn in blue while removed ones are drawn in red. Text differences highlight deleted portions in red and new text in blue so changes to descriptions, rationales or FMEA fields stand out. Deleted links between FTA nodes are shown with red connectors.
 
 Comments can be attached to FMEA entries and individual requirements. Resolving a comment prompts for a short explanation which is shown with the original text.
 

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -726,6 +726,53 @@ class VersionCompareDialog(tk.Toplevel):
                 self.log_text.insert(tk.END, old[i1:i2], "removed")
                 self.log_text.insert(tk.END, new[j1:j2], "added")
 
+    def diff_segments(self, old, new):
+        """Return [(text, color)] representing the diff between old and new."""
+        matcher = difflib.SequenceMatcher(None, old, new)
+        segments = []
+        for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+            if tag == "equal":
+                segments.append((old[i1:i2], "black"))
+            elif tag == "delete":
+                segments.append((old[i1:i2], "red"))
+            elif tag == "insert":
+                segments.append((new[j1:j2], "blue"))
+            elif tag == "replace":
+                segments.append((old[i1:i2], "red"))
+                segments.append((new[j1:j2], "blue"))
+        return segments
+
+    def draw_segment_text(self, canvas, cx, cy, segments, font_obj):
+        """Draw colored text segments centered on (cx, cy)."""
+        # Split segments into lines
+        lines = [[]]
+        for text, color in segments:
+            parts = text.split("\n")
+            for idx, part in enumerate(parts):
+                if idx > 0:
+                    lines.append([])
+                lines[-1].append((part, color))
+
+        line_height = font_obj.metrics("linespace")
+        total_height = line_height * len(lines)
+        start_y = cy - total_height / 2
+        for line in lines:
+            line_width = sum(font_obj.measure(part) for part, _ in line)
+            start_x = cx - line_width / 2
+            x = start_x
+            for part, color in line:
+                if part:
+                    canvas.create_text(
+                        x,
+                        start_y,
+                        text=part,
+                        anchor="nw",
+                        fill=color,
+                        font=font_obj,
+                    )
+                    x += font_obj.measure(part)
+            start_y += line_height
+
     def draw_small_tree(self, canvas, node):
         def draw_connections(n):
             region_width = 60
@@ -901,19 +948,33 @@ class VersionCompareDialog(tk.Toplevel):
             source = n if getattr(n, "is_primary_instance", True) else getattr(n, "original", n)
             subtype_text = source.input_subtype if source.input_subtype else "N/A"
             display_label = source.display_label
+            old_data = map1.get(n.unique_id)
+            new_data = map2.get(n.unique_id)
 
-            top_text = (
-                f"Type: {source.node_type}\n"
-                f"Subtype: {subtype_text}\n"
-                f"{display_label}\n"
-                f"Desc: {source.description}\n\n"
-                f"Rationale: {source.rationale}"
-            )
+            if old_data and new_data:
+                desc_segments = [("Desc: ", "black")] + self.diff_segments(
+                    old_data.get("description", ""), new_data.get("description", "")
+                )
+                rat_segments = [("Rationale: ", "black")] + self.diff_segments(
+                    old_data.get("rationale", ""), new_data.get("rationale", "")
+                )
+            else:
+                desc_segments = [("Desc: " + source.description, "black")]
+                rat_segments = [("Rationale: " + source.rationale, "black")]
+
+            segments = [
+                (f"Type: {source.node_type}\n", "black"),
+                (f"Subtype: {subtype_text}\n", "black"),
+                (f"{display_label}\n", "black"),
+            ] + desc_segments + [("\n\n", "black")] + rat_segments
+
+            top_text = "".join(seg[0] for seg in segments)
             bottom_text = n.name
 
             fill = self.app.get_node_fill_color(n)
             eff_x, eff_y = n.x, n.y
             typ = n.node_type.upper()
+            items_before = self.tree_canvas.find_all()
             if typ in ["GATE", "RIGOR LEVEL", "TOP EVENT"]:
                 if n.gate_type and n.gate_type.upper() == "OR":
                     self.app.fta_drawing_helper.draw_rotated_or_gate_shape(
@@ -951,6 +1012,22 @@ class VersionCompareDialog(tk.Toplevel):
                     outline_color=color,
                     line_width=2,
                 )
+
+            items_after = self.tree_canvas.find_all()
+            text_id = None
+            for item in items_after:
+                if item in items_before:
+                    continue
+                if self.tree_canvas.type(item) == "text" and self.tree_canvas.itemcget(item, "text") == top_text:
+                    text_id = item
+                    break
+
+            if text_id and any(c in ("red", "blue") for _, c in segments):
+                bbox = self.tree_canvas.bbox(text_id)
+                cx = (bbox[0] + bbox[2]) / 2
+                cy = (bbox[1] + bbox[3]) / 2
+                self.tree_canvas.itemconfigure(text_id, state="hidden")
+                self.draw_segment_text(self.tree_canvas, cx, cy, segments, self.app.diagram_font)
             for ch in n.children:
                 draw_node(ch)
 


### PR DESCRIPTION
## Summary
- document how additions and deletions are colored during version comparison
- render inline diffs for node descriptions when comparing versions

## Testing
- `python -m py_compile FreeCTA.py review_toolbox.py`


------
https://chatgpt.com/codex/tasks/task_b_687cdb0b9a848325803ee1efa6fcec82