### PR TITLE
Show requirement traceability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,19 @@ This repository contains a graphical fault tree analysis tool. The latest update
 
 Launch the review features from the **Review** menu:
 
-* **Start Peer Review** – create reviewers, then tick the checkboxes for the FTAs and FMEAs you want to include. A document window opens showing those elements. FTAs are drawn on canvases you can drag and scroll, while FMEAs appear as full tables listing every field so failures can be reviewed line by line.
-* **Start Joint Review** – add participants with reviewer or approver roles, select the desired FTAs and FMEAs via checkboxes and enter a unique review name and description. Approvers can approve only after all reviewers are done and comments resolved. The document window behaves the same as for peer reviews with draggable FTAs and tabulated FMEAs.
+* **Start Peer Review** – create at least one moderator and one reviewer, then tick the checkboxes for the FTAs and FMEAs you want to include. Each moderator and participant has an associated email address. A due date is requested and once reached the review becomes read‑only unless a moderator extends it. A document window opens showing the selected elements. FTAs are drawn on canvases you can drag and scroll, while FMEAs appear as full tables listing every field so failures can be reviewed line by line. Linked requirements are listed below and any text changes are colored the same way as other differences. Changes to which requirements are allocated to each item are highlighted in blue and red.
+* **Start Joint Review** – add participants with reviewer or approver roles and at least one moderator, select the desired FTAs and FMEAs via checkboxes and enter a unique review name and description. Approvers can approve only after all reviewers are done and comments resolved. Moderators may edit the description, due date or participant list later from the toolbox. The document window behaves the same as for peer reviews with draggable FTAs and tabulated FMEAs. Requirement diffs are also shown in this view.
 * **Open Review Toolbox** – manage comments. Selecting a comment focuses the related element and shows the text below the list. Use the **Open Document** button to reopen the visualization for the currently selected review. A drop-down at the top lists every saved review with its approval status.
 * **Merge Review Comments** – combine feedback from another saved model into the current one so parallel reviews can be consolidated.
-* **Compare Versions** – view earlier approved versions. Differences are listed with a short description and small before/after images of changed FTA nodes.
+* **Compare Versions** – view earlier approved versions. Differences are listed with a short description and small before/after images of changed FTA nodes. Requirement allocations are compared in the diagrams and logs.
 * **Set Current User** – choose who you are when adding comments. The toolbox also provides a drop-down selector.
 * The target selector within the toolbox only lists nodes and FMEA items that were chosen when the review was created, so comments can only be attached to the scoped elements.
 
 Nodes with unresolved comments show a small yellow circle to help locate feedback quickly.
+When a review document is opened it automatically compares the current model to the previous approved version. Added elements appear in blue and removed ones in red just like the **Compare Versions** tool, but only for the FTAs and FMEAs included in that review.
 
 When comparing versions, added nodes and connections are drawn in blue while removed ones are drawn in red. Text differences highlight deleted portions in red and new text in blue so changes to descriptions, rationales or FMEA fields stand out. Deleted links between FTA nodes are shown with red connectors.
+Requirement lists are compared as well so allocation changes show up alongside description and rationale edits. The Requirements Matrix window now lists every requirement with the nodes and FMEA items where it is allocated and the safety goals traced to each one.
 
 Comments can be attached to FMEA entries and individual requirements. Resolving a comment prompts for a short explanation which is shown with the original text.
 
@@ -29,9 +31,10 @@ If you use Gmail with two-factor authentication enabled, create an **app passwor
 and enter it instead of your normal account password. Authentication failures will
 prompt you to re-enter these settings.
 
-Each summary email embeds PNG images of the selected FTAs so reviewers can view
+Each summary email embeds PNG images showing the differences between the current
+model and the last approved version for the selected FTAs so reviewers can view
 the diagrams directly in the message. CSV files containing the FMEA tables are
-attached so they can be opened in Excel or another spreadsheet application.
+attached so they can be opened in Excel or another spreadsheet application. Requirement changes with allocations and safety goal traces are listed below the diagrams.
 
 If sending fails with a connection error, the dialog will prompt again so you
 can correct the server address or port.

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -23,6 +23,7 @@ import difflib
 import sys
 import json
 import re
+from PIL import Image, ImageTk
 
 EMAIL_REGEX = re.compile(r"[^@]+@[^@]+\.[^@]+")
 
