### PR TITLE
Add diff view for review documents

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -5876,79 +5876,95 @@ class FaultTreeApp:
         if node.rationale:
             top_text += f"\nRationale: {node.rationale}"
         bottom_text = node.name
+
+        outline_color = "dimgray"
+        line_width = 1
+        if node.unique_id in getattr(self.app, "diff_nodes", []):
+            outline_color = "blue"
+            line_width = 2
+        elif not node.is_primary_instance:
+            outline_color = "red"
         
         # For page elements, assume they use a triangle shape.
         if node.is_page:
-            # If it’s a clone, you might choose to draw with a different outline (e.g. red or dashed)
-            if not node.is_primary_instance:
-                fta_drawing_helper.draw_triangle_shape(canvas, eff_x, eff_y, scale=40,
-                                                       top_text=top_text,
-                                                       bottom_text=bottom_text,
-                                                       fill=fill_color,
-                                                       outline_color="red",  # mark clone with red outline
-                                                       line_width=1,
-                                                       font_obj=self.diagram_font)
-            else:
-                fta_drawing_helper.draw_triangle_shape(canvas, eff_x, eff_y, scale=40,
-                                                       top_text=top_text,
-                                                       bottom_text=bottom_text,
-                                                       fill=fill_color,
-                                                       outline_color="dimgray",
-                                                       line_width=1,
-                                                       font_obj=self.diagram_font)
+            fta_drawing_helper.draw_triangle_shape(
+                canvas,
+                eff_x,
+                eff_y,
+                scale=40,
+                top_text=top_text,
+                bottom_text=bottom_text,
+                fill=fill_color,
+                outline_color=outline_color,
+                line_width=line_width,
+                font_obj=self.diagram_font,
+            )
         else:
             node_type_upper = node.node_type.upper()
             if node_type_upper in ["GATE", "RIGOR LEVEL", "TOP EVENT"]:
                 if node.gate_type and node.gate_type.upper() == "OR":
-                    fta_drawing_helper.draw_rotated_or_gate_shape(self.page_canvas, eff_x, eff_y,
-                                               scale=40,
-                                               top_text=top_text,
-                                               bottom_text=bottom_text,
-                                               fill=fill_color,
-                                               outline_color="dimgray",
-                                               line_width=1)
+                    fta_drawing_helper.draw_rotated_or_gate_shape(
+                        self.page_canvas,
+                        eff_x,
+                        eff_y,
+                        scale=40,
+                        top_text=top_text,
+                        bottom_text=bottom_text,
+                        fill=fill_color,
+                        outline_color=outline_color,
+                        line_width=line_width,
+                    )
                 else:
-                    fta_drawing_helper.draw_rotated_and_gate_shape(self.page_canvas, eff_x, eff_y,
-                                                scale=40,
-                                                top_text=top_text,
-                                                bottom_text=bottom_text,
-                                                fill=fill_color,
-                                                outline_color="dimgray",
-                                                line_width=1)
+                    fta_drawing_helper.draw_rotated_and_gate_shape(
+                        self.page_canvas,
+                        eff_x,
+                        eff_y,
+                        scale=40,
+                        top_text=top_text,
+                        bottom_text=bottom_text,
+                        fill=fill_color,
+                        outline_color=outline_color,
+                        line_width=line_width,
+                    )
             elif node_type_upper in ["CONFIDENCE LEVEL", "ROBUSTNESS SCORE"]:
-                fta_drawing_helper.draw_circle_event_shape(self.page_canvas, eff_x, eff_y, 45,
-                                        top_text=top_text,
-                                        bottom_text=bottom_text,
-                                        fill=fill_color,
-                                        outline_color="dimgray",
-                                        line_width=1)
+                fta_drawing_helper.draw_circle_event_shape(
+                    self.page_canvas,
+                    eff_x,
+                    eff_y,
+                    45,
+                    top_text=top_text,
+                    bottom_text=bottom_text,
+                    fill=fill_color,
+                    outline_color=outline_color,
+                    line_width=line_width,
+                )
             else:
