### PR TITLE
Handle SMTP connection errors

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -231,6 +231,7 @@ from review_toolbox import (
     ReviewParticipant,
     ReviewComment,
     ParticipantDialog,
+    EmailConfigDialog,
     ReviewScopeDialog,
     ReviewDocumentDialog,
     VersionCompareDialog,
@@ -254,9 +255,14 @@ from reportlab.lib.pagesizes import letter, landscape
 from reportlab.lib.units import inch
 from reportlab.lib import colors
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-from io import BytesIO
+from io import BytesIO, StringIO
+from email.utils import make_msgid
+import html
 import PIL.Image as PILImage
 from reportlab.platypus import LongTable
+from email.message import EmailMessage
+import smtplib
+import socket
 
 styles = getSampleStyleSheet()  # Create the stylesheet.
 preformatted_style = ParagraphStyle(name="Preformatted", fontName="Courier", fontSize=10)
@@ -6006,6 +6012,9 @@ class FaultTreeApp:
             name = simpledialog.askstring("Review Name", "Enter unique review name:")
             if not name:
                 return
+            description = simpledialog.askstring("Description", "Enter a short description:")
+            if description is None:
+                description = ""
             if not moderator:
                 messagebox.showerror("Review", "Please specify a moderator")
                 return
@@ -6014,13 +6023,14 @@ class FaultTreeApp:
                 return
             scope = ReviewScopeDialog(self.root, self)
             fta_ids, fmea_names = scope.result if scope.result else ([], [])
-            review = ReviewData(name=name, mode='peer', moderator=moderator,
+            review = ReviewData(name=name, description=description, mode='peer', moderator=moderator,
                                participants=parts, comments=[],
                                fta_ids=fta_ids, fmea_names=fmea_names)
             self.reviews.append(review)
             self.review_data = review
             self.current_user = parts[0].name
             ReviewDocumentDialog(self.root, self, review)
+            self.send_review_email(review)
             self.open_review_toolbox()
 
     def start_joint_review(self):
@@ -6031,6 +6041,9 @@ class FaultTreeApp:
             name = simpledialog.askstring("Review Name", "Enter unique review name:")
             if not name:
                 return
+            description = simpledialog.askstring("Description", "Enter a short description:")
+            if description is None:
+                description = ""
             if not moderator:
                 messagebox.showerror("Review", "Please specify a moderator")
                 return
@@ -6039,13 +6052,14 @@ class FaultTreeApp:
                 return
             scope = ReviewScopeDialog(self.root, self)
             fta_ids, fmea_names = scope.result if scope.result else ([], [])
-            review = ReviewData(name=name, mode='joint', moderator=moderator,
+            review = ReviewData(name=name, description=description, mode='joint', moderator=moderator,
                                participants=participants, comments=[],
                                fta_ids=fta_ids, fmea_names=fmea_names)
             self.reviews.append(review)
             self.review_data = review
             self.current_user = participants[0].name
             ReviewDocumentDialog(self.root, self, review)
+            self.send_review_email(review)
             self.open_review_toolbox()
 
     def open_review_toolbox(self):
@@ -6057,6 +6071,154 @@ class FaultTreeApp:
         if self.review_window is None or not self.review_window.winfo_exists():
             self.review_window = ReviewToolbox(self.root, self)
         self.set_current_user()
+
+    def send_review_email(self, review):
+        """Send the review summary to all reviewers via configured SMTP."""
+        recipients = [p.email for p in review.participants if p.role == 'reviewer' and p.email]
+        if not recipients:
+            return
+
+        # Determine the current user's email if available
+        current_email = next((p.email for p in review.participants
+                              if p.name == self.current_user), "")
+
+        if not getattr(self, "email_config", None):
+            cfg = EmailConfigDialog(self.root, default_email=current_email).result
+            self.email_config = cfg
+
+        cfg = getattr(self, "email_config", None)
+        if not cfg:
+            return
+
+        subject = f"Review: {review.name}"
+        lines = [f"Review Name: {review.name}", f"Description: {review.description}", ""]
+        if review.fta_ids:
+            lines.append("FTAs:")
+            for tid in review.fta_ids:
+                te = next((t for t in self.top_events if t.unique_id == tid), None)
+                if te:
+                    lines.append(f" - {te.name}")
+            lines.append("")
+        if review.fmea_names:
+            lines.append("FMEAs:")
+            for name in review.fmea_names:
+                lines.append(f" - {name}")
+            lines.append("")
+        content = "\n".join(lines)
+        msg = EmailMessage()
+        msg['Subject'] = subject
+        msg['From'] = cfg['email']
+        msg['To'] = ', '.join(recipients)
+        msg.set_content(content)
+
+        html_lines = ["<html><body>", "<pre>", html.escape(content), "</pre>"]
+        image_cids = []
+        images = []
+        for tid in review.fta_ids:
+            node = self.find_node_by_id_all(tid)
+            if not node:
+                continue
+            img = self.capture_page_diagram(node)
+            if img is None:
+                continue
+            buf = BytesIO()
+            img.save(buf, format="PNG")
+            buf.seek(0)
+            cid = make_msgid()
+            label = node.user_name or node.name or f"id{tid}"
+            html_lines.append(f"<p><b>FTA: {html.escape(label)}</b><br>" +
+                             f"<img src=\"cid:{cid[1:-1]}\" alt=\"{html.escape(label)}\"></p>")
+            image_cids.append(cid)
+            images.append(buf.getvalue())
+        html_lines.append("</body></html>")
+        html_body = "\n".join(html_lines)
+        msg.add_alternative(html_body, subtype="html")
+        html_part = msg.get_payload()[1]
+        for cid, data in zip(image_cids, images):
+            html_part.add_related(data, "image", "png", cid=cid)
+
+        # Attach FMEA tables as CSV files (can be opened with Excel)
+        for name in review.fmea_names:
+            fmea = next((f for f in self.fmeas if f["name"] == name), None)
+            if not fmea:
+                continue
+            out = StringIO()
+            writer = csv.writer(out)
+            columns = [
+                "Component",
+                "Parent",
+                "Failure Mode",
+                "Failure Effect",
+                "Cause",
+                "S",
+                "O",
+                "D",
+                "RPN",
+                "Requirements",
+            ]
+            writer.writerow(columns)
+            for be in fmea["entries"]:
+                parent = be.parents[0] if be.parents else None
+                if parent:
+                    comp = parent.user_name if parent.user_name else f"Node {parent.unique_id}"
+                    if parent.description:
+                        comp = f"{comp} - {parent.description}"
+                    parent_name = parent.user_name if parent.user_name else f"Node {parent.unique_id}"
+                else:
+                    comp = getattr(be, "fmea_component", "") or "N/A"
+                    parent_name = ""
+                req_ids = "; ".join(
+                    [f"{req['req_type']}:{req['text']}" for req in getattr(be, 'safety_requirements', [])]
+                )
+                rpn = be.fmea_severity * be.fmea_occurrence * be.fmea_detection
+                failure_mode = be.description or (be.user_name or f"BE {be.unique_id}")
+                row = [
+                    comp,
+                    parent_name,
+                    failure_mode,
+                    be.fmea_effect,
+                    getattr(be, "fmea_cause", ""),
+                    be.fmea_severity,
+                    be.fmea_occurrence,
+                    be.fmea_detection,
+                    rpn,
+                    req_ids,
+                ]
+                writer.writerow(row)
+            csv_bytes = out.getvalue().encode('utf-8')
+            out.close()
+            msg.add_attachment(
+                csv_bytes,
+                maintype="text",
+                subtype="csv",
+                filename=f"fmea_{name}.csv",
+            )
+        try:
+            port = cfg.get('port', 465)
+            if port == 465:
+                with smtplib.SMTP_SSL(cfg['server'], port) as server:
+                    server.login(cfg['email'], cfg['password'])
+                    server.send_message(msg)
+            else:
+                with smtplib.SMTP(cfg['server'], port) as server:
+                    server.starttls()
+                    server.login(cfg['email'], cfg['password'])
+                    server.send_message(msg)
+        except smtplib.SMTPAuthenticationError:
+            messagebox.showerror(
+                "Email",
+                "Login failed. If your account uses two-factor authentication, "
+                "create an app password and use that instead of your normal password."
+            )
+            self.email_config = None
+        except (socket.gaierror, ConnectionRefusedError, smtplib.SMTPConnectError) as e:
+            messagebox.showerror(
+                "Email",
+                "Failed to connect to the SMTP server. Check the address, port and internet connection."
+            )
+            self.email_config = None
+        except Exception as e:
+            messagebox.showerror("Email", f"Failed to send review email: {e}")
 
     def add_version(self):
         name = f"v{len(self.versions)+1}"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ Comments can be attached to FMEA entries and individual requirements. Resolving 
 
 Review information (participants, comments, review names, descriptions and approval state) is saved as part of the model file and restored on load.
 
+## Email Setup
+
+When sending review summaries, the application asks for SMTP settings and login details.
+If you use Gmail with two-factor authentication enabled, create an **app password**
+and enter it instead of your normal account password. Authentication failures will
+prompt you to re-enter these settings.
+
+Each summary email embeds PNG images of the selected FTAs so reviewers can view
+the diagrams directly in the message. CSV files containing the FMEA tables are
+attached so they can be opened in Excel or another spreadsheet application.
+
+If sending fails with a connection error, the dialog will prompt again so you
+can correct the server address or port.
+
 ## License
 
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -22,6 +22,9 @@ from typing import List
 import difflib
 import sys
 import json
+import re
+
+EMAIL_REGEX = re.compile(r"[^@]+@[^@]+\.[^@]+")
 
 # Access the drawing helper defined in the main application if available.
 fta_drawing_helper = getattr(sys.modules.get('__main__'), 'fta_drawing_helper', None)
@@ -70,6 +73,12 @@ class ParticipantDialog(simpledialog.Dialog):
         self.mod_entry.pack(fill=tk.X, padx=5, pady=(0, 5))
 
         tk.Label(master, text="Participants:").pack(anchor="w")
+        header = tk.Frame(master)
+        header.pack(fill=tk.X)
+        tk.Label(header, text="Name", width=15).pack(side=tk.LEFT)
+        tk.Label(header, text="Email", width=20).pack(side=tk.LEFT, padx=5)
+        if self.joint:
+            tk.Label(header, text="Role", width=10).pack(side=tk.LEFT, padx=5)
         self.row_frame = tk.Frame(master)
         self.row_frame.pack(fill=tk.BOTH, expand=True)
         btn = tk.Button(master, text="Add Participant", command=self.add_row)
@@ -98,10 +107,59 @@ class ParticipantDialog(simpledialog.Dialog):
             if not name:
                 continue
             email = email_entry.get().strip()
+            if email and not EMAIL_REGEX.fullmatch(email):
+                messagebox.showerror("Email", f"Invalid email address: {email}")
+                self.result = None
+                return
             role = role_cb.get() if role_cb else "reviewer"
             result.append(ReviewParticipant(name, email, role))
         self.moderator = self.mod_entry.get().strip()
         self.result = result
+
+
+class EmailConfigDialog(simpledialog.Dialog):
+    """Prompt for SMTP configuration and login credentials."""
+
+    def __init__(self, parent, default_email=""):
+        self.default_email = default_email
+        super().__init__(parent, title="Email Settings")
+
+    def body(self, master):
+        tk.Label(master, text="SMTP Server:").grid(row=0, column=0, sticky="w")
+        self.server_entry = tk.Entry(master)
+        self.server_entry.grid(row=0, column=1, pady=2)
+
+        tk.Label(master, text="Port:").grid(row=1, column=0, sticky="w")
+        self.port_entry = tk.Entry(master)
+        self.port_entry.insert(0, "465")
+        self.port_entry.grid(row=1, column=1, pady=2)
+
+        tk.Label(master, text="Email:").grid(row=2, column=0, sticky="w")
+        self.email_entry = tk.Entry(master)
+        if self.default_email:
+            self.email_entry.insert(0, self.default_email)
+        self.email_entry.grid(row=2, column=1, pady=2)
+
+        tk.Label(master, text="Password:").grid(row=3, column=0, sticky="w")
+        self.pass_entry = tk.Entry(master, show="*")
+        self.pass_entry.grid(row=3, column=1, pady=2)
+        tk.Label(master, text="Use an app password for Gmail with 2FA.",
+                 font=(None, 8)).grid(row=4, column=0, columnspan=2, pady=(2,0))
+        return self.email_entry
+
+    def apply(self):
+        try:
+            port = int(self.port_entry.get().strip())
+        except ValueError:
+            messagebox.showerror("Email", "Invalid port number")
+            self.result = None
+            return
+        self.result = {
+            "server": self.server_entry.get().strip(),
+            "port": port,
+            "email": self.email_entry.get().strip(),
+            "password": self.pass_entry.get(),
+        }
 
 
 class ReviewScopeDialog(simpledialog.Dialog):


### PR DESCRIPTION
## Summary
- import `socket` for error handling
- notify users when SMTP server connection fails so they can correct the settings
- document that the dialog reappears after connection errors
- embed FTA diagrams inline in review emails and attach CSV FMEAs

## Testing
- `python -m py_compile FreeCTA.py review_toolbox.py`


------
https://chatgpt.com/codex/tasks/task_b_687cdefe162c832591075b6dcd18faf3