@@ -33,7 +34,7 @@ fta_drawing_helper = getattr(sys.modules.get('__main__'), 'fta_drawing_helper', 
 class ReviewParticipant:
     name: str
     email: str
-    role: str  # 'reviewer' or 'approver'
+    role: str  # 'reviewer', 'approver', or 'moderator'
     done: bool = False
 
 @dataclass
@@ -53,40 +54,63 @@ class ReviewData:
     name: str = ""
     description: str = ""
     mode: str = "peer"  # 'peer' or 'joint'
-    moderator: str = ""
+    moderators: List[ReviewParticipant] = field(default_factory=list)
     participants: List[ReviewParticipant] = field(default_factory=list)
     comments: List[ReviewComment] = field(default_factory=list)
     fta_ids: List[int] = field(default_factory=list)
     fmea_names: List[str] = field(default_factory=list)
+    due_date: str = ""
+    closed: bool = False
     approved: bool = False
 
 class ParticipantDialog(simpledialog.Dialog):
-    def __init__(self, parent, joint: bool):
+    def __init__(self, parent, joint: bool, initial_mods=None, initial_parts=None):
         self.joint = joint
-        self.participants: List[ReviewParticipant] = []
-        self.moderator = ""
+        self.initial_mods = initial_mods or []
+        self.initial_parts = initial_parts or []
+        self.mod_rows = []
+        self.part_rows = []
         super().__init__(parent, title="Review Participants")
 
     def body(self, master):
-        tk.Label(master, text="Moderator:").pack(anchor="w")
-        self.mod_entry = tk.Entry(master)
-        self.mod_entry.pack(fill=tk.X, padx=5, pady=(0, 5))
-
-        tk.Label(master, text="Participants:").pack(anchor="w")
+        tk.Label(master, text="Moderators:").pack(anchor="w")
         header = tk.Frame(master)
         header.pack(fill=tk.X)
         tk.Label(header, text="Name", width=15).pack(side=tk.LEFT)
         tk.Label(header, text="Email", width=20).pack(side=tk.LEFT, padx=5)
-        if self.joint:
-            tk.Label(header, text="Role", width=10).pack(side=tk.LEFT, padx=5)
-        self.row_frame = tk.Frame(master)
-        self.row_frame.pack(fill=tk.BOTH, expand=True)
-        btn = tk.Button(master, text="Add Participant", command=self.add_row)
-        btn.pack(pady=5)
-        self.add_row()
+        self.mod_frame = tk.Frame(master)
+        self.mod_frame.pack(fill=tk.BOTH, expand=True)
+        tk.Button(master, text="Add Moderator", command=self.add_mod_row).pack(pady=5)
+        for m in (self.initial_mods or [None]):
+            self.add_mod_row(m)
 
-    def add_row(self):
-        frame = tk.Frame(self.row_frame)
+        tk.Label(master, text="Participants:").pack(anchor="w")
+        phead = tk.Frame(master)
+        phead.pack(fill=tk.X)
+        tk.Label(phead, text="Name", width=15).pack(side=tk.LEFT)
+        tk.Label(phead, text="Email", width=20).pack(side=tk.LEFT, padx=5)
+        if self.joint:
+            tk.Label(phead, text="Role", width=10).pack(side=tk.LEFT, padx=5)
+        self.part_frame = tk.Frame(master)
+        self.part_frame.pack(fill=tk.BOTH, expand=True)
+        tk.Button(master, text="Add Participant", command=self.add_part_row).pack(pady=5)
+        for p in (self.initial_parts or [None]):
+            self.add_part_row(p)
+
+    def add_mod_row(self, data=None):
+        frame = tk.Frame(self.mod_frame)
+        frame.pack(fill=tk.X, pady=2)
+        name = tk.Entry(frame, width=15)
+        name.pack(side=tk.LEFT)
+        email = tk.Entry(frame, width=20)
+        email.pack(side=tk.LEFT, padx=5)
+        if isinstance(data, ReviewParticipant):
+            name.insert(0, data.name)
+            email.insert(0, data.email)
+        self.mod_rows.append((name, email))
+
+    def add_part_row(self, data=None):
+        frame = tk.Frame(self.part_frame)
         frame.pack(fill=tk.X, pady=2)
         name = tk.Entry(frame, width=15)
         name.pack(side=tk.LEFT)
@@ -98,11 +122,34 @@ class ParticipantDialog(simpledialog.Dialog):
             role_cb.pack(side=tk.LEFT, padx=5)
         else:
             role_cb = None
-        self.participants.append((name, email, role_cb))
+        if isinstance(data, ReviewParticipant):
+            name.insert(0, data.name)
+            email.insert(0, data.email)
+            if role_cb:
+                role_cb.set(data.role)
+        self.part_rows.append((name, email, role_cb))
 
     def apply(self):
-        result = []
-        for name_entry, email_entry, role_cb in self.participants:
+        moderators = []
+        seen = {}
+        for name_e, email_e in self.mod_rows:
+            name = name_e.get().strip()
+            if not name:
+                continue
+            email = email_e.get().strip()
+            if email and not EMAIL_REGEX.fullmatch(email):
+                messagebox.showerror("Email", f"Invalid email address: {email}")
+                self.result = None
+                return
+            if name in seen:
+                messagebox.showerror("Participants", f"{name} already added")
+                self.result = None
+                return
+            seen[name] = "moderator"
+            moderators.append(ReviewParticipant(name, email, "moderator"))
+
+        participants = []
+        for name_entry, email_entry, role_cb in self.part_rows:
             name = name_entry.get().strip()
             if not name:
                 continue
@@ -112,9 +159,14 @@ class ParticipantDialog(simpledialog.Dialog):
                 self.result = None
                 return
             role = role_cb.get() if role_cb else "reviewer"
-            result.append(ReviewParticipant(name, email, role))
-        self.moderator = self.mod_entry.get().strip()
-        self.result = result
+            if name in seen:
+                messagebox.showerror("Participants", f"{name} already added")
+                self.result = None
+                return
+            seen[name] = role
+            participants.append(ReviewParticipant(name, email, role))
+
+        self.result = (moderators, participants)
 
 
 class EmailConfigDialog(simpledialog.Dialog):
@@ -195,6 +247,47 @@ class ReviewScopeDialog(simpledialog.Dialog):
         fmea_names = [name for var, name in self.fmea_vars if var.get()]
         self.result = (fta_ids, fmea_names)
 
+
+class UserSelectDialog(simpledialog.Dialog):
+    """Prompt for user selection via combo box with email."""
+
+    def __init__(self, parent, participants, initial_name=""):
+        self.participants = participants
+        self.initial_name = initial_name
+        super().__init__(parent, title="Select User")
+
+    def body(self, master):
+        tk.Label(master, text="Name:").grid(row=0, column=0, sticky="w")
+        names = [p.name for p in self.participants]
+        self.name_var = tk.StringVar()
+        self.name_combo = ttk.Combobox(master, values=names, textvariable=self.name_var, state="readonly")
+        self.name_combo.grid(row=0, column=1, pady=5)
+        self.name_combo.bind("<<ComboboxSelected>>", self.on_select)
+        if self.initial_name and self.initial_name in names:
+            self.name_combo.set(self.initial_name)
+        elif names:
+            self.name_combo.current(0)
+
+        tk.Label(master, text="Email:").grid(row=1, column=0, sticky="w")
+        self.email_entry = tk.Entry(master)
+        self.email_entry.grid(row=1, column=1, pady=5)
+        self.on_select()
+        return self.name_combo
+
+    def on_select(self, event=None):
+        name = self.name_var.get()
+        email = ""
+        for p in self.participants:
+            if p.name == name:
+                email = p.email
+                break
+        self.email_entry.delete(0, tk.END)
+        if email:
+            self.email_entry.insert(0, email)
+
+    def apply(self):
+        self.result = (self.name_var.get().strip(), self.email_entry.get().strip())
+
 class ReviewToolbox(tk.Toplevel):
     def __init__(self, master, app):
         super().__init__(master)
@@ -216,6 +309,8 @@ class ReviewToolbox(tk.Toplevel):
         tk.Label(self, textvariable=self.desc_var, wraplength=400, justify="left").pack(fill=tk.X, padx=5)
         self.mod_var = tk.StringVar()
         tk.Label(self, textvariable=self.mod_var).pack(fill=tk.X, padx=5)
+        self.due_var = tk.StringVar()
+        tk.Label(self, textvariable=self.due_var).pack(fill=tk.X, padx=5)
 
         user_frame = tk.Frame(self)
         user_frame.pack(fill=tk.X)
@@ -252,6 +347,8 @@ class ReviewToolbox(tk.Toplevel):
         tk.Button(btn_frame, text="Open Document", command=self.open_document).pack(side=tk.LEFT)
         self.approve_btn = tk.Button(btn_frame, text="Approve", command=self.approve)
         self.approve_btn.pack(side=tk.LEFT)
+        self.edit_btn = tk.Button(btn_frame, text="Edit Review", command=self.edit_review)
+        self.edit_btn.pack(side=tk.LEFT)
 
         self.update_buttons()
 
@@ -271,12 +368,15 @@ class ReviewToolbox(tk.Toplevel):
             self.review_var.set(self.app.review_data.name)
             self.status_var.set("approved" if self.app.review_data.approved else "open")
             self.desc_var.set(self.app.review_data.description)
-            self.mod_var.set(f"Moderator: {self.app.review_data.moderator}")
+            mods = ", ".join(m.name for m in self.app.review_data.moderators)
+            self.mod_var.set(f"Moderators: {mods}")
+            self.due_var.set(f"Due: {self.app.review_data.due_date}")
         else:
             self.review_var.set("")
             self.status_var.set("")
             self.desc_var.set("")
             self.mod_var.set("")
+            self.due_var.set("")
 
     def on_review_change(self, event=None):
         name = self.review_var.get()
@@ -287,10 +387,13 @@ class ReviewToolbox(tk.Toplevel):
         self.status_var.set("approved" if self.app.review_data and self.app.review_data.approved else "open")
         if self.app.review_data:
             self.desc_var.set(self.app.review_data.description)
-            self.mod_var.set(f"Moderator: {self.app.review_data.moderator}")
+            mods = ", ".join(m.name for m in self.app.review_data.moderators)
+            self.mod_var.set(f"Moderators: {mods}")
+            self.due_var.set(f"Due: {self.app.review_data.due_date}")
         else:
             self.desc_var.set("")
             self.mod_var.set("")
+            self.due_var.set("")
         self.refresh_comments()
         self.refresh_targets()
         self.update_buttons()
@@ -305,8 +408,7 @@ class ReviewToolbox(tk.Toplevel):
         if not self.app.review_data:
             return
         names = [p.name for p in self.app.review_data.participants]
-        if self.app.review_data.moderator:
-            names.append(self.app.review_data.moderator)
+        names.extend(m.name for m in self.app.review_data.moderators)
         self.user_combo['values'] = names
         if self.app.current_user:
             self.user_var.set(self.app.current_user)
@@ -344,12 +446,15 @@ class ReviewToolbox(tk.Toplevel):
         if not target and not self.app.selected_node:
             messagebox.showwarning("Add Comment", "Select a node first")
             return
-        allowed = [p.name for p in self.app.review_data.participants]
-        if self.app.review_data.moderator:
-            allowed.append(self.app.review_data.moderator)
-        reviewer = simpledialog.askstring("User", "Enter your name:", initialvalue=self.app.current_user)
-        if not reviewer:
+        if self.app.review_is_closed():
+            messagebox.showwarning("Review", "This review is closed")
             return
+        all_parts = self.app.review_data.participants + self.app.review_data.moderators
+        dlg = UserSelectDialog(self, all_parts, initial_name=self.app.current_user)
+        if not dlg.result:
+            return
+        reviewer, _ = dlg.result
+        allowed = [p.name for p in all_parts]
         if reviewer not in allowed:
             messagebox.showerror("User", "Name not found in participants")
             return
@@ -390,8 +495,11 @@ class ReviewToolbox(tk.Toplevel):
         idx = self.comment_list.curselection()
         if not idx:
             return
-        if self.app.current_user != self.app.review_data.moderator:
-            messagebox.showerror("Resolve", "Only the moderator can resolve comments")
+        if self.app.review_is_closed():
+            messagebox.showwarning("Review", "This review is closed")
+            return
+        if self.app.current_user not in [m.name for m in self.app.review_data.moderators]:
+            messagebox.showerror("Resolve", "Only a moderator can resolve comments")
             return
         c = self.app.review_data.comments[idx[0]]
         resolution = simpledialog.askstring("Resolve Comment", "Enter resolution comment:")
@@ -402,6 +510,9 @@ class ReviewToolbox(tk.Toplevel):
         self.refresh_comments()
 
     def mark_done(self):
+        if self.app.review_is_closed():
+            messagebox.showwarning("Review", "This review is closed")
+            return
         user = self.app.current_user
         for p in self.app.review_data.participants:
             if p.name == user:
@@ -410,6 +521,9 @@ class ReviewToolbox(tk.Toplevel):
         self.update_buttons()
 
     def approve(self):
+        if self.app.review_is_closed():
+            messagebox.showwarning("Review", "This review is closed")
+            return
         if self.app.review_data.mode == 'joint':
             all_done = all(p.done for p in self.app.review_data.participants if p.role == 'reviewer')
             if not all_done:
@@ -423,6 +537,35 @@ class ReviewToolbox(tk.Toplevel):
         messagebox.showinfo("Approve", "Review approved")
         self.app.add_version()
         self.refresh_reviews()
+
+    def edit_review(self):
+        if not self.app.review_data:
+            return
+        if self.app.current_user not in [m.name for m in self.app.review_data.moderators]:
+            messagebox.showerror("Edit", "Only a moderator can edit the review")
+            return
+        dialog = ParticipantDialog(
+            self,
+            self.app.review_data.mode == 'joint',
+            initial_mods=self.app.review_data.moderators,
+            initial_parts=self.app.review_data.participants,
+        )
+        if not dialog.result:
+            return
+        moderators, participants = dialog.result
+        if not moderators:
+            messagebox.showerror("Review", "At least one moderator required")
+            return
+        self.app.review_data.moderators = moderators
+        self.app.review_data.participants = participants
+        desc = simpledialog.askstring("Description", "Edit description:", initialvalue=self.app.review_data.description)
+        if desc is not None:
+            self.app.review_data.description = desc
+        due = simpledialog.askstring("Due Date", "Edit due date (YYYY-MM-DD):", initialvalue=self.app.review_data.due_date)
+        if due is not None:
+            self.app.review_data.due_date = due
+        self.refresh_reviews()
+        self.refresh_comments()
 
     def open_document(self):
         if not self.app.review_data:
@@ -456,14 +599,24 @@ class ReviewToolbox(tk.Toplevel):
             if p.name == self.app.current_user:
                 role = p.role
                 break
-        if self.app.review_data and self.app.review_data.mode == 'joint' and role == 'approver':
+        if (
+            self.app.review_data
+            and self.app.review_data.mode == 'joint'
+            and role == 'approver'
+            and not self.app.review_is_closed()
+        ):
             self.approve_btn.pack(side=tk.LEFT)
         else:
             self.approve_btn.pack_forget()
-        if self.app.review_data and self.app.current_user == self.app.review_data.moderator:
-            self.resolve_btn.pack(side=tk.LEFT)
+        if self.app.review_data and self.app.current_user in [m.name for m in self.app.review_data.moderators]:
+            self.edit_btn.pack(side=tk.LEFT)
+            if not self.app.review_is_closed():
+                self.resolve_btn.pack(side=tk.LEFT)
+            else:
+                self.resolve_btn.pack_forget()
         else:
             self.resolve_btn.pack_forget()
+            self.edit_btn.pack_forget()
 
     def refresh_targets(self):
         items, self.target_map = self.app.get_review_targets()
@@ -498,6 +651,7 @@ class ReviewDocumentDialog(tk.Toplevel):
         self.dh = getattr(app, 'fta_drawing_helper', None) or fta_drawing_helper
         self.title(f"Review Document - {review.name}")
 
+        self.resizable(True, True)
         self.outer = tk.Canvas(self)
         vbar = tk.Scrollbar(self, orient=tk.VERTICAL, command=self.outer.yview)
         self.outer.configure(yscrollcommand=vbar.set)
@@ -509,9 +663,10 @@ class ReviewDocumentDialog(tk.Toplevel):
             "<Configure>",
             lambda e: self.outer.configure(scrollregion=self.outer.bbox("all")),
         )