-                fta_drawing_helper.draw_circle_event_shape(self.page_canvas, eff_x, eff_y, 45,
-                                        top_text=top_text,
-                                        bottom_text=bottom_text,
-                                        fill=fill_color,
-                                        outline_color="dimgray",
-                                        line_width=1)
+                fta_drawing_helper.draw_circle_event_shape(
+                    self.page_canvas,
+                    eff_x,
+                    eff_y,
+                    45,
+                    top_text=top_text,
+                    bottom_text=bottom_text,
+                    fill=fill_color,
+                    outline_color=outline_color,
+                    line_width=line_width,
+                )
 
         if self.review_data:
-            unresolved = any(c.node_id == node.unique_id and not c.resolved for c in self.review_data.comments)
+            unresolved = any(
+                c.node_id == node.unique_id and not c.resolved
+                for c in self.review_data.comments
+            )
             if unresolved:
-                canvas.create_oval(eff_x + 35, eff_y + 35, eff_x + 45, eff_y + 45, fill='yellow', outline='black')
-
-        if self.review_data:
-            unresolved = any(c.node_id == node.unique_id and not c.resolved for c in self.review_data.comments)
-            if unresolved:
-                canvas.create_oval(eff_x + 35, eff_y + 35, eff_x + 45, eff_y + 45, fill='yellow', outline='black')
-
-        if self.review_data:
-            unresolved = any(c.node_id == node.unique_id and not c.resolved for c in self.review_data.comments)
-            if unresolved:
-                canvas.create_oval(eff_x + 35, eff_y + 35, eff_x + 45, eff_y + 45, fill='yellow', outline='black')
-
-        if self.review_data:
-            unresolved = any(c.node_id == node.unique_id and not c.resolved for c in self.review_data.comments)
-            if unresolved:
-                canvas.create_oval(eff_x + 35, eff_y + 35, eff_x + 45, eff_y + 45, fill='yellow', outline='black')
+                canvas.create_oval(
+                    eff_x + 35,
+                    eff_y + 35,
+                    eff_x + 45,
+                    eff_y + 45,
+                    fill="yellow",
+                    outline="black",
+                )
 
     def on_ctrl_mousewheel_page(self, event):
         if event.delta > 0:
@@ -6112,6 +6128,11 @@ class FaultTreeApp:
         msg.set_content(content)
 
         html_lines = ["<html><body>", "<pre>", html.escape(content), "</pre>"]
+        prev = self.versions[-1]["data"] if self.versions else None
+        current = self.export_model_data(include_versions=False)
+        diff_nodes = self.calculate_diff_between(prev, current) if prev else []
+        old_diff = self.diff_nodes
+        self.diff_nodes = diff_nodes
         image_cids = []
         images = []
         for tid in review.fta_ids:
@@ -6130,6 +6151,7 @@ class FaultTreeApp:
                              f"<img src=\"cid:{cid[1:-1]}\" alt=\"{html.escape(label)}\"></p>")
             image_cids.append(cid)
             images.append(buf.getvalue())
+        self.diff_nodes = old_diff
         html_lines.append("</body></html>")
         html_body = "\n".join(html_lines)
         msg.add_alternative(html_body, subtype="html")
@@ -6137,7 +6159,7 @@ class FaultTreeApp:
         for cid, data in zip(image_cids, images):
             html_part.add_related(data, "image", "png", cid=cid)
 
-        # Attach FMEA tables as CSV files (can be opened with Excel)
+        # Attach FMEA tables as CSV files (showing diffs)
         for name in review.fmea_names:
             fmea = next((f for f in self.fmeas if f["name"] == name), None)
             if not fmea:
@@ -6145,6 +6167,7 @@ class FaultTreeApp:
             out = StringIO()
             writer = csv.writer(out)
             columns = [
+                "Status",
                 "Component",
                 "Parent",
                 "Failure Mode",
@@ -6157,30 +6180,62 @@ class FaultTreeApp:
                 "Requirements",
             ]
             writer.writerow(columns)
