### PR TITLE
Add diff highlighting and better user selection

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -233,6 +233,7 @@ from review_toolbox import (
     ParticipantDialog,
     EmailConfigDialog,
     ReviewScopeDialog,
+    UserSelectDialog,
     ReviewDocumentDialog,
     VersionCompareDialog,
 )
@@ -258,6 +259,7 @@ from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from io import BytesIO, StringIO
 from email.utils import make_msgid
 import html
+import datetime
 import PIL.Image as PILImage
 from reportlab.platypus import LongTable
 from email.message import EmailMessage
@@ -5590,10 +5592,14 @@ class FaultTreeApp:
                 "name": r.name,
                 "description": r.description,
                 "mode": r.mode,
-                "moderator": r.moderator,
+                "moderators": [asdict(m) for m in r.moderators],
                 "approved": r.approved,
+                "due_date": r.due_date,
+                "closed": r.closed,
                 "participants": [asdict(p) for p in r.participants],
                 "comments": [asdict(c) for c in r.comments],
+                "fta_ids": r.fta_ids,
+                "fmea_names": r.fmea_names,
             })
         current_name = self.review_data.name if self.review_data else None
         data = {
@@ -5686,15 +5692,22 @@ class FaultTreeApp:
             for rd in reviews_data:
                 participants = [ReviewParticipant(**p) for p in rd.get("participants", [])]
                 comments = [ReviewComment(**c) for c in rd.get("comments", [])]
+                moderators = [ReviewParticipant(**m) for m in rd.get("moderators", [])]
+                if not moderators and rd.get("moderator"):
+                    moderators = [ReviewParticipant(rd.get("moderator"), "", "moderator")]
                 self.reviews.append(
                     ReviewData(
                         name=rd.get("name", ""),
                         description=rd.get("description", ""),
                         mode=rd.get("mode", "peer"),
-                        moderator=rd.get("moderator", ""),
+                        moderators=moderators,
                         participants=participants,
                         comments=comments,
                         approved=rd.get("approved", False),
+                        due_date=rd.get("due_date", ""),
+                        closed=rd.get("closed", False),
+                        fta_ids=rd.get("fta_ids", []),
+                        fmea_names=rd.get("fmea_names", []),
                     )
                 )
             current = data.get("current_review")
@@ -5708,14 +5721,21 @@ class FaultTreeApp:
             if rd:
                 participants = [ReviewParticipant(**p) for p in rd.get("participants", [])]
                 comments = [ReviewComment(**c) for c in rd.get("comments", [])]
+                moderators = [ReviewParticipant(**m) for m in rd.get("moderators", [])]
+                if not moderators and rd.get("moderator"):
+                    moderators = [ReviewParticipant(rd.get("moderator"), "", "moderator")]
                 review = ReviewData(
                     name=rd.get("name", "Review 1"),
                     description=rd.get("description", ""),
                     mode=rd.get("mode", "peer"),
-                    moderator=rd.get("moderator", ""),
+                    moderators=moderators,
                     participants=participants,
                     comments=comments,
                     approved=rd.get("approved", False),
+                    due_date=rd.get("due_date", ""),
+                    closed=rd.get("closed", False),
+                    fta_ids=rd.get("fta_ids", []),
+                    fmea_names=rd.get("fmea_names", []),
                 )
                 self.reviews = [review]
                 self.review_data = review
@@ -6007,28 +6027,28 @@ class FaultTreeApp:
         dialog = ParticipantDialog(self.root, joint=False)
 
         if dialog.result:
-            parts = dialog.result
-            moderator = dialog.moderator
+            moderators, parts = dialog.result
             name = simpledialog.askstring("Review Name", "Enter unique review name:")
             if not name:
                 return
             description = simpledialog.askstring("Description", "Enter a short description:")
             if description is None:
                 description = ""
-            if not moderator:
+            if not moderators:
                 messagebox.showerror("Review", "Please specify a moderator")
                 return
+            due_date = simpledialog.askstring("Due Date", "Enter due date (YYYY-MM-DD):")
             if any(r.name == name for r in self.reviews):
                 messagebox.showerror("Review", "Name already exists")
                 return
             scope = ReviewScopeDialog(self.root, self)
             fta_ids, fmea_names = scope.result if scope.result else ([], [])
-            review = ReviewData(name=name, description=description, mode='peer', moderator=moderator,
+            review = ReviewData(name=name, description=description, mode='peer', moderators=moderators,
                                participants=parts, comments=[],
-                               fta_ids=fta_ids, fmea_names=fmea_names)
+                               fta_ids=fta_ids, fmea_names=fmea_names, due_date=due_date)
             self.reviews.append(review)
             self.review_data = review
-            self.current_user = parts[0].name
+            self.current_user = moderators[0].name if moderators else parts[0].name
             ReviewDocumentDialog(self.root, self, review)
             self.send_review_email(review)
             self.open_review_toolbox()
@@ -6036,28 +6056,34 @@ class FaultTreeApp:
     def start_joint_review(self):
         dialog = ParticipantDialog(self.root, joint=True)
         if dialog.result:
-            participants = dialog.result
-            moderator = dialog.moderator
+            moderators, participants = dialog.result
             name = simpledialog.askstring("Review Name", "Enter unique review name:")
             if not name:
                 return
             description = simpledialog.askstring("Description", "Enter a short description:")
             if description is None:
                 description = ""
-            if not moderator:
+            if not moderators:
                 messagebox.showerror("Review", "Please specify a moderator")
                 return
+            if not any(p.role == 'reviewer' for p in participants):
+                messagebox.showerror("Review", "At least one reviewer required")
+                return
+            if not any(p.role == 'approver' for p in participants):
+                messagebox.showerror("Review", "At least one approver required")
+                return
+            due_date = simpledialog.askstring("Due Date", "Enter due date (YYYY-MM-DD):")
             if any(r.name == name for r in self.reviews):
                 messagebox.showerror("Review", "Name already exists")
                 return
             scope = ReviewScopeDialog(self.root, self)
             fta_ids, fmea_names = scope.result if scope.result else ([], [])
-            review = ReviewData(name=name, description=description, mode='joint', moderator=moderator,
+            review = ReviewData(name=name, description=description, mode='joint', moderators=moderators,
                                participants=participants, comments=[],
-                               fta_ids=fta_ids, fmea_names=fmea_names)
+                               fta_ids=fta_ids, fmea_names=fmea_names, due_date=due_date)
             self.reviews.append(review)
             self.review_data = review
-            self.current_user = participants[0].name
+            self.current_user = moderators[0].name if moderators else participants[0].name
             ReviewDocumentDialog(self.root, self, review)
             self.send_review_email(review)
             self.open_review_toolbox()
@@ -6221,6 +6247,21 @@ class FaultTreeApp:
             messagebox.showerror("Email", f"Failed to send review email: {e}")
 
 
+    def review_is_closed(self):
+        if not self.review_data:
+            return False
+        if getattr(self.review_data, "closed", False):
+            return True
+        if self.review_data.due_date:
+            try:
+                due = datetime.datetime.strptime(self.review_data.due_date, "%Y-%m-%d").date()
+                if datetime.date.today() > due:
+                    return True
+            except ValueError:
+                pass
+        return False
+
+
     def add_version(self):
         name = f"v{len(self.versions)+1}"
         # Exclude the versions list when capturing a snapshot to avoid
@@ -6244,24 +6285,34 @@ class FaultTreeApp:
         for rd in data.get("reviews", []):
             participants = [ReviewParticipant(**p) for p in rd.get("participants", [])]
             comments = [ReviewComment(**c) for c in rd.get("comments", [])]
+            moderators = [ReviewParticipant(**m) for m in rd.get("moderators", [])]
+            if not moderators and rd.get("moderator"):
+                moderators = [ReviewParticipant(rd.get("moderator"), "", "moderator")]
             review = next((r for r in self.reviews if r.name == rd.get("name", "")), None)
             if review is None:
                 review = ReviewData(
                     name=rd.get("name", ""),
                     description=rd.get("description", ""),
                     mode=rd.get("mode", "peer"),
-                    moderator=rd.get("moderator", ""),
+                    moderators=moderators,
                     participants=participants,
                     comments=comments,
                     approved=rd.get("approved", False),
                     fta_ids=rd.get("fta_ids", []),
                     fmea_names=rd.get("fmea_names", []),
+                    due_date=rd.get("due_date", ""),
+                    closed=rd.get("closed", False),
                 )
                 self.reviews.append(review)
                 continue
             for p in participants:
                 if all(p.name != ep.name for ep in review.participants):
                     review.participants.append(p)
+            for m in moderators:
+                if all(m.name != em.name for em in review.moderators):
+                    review.moderators.append(m)
+            review.due_date = rd.get("due_date", review.due_date)
+            review.closed = rd.get("closed", review.closed)
             next_id = len(review.comments) + 1
             for c in comments:
                 review.comments.append(ReviewComment(next_id, c.node_id, c.text, c.reviewer,
@@ -6305,12 +6356,12 @@ class FaultTreeApp:
         if not self.review_data:
             messagebox.showwarning("User", "Start a review first")
             return
-        allowed = [p.name for p in self.review_data.participants]
-        if self.review_data.moderator:
-            allowed.append(self.review_data.moderator)
-        name = simpledialog.askstring("Current User", "Enter your name:", initialvalue=self.current_user)
-        if not name:
+        parts = self.review_data.participants + self.review_data.moderators
+        dlg = UserSelectDialog(self.root, parts, initial_name=self.current_user)
+        if not dlg.result:
             return
+        name, _ = dlg.result
+        allowed = [p.name for p in parts]
         if name not in allowed:
             messagebox.showerror("User", "Name not found in participants")
             return
@@ -6319,7 +6370,7 @@ class FaultTreeApp:
     def get_current_user_role(self):
         if not self.review_data:
             return None
-        if self.current_user == self.review_data.moderator:
+        if self.current_user in [m.name for m in self.review_data.moderators]:
             return "moderator"
         for p in self.review_data.participants:
             if p.name == self.current_user:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository contains a graphical fault tree analysis tool. The latest update
 
 Launch the review features from the **Review** menu:
 
-* **Start Peer Review** – create reviewers, then tick the checkboxes for the FTAs and FMEAs you want to include. A document window opens showing those elements. FTAs are drawn on canvases you can drag and scroll, while FMEAs appear as full tables listing every field so failures can be reviewed line by line.
-* **Start Joint Review** – add participants with reviewer or approver roles, select the desired FTAs and FMEAs via checkboxes and enter a unique review name and description. Approvers can approve only after all reviewers are done and comments resolved. The document window behaves the same as for peer reviews with draggable FTAs and tabulated FMEAs.
+* **Start Peer Review** – create at least one moderator and one reviewer, then tick the checkboxes for the FTAs and FMEAs you want to include. Each moderator and participant has an associated email address. A due date is requested and once reached the review becomes read‑only unless a moderator extends it. A document window opens showing the selected elements. FTAs are drawn on canvases you can drag and scroll, while FMEAs appear as full tables listing every field so failures can be reviewed line by line.
+* **Start Joint Review** – add participants with reviewer or approver roles and at least one moderator, select the desired FTAs and FMEAs via checkboxes and enter a unique review name and description. Approvers can approve only after all reviewers are done and comments resolved. Moderators may edit the description, due date or participant list later from the toolbox. The document window behaves the same as for peer reviews with draggable FTAs and tabulated FMEAs.
 * **Open Review Toolbox** – manage comments. Selecting a comment focuses the related element and shows the text below the list. Use the **Open Document** button to reopen the visualization for the currently selected review. A drop-down at the top lists every saved review with its approval status.
 * **Merge Review Comments** – combine feedback from another saved model into the current one so parallel reviews can be consolidated.
 * **Compare Versions** – view earlier approved versions. Differences are listed with a short description and small before/after images of changed FTA nodes.
@@ -15,6 +15,7 @@ Launch the review features from the **Review** menu:
 * The target selector within the toolbox only lists nodes and FMEA items that were chosen when the review was created, so comments can only be attached to the scoped elements.
 
 Nodes with unresolved comments show a small yellow circle to help locate feedback quickly.
+When a review document is opened, nodes and FMEA rows changed since the last approved version are highlighted in blue so reviewers can focus on updates.
 
 When comparing versions, added nodes and connections are drawn in blue while removed ones are drawn in red. Text differences highlight deleted portions in red and new text in blue so changes to descriptions, rationales or FMEA fields stand out. Deleted links between FTA nodes are shown with red connectors.
 


### PR DESCRIPTION
## Summary
- prevent duplicate participants in ParticipantDialog
- add UserSelectDialog for choosing users with email
- use UserSelectDialog for setting current user and adding comments
- highlight updated nodes and FMEA entries in ReviewDocument
- document new highlighting behavior in README

## Testing
- `python -m py_compile FreeCTA.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_687cfc7cea288325b5d941a44a0961f0