+        self.images = []
         self.populate()
 
-    def draw_tree(self, canvas, node):
+    def draw_tree(self, canvas, node, diff_nodes=None):
         def draw_connections(n):
             region_width = 100
             parent_bottom = (n.x, n.y + 40)
@@ -522,9 +677,10 @@ class ReviewDocumentDialog(tk.Toplevel):
                 )
                 child_top = (ch.x, ch.y - 45)
                 if self.dh:
+                    color = "blue" if diff_nodes and ch.unique_id in diff_nodes else "dimgray"
                     self.dh.draw_90_connection(
                         canvas, parent_conn, child_top,
-                        outline_color="dimgray", line_width=1
+                        outline_color=color, line_width=1
                     )
                 draw_connections(ch)
 
@@ -548,7 +704,7 @@ class ReviewDocumentDialog(tk.Toplevel):
                         top_text=top_text,
                         bottom_text=bottom_text,
                         fill=fill,
-                        outline_color="dimgray",
+                        outline_color="blue" if diff_nodes and n.unique_id in diff_nodes else "dimgray",
                         line_width=1,
                     )
             elif typ in ["GATE", "RIGOR LEVEL", "TOP EVENT"]:
@@ -562,7 +718,7 @@ class ReviewDocumentDialog(tk.Toplevel):
                             top_text=top_text,
                             bottom_text=bottom_text,
                             fill=fill,