-            for be in fmea["entries"]:
-                parent = be.parents[0] if be.parents else None
+            prev_entries = {}
+            if prev:
+                pf = next((f for f in prev.get("fmeas", []) if f["name"] == name), None)
+                if pf:
+                    prev_entries = {e["unique_id"]: e for e in pf.get("entries", [])}
+            curr_entries = {e.unique_id: e for e in fmea["entries"]}
+
+            for uid in set(prev_entries) | set(curr_entries):
+                if uid in curr_entries and uid not in prev_entries:
+                    st = "added"
+                    entry = curr_entries[uid]
+                elif uid in prev_entries and uid not in curr_entries:
+                    st = "removed"
+                    d = prev_entries[uid]
+                    class Dummy:
+                        pass
+                    entry = Dummy()
+                    entry.parents = d.get("parents", [])
+                    entry.description = d.get("description", "")
+                    entry.user_name = d.get("user_name", "")
+                    entry.fmea_effect = d.get("fmea_effect", "")
+                    entry.fmea_cause = d.get("fmea_cause", "")
+                    entry.fmea_severity = d.get("fmea_severity", 1)
+                    entry.fmea_occurrence = d.get("fmea_occurrence", 1)
+                    entry.fmea_detection = d.get("fmea_detection", 1)
+                    entry.safety_requirements = d.get("safety_requirements", [])
+                else:
+                    st = "existing"
+                    entry = curr_entries[uid]
+                    if json.dumps(prev_entries[uid], sort_keys=True) != json.dumps(entry.to_dict(), sort_keys=True):
+                        st = "updated"
+
+                parent = entry.parents[0] if entry.parents else None
                 if parent:
                     comp = parent.user_name if parent.user_name else f"Node {parent.unique_id}"
-                    if parent.description:
+                    if getattr(parent, "description", ""):
                         comp = f"{comp} - {parent.description}"
                     parent_name = parent.user_name if parent.user_name else f"Node {parent.unique_id}"
                 else:
-                    comp = getattr(be, "fmea_component", "") or "N/A"
+                    comp = getattr(entry, "fmea_component", "") or "N/A"
                     parent_name = ""
                 req_ids = "; ".join(
-                    [f"{req['req_type']}:{req['text']}" for req in getattr(be, 'safety_requirements', [])]
+                    [f"{req['req_type']}:{req['text']}" for req in getattr(entry, 'safety_requirements', [])]
                 )
-                rpn = be.fmea_severity * be.fmea_occurrence * be.fmea_detection
-                failure_mode = be.description or (be.user_name or f"BE {be.unique_id}")
+                rpn = entry.fmea_severity * entry.fmea_occurrence * entry.fmea_detection
+                failure_mode = entry.description or (entry.user_name or f"BE {uid}")
                 row = [
+                    st,
                     comp,
                     parent_name,
                     failure_mode,
-                    be.fmea_effect,
-                    getattr(be, "fmea_cause", ""),
-                    be.fmea_severity,
-                    be.fmea_occurrence,
-                    be.fmea_detection,
+                    entry.fmea_effect,
+                    getattr(entry, "fmea_cause", ""),
+                    entry.fmea_severity,
+                    entry.fmea_occurrence,
+                    entry.fmea_detection,
                     rpn,
                     req_ids,
                 ]

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -498,6 +498,13 @@ class ReviewDocumentDialog(tk.Toplevel):
         self.dh = getattr(app, 'fta_drawing_helper', None) or fta_drawing_helper
         self.title(f"Review Document - {review.name}")
 
+        self.prev_data = app.versions[-1]["data"] if app.versions else None
+        self.curr_data = app.export_model_data(include_versions=False)
+        if self.prev_data:
+            self.diff_nodes = app.calculate_diff_between(self.prev_data, self.curr_data)
+        else:
+            self.diff_nodes = []
+
         self.outer = tk.Canvas(self)
         vbar = tk.Scrollbar(self, orient=tk.VERTICAL, command=self.outer.yview)
         self.outer.configure(yscrollcommand=vbar.set)
@@ -538,6 +545,8 @@ class ReviewDocumentDialog(tk.Toplevel):
                 top_text += f"\n{n.description}"
             bottom_text = n.name
             typ = n.node_type.upper()
+            outline = "blue" if n.unique_id in self.diff_nodes else "dimgray"
+            lw = 2 if n.unique_id in self.diff_nodes else 1
             if n.is_page:
                 if self.dh:
                     self.dh.draw_triangle_shape(
@@ -548,8 +557,8 @@ class ReviewDocumentDialog(tk.Toplevel):
                         top_text=top_text,
                         bottom_text=bottom_text,
                         fill=fill,
-                        outline_color="dimgray",
-                        line_width=1,
+                        outline_color=outline,
+                        line_width=lw,
                     )
             elif typ in ["GATE", "RIGOR LEVEL", "TOP EVENT"]:
                 if n.gate_type and n.gate_type.upper() == "OR":
@@ -562,8 +571,8 @@ class ReviewDocumentDialog(tk.Toplevel):
                             top_text=top_text,
                             bottom_text=bottom_text,
                             fill=fill,
-                            outline_color="dimgray",
-                            line_width=1,
+                            outline_color=outline,
+                            line_width=lw,
                         )
                 else:
                     if self.dh:
@@ -575,8 +584,8 @@ class ReviewDocumentDialog(tk.Toplevel):
                             top_text=top_text,
                             bottom_text=bottom_text,
                             fill=fill,
-                            outline_color="dimgray",
-                            line_width=1,
+                            outline_color=outline,
+                            line_width=lw,
                         )
             else:
                 if self.dh:
@@ -588,8 +597,8 @@ class ReviewDocumentDialog(tk.Toplevel):
                         top_text=top_text,
                         bottom_text=bottom_text,
                         fill=fill,
-                        outline_color="dimgray",
-                        line_width=1,
+                        outline_color=outline,
+                        line_width=lw,
                     )
 
         def draw_all(n):
@@ -668,8 +677,44 @@ class ReviewDocumentDialog(tk.Toplevel):
             hsb.grid(row=1, column=0, sticky="ew")
             frame.grid_columnconfigure(0, weight=1)
             frame.grid_rowconfigure(0, weight=1)
+            tree.tag_configure("added", background="#cce5ff")
+            tree.tag_configure("removed", background="#f8d7da")
+
+            prev_entries = {}
+            if self.prev_data:
+                pf = next((f for f in self.prev_data.get("fmeas", []) if f["name"] == name), None)
+                if pf:
+                    prev_entries = {e["unique_id"]: e for e in pf.get("entries", [])}
 
             for entry in fmea["entries"]:
+                prev_entries.setdefault(entry.unique_id, None)
+
+            for uid, prev in list(prev_entries.items()):
+                curr = next((e for e in fmea["entries"] if e.unique_id == uid), None)
+                if curr and prev is not None:
+                    st = "existing"
+                    if json.dumps(prev, sort_keys=True) != json.dumps(curr.to_dict(), sort_keys=True):
+                        st = "added"
+                    entry = curr
+                elif curr and prev is None:
+                    st = "added"
+                    entry = curr
+                else:
+                    st = "removed"
+                    d = prev
+                    class Dummy:
+                        pass
+                    entry = Dummy()
+                    entry.parents = d.get("parents", [])
+                    entry.description = d.get("description", "")
+                    entry.user_name = d.get("user_name", "")
+                    entry.fmea_effect = d.get("fmea_effect", "")
+                    entry.fmea_cause = d.get("fmea_cause", "")
+                    entry.fmea_severity = d.get("fmea_severity", 1)
+                    entry.fmea_occurrence = d.get("fmea_occurrence", 1)
+                    entry.fmea_detection = d.get("fmea_detection", 1)
+                    entry.safety_requirements = d.get("safety_requirements", [])
+
                 parent = entry.parents[0] if entry.parents else None
                 if parent:
                     comp = parent.user_name if parent.user_name else f"Node {parent.unique_id}"
@@ -681,7 +726,7 @@ class ReviewDocumentDialog(tk.Toplevel):
                     [f"{req['req_type']}:{req['text']}" for req in getattr(entry, 'safety_requirements', [])]
                 )
                 rpn = entry.fmea_severity * entry.fmea_occurrence * entry.fmea_detection
-                failure_mode = entry.description or entry.user_name or f"BE {entry.unique_id}"
+                failure_mode = entry.description or entry.user_name or f"BE {uid}"
                 vals = [
                     comp,
                     parent_name,
@@ -694,7 +739,7 @@ class ReviewDocumentDialog(tk.Toplevel):
                     rpn,
                     req_ids,
                 ]
-                tree.insert("", "end", values=vals)
+                tree.insert("", "end", values=vals, tags=(st,))
 
             row += 1
 


### PR DESCRIPTION
## Summary
- highlight changed nodes in review diagrams by tracking diff
- color diffs in page diagrams
- show diff entries for FMEAs in review documents and emails
- include diff images and CSVs in review email attachments

## Testing
- `python -m py_compile FreeCTA.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_687cfb84526483259654d1305c909e31