-                            outline_color="dimgray",
+                            outline_color="blue" if diff_nodes and n.unique_id in diff_nodes else "dimgray",
                             line_width=1,
                         )
                 else:
@@ -575,7 +731,7 @@ class ReviewDocumentDialog(tk.Toplevel):
                             top_text=top_text,
                             bottom_text=bottom_text,
                             fill=fill,
-                            outline_color="dimgray",
+                            outline_color="blue" if diff_nodes and n.unique_id in diff_nodes else "dimgray",
                             line_width=1,
                         )
             else:
@@ -588,7 +744,7 @@ class ReviewDocumentDialog(tk.Toplevel):
                         top_text=top_text,
                         bottom_text=bottom_text,
                         fill=fill,
-                        outline_color="dimgray",
+                        outline_color="blue" if diff_nodes and n.unique_id in diff_nodes else "dimgray",
                         line_width=1,
                     )
 
@@ -602,16 +758,317 @@ class ReviewDocumentDialog(tk.Toplevel):
         draw_all(node)
         canvas.config(scrollregion=canvas.bbox("all"))
 
+    def diff_segments(self, old, new):
+        matcher = difflib.SequenceMatcher(None, old, new)
+        segments = []
+        for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+            if tag == "equal":
+                segments.append((old[i1:i2], "black"))
+            elif tag == "delete":
+                segments.append((old[i1:i2], "red"))
+            elif tag == "insert":
+                segments.append((new[j1:j2], "blue"))
+            elif tag == "replace":
+                segments.append((old[i1:i2], "red"))
+                segments.append((new[j1:j2], "blue"))
+        return segments
+
+    def insert_diff_text(self, widget, old, new):
+        matcher = difflib.SequenceMatcher(None, old, new)
+        for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+            if tag == "equal":
+                widget.insert(tk.END, old[i1:i2])
+            elif tag == "delete":
+                widget.insert(tk.END, old[i1:i2], "removed")
+            elif tag == "insert":
+                widget.insert(tk.END, new[j1:j2], "added")
+            elif tag == "replace":
+                widget.insert(tk.END, old[i1:i2], "removed")
+                widget.insert(tk.END, new[j1:j2], "added")
+
+    def draw_segment_text(self, canvas, cx, cy, segments, font_obj):
+        lines = [[]]
+        for text, color in segments:
+            parts = text.split("\n")
+            for idx, part in enumerate(parts):
+                if idx > 0:
+                    lines.append([])
+                lines[-1].append((part, color))
+        line_height = font_obj.metrics("linespace")
+        total_height = line_height * len(lines)
+        start_y = cy - total_height / 2
+        for line in lines:
+            line_width = sum(font_obj.measure(part) for part, _ in line)
+            start_x = cx - line_width / 2
+            x = start_x
+            for part, color in line:
+                if part:
+                    canvas.create_text(x, start_y, text=part, anchor="nw", fill=color, font=font_obj)
+                    x += font_obj.measure(part)
+            start_y += line_height
+
+    def draw_diff_tree(self, canvas, roots, status, conn_status, node_objs, allow_ids, map1, map2):
+        def draw_connections(n):
+            if n.unique_id not in allow_ids:
+                for ch in n.children:
+                    draw_connections(ch)
+                return
+            region_width = 60
+            parent_bottom = (n.x, n.y + 20)
+            for i, ch in enumerate(n.children):
+                if ch.unique_id not in allow_ids:
+                    continue
+                parent_conn = (
+                    n.x - region_width / 2 + (i + 0.5) * (region_width / len(n.children)),
+                    parent_bottom[1],
+                )
+                child_top = (ch.x, ch.y - 25)
+                if self.dh:
+                    edge_st = conn_status.get((n.unique_id, ch.unique_id), "existing")
+                    if status.get(n.unique_id) == "removed" or status.get(ch.unique_id) == "removed":
+                        edge_st = "removed"
+                    color = "gray"
+                    if edge_st == "added":
+                        color = "blue"
+                    elif edge_st == "removed":
+                        color = "red"
+                    self.dh.draw_90_connection(canvas, parent_conn, child_top, outline_color=color, line_width=1)
+                draw_connections(ch)
+
+        def draw_node(n):
+            if n.unique_id not in allow_ids:
+                for ch in n.children:
+                    draw_node(ch)
+                return
+            st = status.get(n.unique_id, "existing")
+            color = "dimgray"
+            if st == "added":
+                color = "blue"
+            elif st == "removed":
+                color = "red"
+
+            source = n if getattr(n, "is_primary_instance", True) else getattr(n, "original", n)
+            subtype_text = source.input_subtype if source.input_subtype else "N/A"
+            display_label = source.display_label
+            old_data = map1.get(n.unique_id)
+            new_data = map2.get(n.unique_id)
+            def req_lines(reqs):
+                return "; ".join(
+                    self.app.format_requirement_with_trace(r) for r in reqs
+                )
+
+            if old_data and new_data:
+                desc_segments = [("Desc: ", "black")] + self.diff_segments(
+                    old_data.get("description", ""),
+                    new_data.get("description", ""),
+                )
+                rat_segments = [("Rationale: ", "black")] + self.diff_segments(
+                    old_data.get("rationale", ""),
+                    new_data.get("rationale", ""),
+                )
+                req_segments = [("Reqs: ", "black")] + self.diff_segments(
+                    req_lines(old_data.get("safety_requirements", [])),
+                    req_lines(new_data.get("safety_requirements", [])),
+                )
+            else:
+                desc_segments = [("Desc: " + source.description, "black")]
+                rat_segments = [("Rationale: " + source.rationale, "black")]
+                req_segments = [
+                    ("Reqs: " + req_lines(getattr(source, "safety_requirements", [])), "black")
+                ]
+
+            segments = [
+                (f"Type: {source.node_type}\n", "black"),
+                (f"Subtype: {subtype_text}\n", "black"),
+                (f"{display_label}\n", "black"),
+            ] + desc_segments + [("\n\n", "black")] + rat_segments + [("\n\n", "black")] + req_segments
+
+            top_text = "".join(seg[0] for seg in segments)
+            bottom_text = n.name
+            fill = self.app.get_node_fill_color(n)
+            eff_x, eff_y = n.x, n.y
+            typ = n.node_type.upper()
+            items_before = canvas.find_all()
+            if typ in ["GATE", "RIGOR LEVEL", "TOP EVENT"]:
+                if n.gate_type and n.gate_type.upper() == "OR":
+                    if self.dh:
+                        self.dh.draw_rotated_or_gate_shape(canvas, eff_x, eff_y, scale=40, top_text=top_text, bottom_text=bottom_text, fill=fill, outline_color=color, line_width=2)
+                else:
+                    if self.dh:
+                        self.dh.draw_rotated_and_gate_shape(canvas, eff_x, eff_y, scale=40, top_text=top_text, bottom_text=bottom_text, fill=fill, outline_color=color, line_width=2)
+            else:
+                if self.dh:
+                    self.dh.draw_circle_event_shape(canvas, eff_x, eff_y, 45, top_text=top_text, bottom_text=bottom_text, fill=fill, outline_color=color, line_width=2)
+
+            items_after = canvas.find_all()
+            text_id = None
+            for item in items_after:
+                if item in items_before:
+                    continue
+                if canvas.type(item) == "text" and canvas.itemcget(item, "text") == top_text:
+                    text_id = item
+                    break
+
+            if text_id and any(c in ("red", "blue") for _, c in segments):
+                bbox = canvas.bbox(text_id)
+                cx = (bbox[0] + bbox[2]) / 2
+                cy = (bbox[1] + bbox[3]) / 2
+                canvas.itemconfigure(text_id, state="hidden")
+                self.draw_segment_text(canvas, cx, cy, segments, self.app.diagram_font)
+            for ch in n.children:
+                draw_node(ch)
+
+        canvas.delete("all")
+        for r in roots:
+            draw_connections(r)
+            draw_node(r)
+
+        existing_pairs = set()
+        for p in node_objs.values():
+            for ch in p.children:
+                existing_pairs.add((p.unique_id, ch.unique_id))
+
+        for (pid, cid), st in conn_status.items():
+            if st != "removed":
+                continue
+            if (pid, cid) in existing_pairs:
+                continue
+            if pid in node_objs and cid in node_objs and pid in allow_ids and cid in allow_ids:
+                parent = node_objs[pid]
+                child = node_objs[cid]
+                parent_pt = (parent.x, parent.y + 20)
+                child_pt = (child.x, child.y - 25)
+                if self.dh:
+                    self.dh.draw_90_connection(canvas, parent_pt, child_pt, outline_color="red", line_width=1)
+
+        canvas.config(scrollregion=canvas.bbox("all"))
+
     def populate(self):
         row = 0
+        current = self.app.export_model_data(include_versions=False)
+        base_data = self.app.versions[-1]["data"] if self.app.versions else {"top_events": [], "fmeas": []}
+
+        def filter_data(data):
+            return {
+                "top_events": [t for t in data.get("top_events", []) if t["unique_id"] in self.review.fta_ids],
+                "fmeas": [f for f in data.get("fmeas", []) if f.get("name") in self.review.fmea_names],
+            }
+
+        data1 = filter_data(base_data)
+        data2 = filter_data(current)
+
+        map1 = self.app.node_map_from_data(data1["top_events"])
+        map2 = self.app.node_map_from_data(data2["top_events"])
+
+        def build_conn_set(events):
+            conns = set()
+            def visit(d):
+                for ch in d.get("children", []):
+                    conns.add((d["unique_id"], ch["unique_id"]))
+                    visit(ch)
+            for t in events:
+                visit(t)
+            return conns
+
+        conns1 = build_conn_set(data1["top_events"])
+        conns2 = build_conn_set(data2["top_events"])
+
+        conn_status = {}
+        for c in conns1 | conns2:
+            if c in conns1 and c not in conns2:
+                conn_status[c] = "removed"
+            elif c in conns2 and c not in conns1:
+                conn_status[c] = "added"
+            else:
+                conn_status[c] = "existing"
+
+        status = {}
+        for nid in set(map1) | set(map2):
+            if nid in map1 and nid not in map2:
+                status[nid] = "removed"
+            elif nid in map2 and nid not in map1:
+                status[nid] = "added"
+            else:
+                if json.dumps(map1[nid], sort_keys=True) != json.dumps(map2[nid], sort_keys=True):
+                    status[nid] = "added"
+                else:
+                    status[nid] = "existing"
+
+        module = sys.modules.get(self.app.__class__.__module__)
+        FaultTreeNodeCls = getattr(module, 'FaultTreeNode', None)
+        if not FaultTreeNodeCls and self.app.top_events:
+            FaultTreeNodeCls = type(self.app.top_events[0])
+
+        new_roots = [FaultTreeNodeCls.from_dict(t) for t in data2["top_events"]]
+        removed_ids = [nid for nid, st in status.items() if st == "removed"]
+        for rid in removed_ids:
+            if rid in map1:
+                nd = map1[rid]
+                new_roots.append(FaultTreeNodeCls.from_dict(nd))
+
+        relevant_ids = set()
+        def collect_ids(d):
+            relevant_ids.add(d["unique_id"])
+            for ch in d.get("children", []):
+                collect_ids(ch)
+        for t in data1["top_events"]:
+            collect_ids(t)
+        for t in data2["top_events"]:
+            collect_ids(t)
+
+        node_objs = {}
+        def collect_nodes(n):
+            if n.unique_id not in node_objs:
+                node_objs[n.unique_id] = n
+            for ch in n.children:
+                collect_nodes(ch)
+        for rnode in new_roots:
+            collect_nodes(rnode)
+
+        old_fmea = {
+            f["name"]: {e["unique_id"]: e for e in f.get("entries", [])}
+            for f in data1.get("fmeas", [])
+        }
+        new_fmea = {
+            f["name"]: {e["unique_id"]: e for e in f.get("entries", [])}
+            for f in data2.get("fmeas", [])
+        }
+
+        reqs1 = {}
+        reqs2 = {}
+
+        def collect_reqs(node_dict, target):
+            for r in node_dict.get("safety_requirements", []):
+                rid = r.get("id")
+                if rid and rid not in target:
+                    target[rid] = r
+            for ch in node_dict.get("children", []):
+                collect_reqs(ch, target)
+
+        for nid in self.review.fta_ids:
+            if nid in map1:
+                collect_reqs(map1[nid], reqs1)
+            if nid in map2:
+                collect_reqs(map2[nid], reqs2)
+
+        for name in self.review.fmea_names:
+            for e in old_fmea.get(name, {}).values():
+                for r in e.get("safety_requirements", []):
+                    rid = r.get("id")
+                    if rid and rid not in reqs1:
+                        reqs1[rid] = r
+            for e in new_fmea.get(name, {}).values():
+                for r in e.get("safety_requirements", []):
+                    rid = r.get("id")
+                    if rid and rid not in reqs2:
+                        reqs2[rid] = r
+
         heading_font = ("TkDefaultFont", 10, "bold")
         for nid in self.review.fta_ids:
             node = self.app.find_node_by_id_all(nid)
             if not node:
                 continue
-            tk.Label(self.inner, text=f"FTA: {node.name}", font=heading_font).grid(
-                row=row, column=0, sticky="w", padx=5, pady=5
-            )
+            tk.Label(self.inner, text=f"FTA: {node.name}", font=heading_font).grid(row=row, column=0, sticky="w", padx=5, pady=5)
             row += 1
             frame = tk.Frame(self.inner)
             frame.grid(row=row, column=0, padx=5, pady=5, sticky="nsew")
@@ -626,18 +1083,21 @@ class ReviewDocumentDialog(tk.Toplevel):
             frame.columnconfigure(0, weight=1)
             c.bind("<ButtonPress-1>", lambda e, cv=c: cv.scan_mark(e.x, e.y))
             c.bind("<B1-Motion>", lambda e, cv=c: cv.scan_dragto(e.x, e.y, gain=1))
-            self.draw_tree(c, node)
-            bbox = c.bbox("all")
-            if bbox:
-                c.config(scrollregion=bbox)
+
+            img = self.app.capture_diff_diagram(node)
+            if img:
+                from PIL import ImageTk
+                img = img.resize((img.width // 2, img.height // 2), Image.LANCZOS)
+                photo = ImageTk.PhotoImage(img)
+                self.images.append(photo)
+                c.create_image(0, 0, image=photo, anchor="nw")
+                c.config(scrollregion=(0, 0, img.width, img.height))
             row += 1
         for name in self.review.fmea_names:
-            fmea = next((f for f in self.app.fmeas if f["name"] == name), None)
-            if not fmea:
+            cur_fmea = next((f for f in data2.get("fmeas", []) if f["name"] == name), None)
+            if not cur_fmea and name not in old_fmea:
                 continue
-            tk.Label(self.inner, text=f"FMEA: {name}", font=heading_font).grid(
-                row=row, column=0, sticky="w", padx=5, pady=5
-            )
+            tk.Label(self.inner, text=f"FMEA: {name}", font=heading_font).grid(row=row, column=0, sticky="w", padx=5, pady=5)
             row += 1
             frame = tk.Frame(self.inner)
             frame.grid(row=row, column=0, sticky="nsew", padx=5, pady=5)
@@ -669,32 +1129,89 @@ class ReviewDocumentDialog(tk.Toplevel):
             frame.grid_columnconfigure(0, weight=1)
             frame.grid_rowconfigure(0, weight=1)
 
-            for entry in fmea["entries"]:
-                parent = entry.parents[0] if entry.parents else None
-                if parent:
-                    comp = parent.user_name if parent.user_name else f"Node {parent.unique_id}"
-                    parent_name = comp
+            tree.tag_configure("added", background="#cce5ff")
+            tree.tag_configure("removed", background="#f8d7da")
+            tree.tag_configure("existing", background="#e2e3e5")
+
+            entries1 = old_fmea.get(name, {})
+            entries2 = {e["unique_id"]: e for e in (cur_fmea.get("entries", []) if cur_fmea else [])}
+
+            for uid in set(entries1) | set(entries2):
+                if uid in entries1 and uid not in entries2:
+                    st = "removed"
+                    entry = entries1[uid]
+                elif uid in entries2 and uid not in entries1:
+                    st = "added"
+                    entry = entries2[uid]
                 else:
-                    comp = getattr(entry, "fmea_component", "") or "N/A"
-                    parent_name = ""
+                    if json.dumps(entries1[uid], sort_keys=True) != json.dumps(entries2[uid], sort_keys=True):
+                        st = "added"
+                        entry = entries2[uid]
+                    else:
+                        st = "existing"
+                        entry = entries2[uid]
+
+                parent = entry.get("parents", [{}])
+                parent = parent[0] if parent else {}
+                comp = parent.get("user_name") or entry.get("fmea_component", "") or "N/A"
+                parent_name = parent.get("user_name", f"Node {parent.get('unique_id')}") if parent else ""
+                rpn = int(entry.get("fmea_severity", 1)) * int(entry.get("fmea_occurrence", 1)) * int(entry.get("fmea_detection", 1))
                 req_ids = "; ".join(
-                    [f"{req['req_type']}:{req['text']}" for req in getattr(entry, 'safety_requirements', [])]
+                    f"{r.get('req_type', '')}:{r.get('text', '')}"
+                    for r in entry.get("safety_requirements", [])
                 )
-                rpn = entry.fmea_severity * entry.fmea_occurrence * entry.fmea_detection
-                failure_mode = entry.description or entry.user_name or f"BE {entry.unique_id}"
+                failure_mode = entry.get("description") or entry.get("user_name", f"BE {uid}")
                 vals = [
                     comp,
                     parent_name,
                     failure_mode,
-                    entry.fmea_effect,
-                    getattr(entry, "fmea_cause", ""),
-                    entry.fmea_severity,
-                    entry.fmea_occurrence,
-                    entry.fmea_detection,
+                    entry.get("fmea_effect", ""),
+                    entry.get("fmea_cause", ""),
+                    entry.get("fmea_severity", ""),
+                    entry.get("fmea_occurrence", ""),
+                    entry.get("fmea_detection", ""),
                     rpn,
                     req_ids,
                 ]
-                tree.insert("", "end", values=vals)
+                tree.insert("", "end", values=vals, tags=(st,))
+
+        row += 1
+
+        if reqs1 or reqs2:
+            tk.Label(self.inner, text="Requirements", font=heading_font).grid(row=row, column=0, sticky="w", padx=5, pady=5)
+            row += 1
+            frame = tk.Frame(self.inner)
+            frame.grid(row=row, column=0, sticky="nsew", padx=5, pady=5)
+            vbar = tk.Scrollbar(frame, orient="vertical")
+            text = tk.Text(frame, wrap="word", yscrollcommand=vbar.set, height=8)
+            text.tag_configure("added", foreground="blue")
+            text.tag_configure("removed", foreground="red")
+            vbar.config(command=text.yview)
+            text.grid(row=0, column=0, sticky="nsew")
+            vbar.grid(row=0, column=1, sticky="ns")
+            frame.grid_columnconfigure(0, weight=1)
+            frame.grid_rowconfigure(0, weight=1)
+
+            def fmt(r):
+                return self.app.format_requirement_with_trace(r)
+
+            all_ids = sorted(set(reqs1) | set(reqs2))
+            for rid in all_ids:
+                r1 = reqs1.get(rid)
+                r2 = reqs2.get(rid)
+                if r1 and not r2:
+                    text.insert(tk.END, f"Removed: ")
+                    self.insert_diff_text(text, fmt(r1), "")
+                elif r2 and not r1:
+                    text.insert(tk.END, f"Added: ")
+                    self.insert_diff_text(text, "", fmt(r2))
+                else:
+                    if json.dumps(r1, sort_keys=True) != json.dumps(r2, sort_keys=True):
+                        text.insert(tk.END, f"Updated: ")
+                        self.insert_diff_text(text, fmt(r1), fmt(r2))
+                    else:
+                        text.insert(tk.END, fmt(r2))
+                text.insert(tk.END, "\n")
 
             row += 1
 
@@ -1022,6 +1539,11 @@ class VersionCompareDialog(tk.Toplevel):
             old_data = map1.get(n.unique_id)
             new_data = map2.get(n.unique_id)
 
+            def req_lines(reqs):
+                return "; ".join(
+                    self.app.format_requirement_with_trace(r) for r in reqs
+                )
+
             if old_data and new_data:
                 desc_segments = [("Desc: ", "black")] + self.diff_segments(
                     old_data.get("description", ""), new_data.get("description", "")
@@ -1029,15 +1551,22 @@ class VersionCompareDialog(tk.Toplevel):
                 rat_segments = [("Rationale: ", "black")] + self.diff_segments(
                     old_data.get("rationale", ""), new_data.get("rationale", "")
                 )
+                req_segments = [("Reqs: ", "black")] + self.diff_segments(
+                    req_lines(old_data.get("safety_requirements", [])),
+                    req_lines(new_data.get("safety_requirements", [])),
+                )
             else:
                 desc_segments = [("Desc: " + source.description, "black")]
                 rat_segments = [("Rationale: " + source.rationale, "black")]
+                req_segments = [
+                    ("Reqs: " + req_lines(getattr(source, "safety_requirements", [])), "black")
+                ]
 
             segments = [
                 (f"Type: {source.node_type}\n", "black"),
                 (f"Subtype: {subtype_text}\n", "black"),
                 (f"{display_label}\n", "black"),
-            ] + desc_segments + [("\n\n", "black")] + rat_segments
+            ] + desc_segments + [("\n\n", "black")] + rat_segments + [("\n\n", "black")] + req_segments
 
             top_text = "".join(seg[0] for seg in segments)
             bottom_text = n.name
@@ -1169,11 +1698,7 @@ class VersionCompareDialog(tk.Toplevel):
                     self.insert_diff(n1.get("rationale", ""), n2.get("rationale", ""))
                     self.log_text.insert(tk.END, "\n")
                 def req_lines(reqs):
-                    lines = []
-                    for r in reqs:
-                        lines.append(
-                            f"[{r.get('id','')}] [{r.get('req_type','')}] [{r.get('asil','')}] {r.get('text','')}"
-                        )
+                    lines = [self.app.format_requirement_with_trace(r) for r in reqs]
                     return "\n".join(lines)
 
                 req1 = req_lines(n1.get("safety_requirements", []))


### PR DESCRIPTION
## Summary
- capture linked elements and safety goals for every requirement
- show this information in the Requirements Matrix window
- include requirement traces when diffing FTAs, review documents and emails
- describe traceability in README
- fix AttributeError by adding trace helper methods to the main app
- handle FMEA entries stored as objects when collecting allocations
- use diff images for FTAs in review documents so changes match the compare dialog
- avoid IndexError in safety goal lookup
- scale diagrams in review documents to half size

## Testing
- `python -m py_compile FreeCTA.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_687cfc7cea288325b5d941a44a0961f0