### PR TITLE
Add safe state field and diff highlighting

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -1744,6 +1744,12 @@ class EditNodeDialog(simpledialog.Dialog):
                 self.sg_asil_combo.grid(row=row_next, column=1, padx=5, pady=5, sticky="w")
                 row_next += 1
 
+                ttk.Label(master, text="Safe State:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
+                self.safe_state_entry = tk.Entry(master, width=40, font=dialog_font)
+                self.safe_state_entry.insert(0, self.node.safe_state)
+                self.safe_state_entry.grid(row=row_next, column=1, padx=5, pady=5, sticky="w")
+                row_next += 1
+
 
         if self.node.node_type.upper() not in ["TOP EVENT", "BASIC EVENT"]:
             self.is_page_var = tk.BooleanVar(value=self.node.is_page)
@@ -2114,6 +2120,7 @@ class EditNodeDialog(simpledialog.Dialog):
                 target_node.is_page = False
                 target_node.safety_goal_description = self.safety_goal_text.get("1.0", "end-1c")
                 target_node.safety_goal_asil = self.sg_asil_var.get().strip()
+                target_node.safe_state = self.safe_state_entry.get().strip()
             else:
                 target_node.is_page = self.is_page_var.get()
 
@@ -2422,6 +2429,22 @@ class FaultTreeApp:
             else:
                 if json.dumps(r1, sort_keys=True) != json.dumps(r2, sort_keys=True):
                     lines.append("Updated: " + html_diff(self.format_requirement_with_trace(r1), self.format_requirement_with_trace(r2)))
+
+        for nid in review.fta_ids:
+            n1 = map1.get(nid, {})
+            n2 = map2.get(nid, {})
+            sg_old = f"{n1.get('safety_goal_description','')} [{n1.get('safety_goal_asil','')}]"
+            sg_new = f"{n2.get('safety_goal_description','')} [{n2.get('safety_goal_asil','')}]"
+            label = n2.get('user_name') or n1.get('user_name') or f"Node {nid}"
+            if sg_old != sg_new:
+                lines.append(
+                    f"Safety Goal for {html.escape(label)}: " + html_diff(sg_old, sg_new)
+                )
+            if n1.get('safe_state','') != n2.get('safe_state',''):
+                lines.append(
+                    f"Safe State for {html.escape(label)}: " + html_diff(n1.get('safe_state',''), n2.get('safe_state',''))
+                )
+
         return "<br>".join(lines)
 
     # --- Requirement Traceability Helpers used by reviews and matrix view ---
@@ -2556,6 +2579,22 @@ class FaultTreeApp:
             else:
                 if json.dumps(r1, sort_keys=True) != json.dumps(r2, sort_keys=True):
                     lines.append("Updated: " + html_diff(self.format_requirement_with_trace(r1), self.format_requirement_with_trace(r2)))
+
+        for nid in review.fta_ids:
+            n1 = map1.get(nid, {})
+            n2 = map2.get(nid, {})
+            sg_old = f"{n1.get('safety_goal_description','')} [{n1.get('safety_goal_asil','')}]"
+            sg_new = f"{n2.get('safety_goal_description','')} [{n2.get('safety_goal_asil','')}]"
+            label = n2.get('user_name') or n1.get('user_name') or f"Node {nid}"
+            if sg_old != sg_new:
+                lines.append(
+                    f"Safety Goal for {html.escape(label)}: " + html_diff(sg_old, sg_new)
+                )
+            if n1.get('safe_state','') != n2.get('safe_state',''):
+                lines.append(
+                    f"Safe State for {html.escape(label)}: " + html_diff(n1.get('safe_state',''), n2.get('safe_state',''))
+                )
+
         return "<br>".join(lines)
 
     # --- Requirement Traceability Helpers used by reviews and matrix view ---
@@ -2696,6 +2735,22 @@ class FaultTreeApp:
             else:
                 if json.dumps(r1, sort_keys=True) != json.dumps(r2, sort_keys=True):
                     lines.append("Updated: " + html_diff(self.format_requirement_with_trace(r1), self.format_requirement_with_trace(r2)))
+
+        for nid in review.fta_ids:
+            n1 = map1.get(nid, {})
+            n2 = map2.get(nid, {})
+            sg_old = f"{n1.get('safety_goal_description','')} [{n1.get('safety_goal_asil','')}]"
+            sg_new = f"{n2.get('safety_goal_description','')} [{n2.get('safety_goal_asil','')}]"
+            label = n2.get('user_name') or n1.get('user_name') or f"Node {nid}"
+            if sg_old != sg_new:
+                lines.append(
+                    f"Safety Goal for {html.escape(label)}: " + html_diff(sg_old, sg_new)
+                )
+            if n1.get('safe_state','') != n2.get('safe_state',''):
+                lines.append(
+                    f"Safe State for {html.escape(label)}: " + html_diff(n1.get('safe_state',''), n2.get('safe_state',''))
+                )
+
         return "<br>".join(lines)
 
     # --- Requirement Traceability Helpers used by reviews and matrix view ---
@@ -7739,6 +7794,7 @@ class FaultTreeApp:
             return ", ".join(sorted(goals))
 
         import difflib
+
         def insert_diff(widget, old, new):
             matcher = difflib.SequenceMatcher(None, old, new)
             for tag, i1, i2, j1, j2 in matcher.get_opcodes():
@@ -7752,6 +7808,27 @@ class FaultTreeApp:
                     widget.insert(tk.END, old[i1:i2], "removed")
                     widget.insert(tk.END, new[j1:j2], "added")
 
+        def insert_list_diff(widget, old, new):
+            old_items = [s.strip() for s in old.split(',') if s.strip()]
+            new_items = [s.strip() for s in new.split(',') if s.strip()]
+            old_set = set(old_items)
+            new_set = set(new_items)
+            first = True
+            for item in new_items:
+                if not first:
+                    widget.insert(tk.END, ", ")
+                first = False
+                if item not in old_set:
+                    widget.insert(tk.END, item, "added")
+                else:
+                    widget.insert(tk.END, item)
+            for item in old_items:
+                if item not in new_set:
+                    if not first:
+                        widget.insert(tk.END, ", ")
+                    first = False
+                    widget.insert(tk.END, item, "removed")
+
         for req in reqs:
             rid = req.get("id")
             alloc = ", ".join(self.get_requirement_allocation_names(rid))
@@ -7759,7 +7836,7 @@ class FaultTreeApp:
             text.insert(tk.END, f"[{rid}] {req.get('text','')}\n")
             text.insert(tk.END, "  Allocated to: ")
             if base_data:
-                insert_diff(text, alloc_from_data(rid), alloc)
+                insert_list_diff(text, alloc_from_data(rid), alloc)
             else:
                 text.insert(tk.END, alloc)
             text.insert(tk.END, "\n  Safety Goals: ")
@@ -8322,20 +8399,24 @@ class FaultTreeApp:
         """Display safety goals and derived requirements in a tree view."""
         win = tk.Toplevel(self.root)
         win.title("Safety Goals Matrix")
-        tree = ttk.Treeview(win, columns=["ID", "ASIL", "Text"], show="tree headings")
+        tree = ttk.Treeview(win, columns=["ID", "ASIL", "SafeState", "Text"], show="tree headings")
         tree.heading("ID", text="Requirement ID")
         tree.heading("ASIL", text="ASIL")
+        tree.heading("SafeState", text="Safe State")
         tree.heading("Text", text="Text")
         tree.column("ID", width=120)
         tree.column("ASIL", width=60)
+        tree.column("SafeState", width=100)
         tree.column("Text", width=300)
         tree.pack(fill=tk.BOTH, expand=True)
 
         for te in self.top_events:
             sg_text = te.safety_goal_description or (te.user_name or f"SG {te.unique_id}")
             sg_id = te.user_name or f"SG {te.unique_id}"
-            parent_iid = tree.insert("", "end", text=sg_text,
-                                    values=[sg_id, te.safety_goal_asil, sg_text])
+            parent_iid = tree.insert(
+                "", "end", text=sg_text,
+                values=[sg_id, te.safety_goal_asil, te.safe_state, sg_text],
+            )
             reqs = self.collect_requirements_recursive(te)
             seen_ids = set()
             for req in reqs:
@@ -8356,7 +8437,7 @@ class FaultTreeApp:
         if not path:
             return
 
-        columns = ["Safety Goal", "SG ASIL", "Requirement ID", "Req ASIL", "Text"]
+        columns = ["Safety Goal", "SG ASIL", "Safe State", "Requirement ID", "Req ASIL", "Text"]
         with open(path, "w", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(columns)
@@ -8370,7 +8451,7 @@ class FaultTreeApp:
                     if rid in seen:
                         continue
                     seen.add(rid)
-                    writer.writerow([sg_text, sg_asil, rid, req.get("asil", ""), req.get("text", "")])
+                    writer.writerow([sg_text, sg_asil, te.safe_state, rid, req.get("asil", ""), req.get("text", "")])
         messagebox.showinfo("Export", "Safety goal requirements exported.")
 
 
@@ -9560,6 +9641,7 @@ class FaultTreeNode:
         self.original = self
         self.safety_goal_description = ""
         self.safety_goal_asil = ""
+        self.safe_state = ""
         self.vehicle_safety_requirements = []          # List of vehicle safety requirements
         self.operational_safety_requirements = []        # List of operational safety requirements
         # Each requirement is a dict with keys: "id", "req_type" and "text"
@@ -9601,6 +9683,7 @@ class FaultTreeNode:
             "is_primary_instance": self.is_primary_instance,
             "safety_goal_description": self.safety_goal_description,
             "safety_goal_asil": self.safety_goal_asil,
+            "safe_state": self.safe_state,
             "fmea_effect": self.fmea_effect,
             "fmea_cause": self.fmea_cause,
             "fmea_severity": self.fmea_severity,
@@ -9639,6 +9722,7 @@ class FaultTreeNode:
         node.is_primary_instance = boolify(data.get("is_primary_instance", True), True)
         node.safety_goal_description = data.get("safety_goal_description", "")
         node.safety_goal_asil = data.get("safety_goal_asil", "")
+        node.safe_state = data.get("safe_state", "")
         node.fmea_effect = data.get("fmea_effect", "")
         node.fmea_cause = data.get("fmea_cause", "")
         node.fmea_severity = data.get("fmea_severity", 1)

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -868,6 +868,13 @@ class ReviewDocumentDialog(tk.Toplevel):
                     old_data.get("rationale", ""),
                     new_data.get("rationale", ""),
                 )
+                sg_segments = [("SG: ", "black")] + self.diff_segments(
+                    f"{old_data.get('safety_goal_description','')} [{old_data.get('safety_goal_asil','')}]",
+                    f"{new_data.get('safety_goal_description','')} [{new_data.get('safety_goal_asil','')}]",
+                )
+                ss_segments = [("Safe State: ", "black")] + self.diff_segments(
+                    old_data.get('safe_state', ''), new_data.get('safe_state', '')
+                )
                 req_segments = [("Reqs: ", "black")] + self.diff_segments(
                     req_lines(old_data.get("safety_requirements", [])),
                     req_lines(new_data.get("safety_requirements", [])),
@@ -875,6 +882,15 @@ class ReviewDocumentDialog(tk.Toplevel):
             else:
                 desc_segments = [("Desc: " + source.description, "black")]
                 rat_segments = [("Rationale: " + source.rationale, "black")]
+                sg_segments = [(
+                    "SG: "
+                    + f"{source.safety_goal_description} [{source.safety_goal_asil}]",
+                    "black",
+                )]
+                ss_segments = [(
+                    "Safe State: " + getattr(source, 'safe_state', ''),
+                    "black",
+                )]
                 req_segments = [
                     ("Reqs: " + req_lines(getattr(source, "safety_requirements", [])), "black")
                 ]
@@ -883,7 +899,7 @@ class ReviewDocumentDialog(tk.Toplevel):
                 (f"Type: {source.node_type}\n", "black"),
                 (f"Subtype: {subtype_text}\n", "black"),
                 (f"{display_label}\n", "black"),
-            ] + desc_segments + [("\n\n", "black")] + rat_segments + [("\n\n", "black")] + req_segments
+            ] + desc_segments + [("\n\n", "black")] + rat_segments + [("\n\n", "black")] + sg_segments + [("\n\n", "black")] + ss_segments + [("\n\n", "black")] + req_segments
 
             top_text = "".join(seg[0] for seg in segments)
             bottom_text = n.name
@@ -1214,6 +1230,21 @@ class ReviewDocumentDialog(tk.Toplevel):
                     else:
                         text.insert(tk.END, fmt(r2))
                 text.insert(tk.END, "\n")
+
+            for nid in self.review.fta_ids:
+                n1 = map1.get(nid, {})
+                n2 = map2.get(nid, {})
+                sg_old = f"{n1.get('safety_goal_description','')} [{n1.get('safety_goal_asil','')}]"
+                sg_new = f"{n2.get('safety_goal_description','')} [{n2.get('safety_goal_asil','')}]"
+                label = n2.get('user_name') or n1.get('user_name') or f"Node {nid}"
+                if sg_old != sg_new:
+                    text.insert(tk.END, f"Safety Goal for {label}: ")
+                    self.insert_diff_text(text, sg_old, sg_new)
+                    text.insert(tk.END, "\n")
+                if n1.get('safe_state','') != n2.get('safe_state',''):
+                    text.insert(tk.END, f"Safe State for {label}: ")
+                    self.insert_diff_text(text, n1.get('safe_state',''), n2.get('safe_state',''))
+                    text.insert(tk.END, "\n")
 
             row += 1
 
@@ -1553,6 +1584,13 @@ class VersionCompareDialog(tk.Toplevel):
                 rat_segments = [("Rationale: ", "black")] + self.diff_segments(
                     old_data.get("rationale", ""), new_data.get("rationale", "")
                 )
+                sg_segments = [("SG: ", "black")] + self.diff_segments(
+                    f"{old_data.get('safety_goal_description','')} [{old_data.get('safety_goal_asil','')}]",
+                    f"{new_data.get('safety_goal_description','')} [{new_data.get('safety_goal_asil','')}]",
+                )
+                ss_segments = [("Safe State: ", "black")] + self.diff_segments(
+                    old_data.get('safe_state', ''), new_data.get('safe_state', '')
+                )
                 req_segments = [("Reqs: ", "black")] + self.diff_segments(
                     req_lines(old_data.get("safety_requirements", [])),
                     req_lines(new_data.get("safety_requirements", [])),
@@ -1560,6 +1598,14 @@ class VersionCompareDialog(tk.Toplevel):
             else:
                 desc_segments = [("Desc: " + source.description, "black")]
                 rat_segments = [("Rationale: " + source.rationale, "black")]
+                sg_segments = [(
+                    "SG: " + f"{source.safety_goal_description} [{source.safety_goal_asil}]",
+                    "black",
+                )]
+                ss_segments = [(
+                    "Safe State: " + getattr(source, 'safe_state', ''),
+                    "black",
+                )]
                 req_segments = [
                     ("Reqs: " + req_lines(getattr(source, "safety_requirements", [])), "black")
                 ]
@@ -1568,7 +1614,7 @@ class VersionCompareDialog(tk.Toplevel):
                 (f"Type: {source.node_type}\n", "black"),
                 (f"Subtype: {subtype_text}\n", "black"),
                 (f"{display_label}\n", "black"),
-            ] + desc_segments + [("\n\n", "black")] + rat_segments + [("\n\n", "black")] + req_segments
+            ] + desc_segments + [("\n\n", "black")] + rat_segments + [("\n\n", "black")] + sg_segments + [("\n\n", "black")] + ss_segments + [("\n\n", "black")] + req_segments
 
             top_text = "".join(seg[0] for seg in segments)
             bottom_text = n.name
@@ -1698,6 +1744,22 @@ class VersionCompareDialog(tk.Toplevel):
                         f"Rationale change for {n1.get('user_name', nid)}: ",
                     )
                     self.insert_diff(n1.get("rationale", ""), n2.get("rationale", ""))
+                    self.log_text.insert(tk.END, "\n")
+                sg1 = f"{n1.get('safety_goal_description','')} [{n1.get('safety_goal_asil','')}]"
+                sg2 = f"{n2.get('safety_goal_description','')} [{n2.get('safety_goal_asil','')}]"
+                if sg1 != sg2:
+                    self.log_text.insert(
+                        tk.END,
+                        f"Safety Goal change for {n1.get('user_name', nid)}: ",
+                    )
+                    self.insert_diff(sg1, sg2)
+                    self.log_text.insert(tk.END, "\n")
+                if n1.get('safe_state','') != n2.get('safe_state',''):
+                    self.log_text.insert(
+                        tk.END,
+                        f"Safe State change for {n1.get('user_name', nid)}: ",
+                    )
+                    self.insert_diff(n1.get('safe_state',''), n2.get('safe_state',''))
                     self.log_text.insert(tk.END, "\n")
                 def req_lines(reqs):
                     lines = [self.app.format_requirement_with_trace(r) for r in reqs]


### PR DESCRIPTION
## Summary
- add `safe_state` attribute to `FaultTreeNode`
- include safe state in node editor dialog
- export safe state in safety goals matrix and CSV
- highlight safety goal/ASIL and safe state differences in compare, document, and email diff
- highlight added and removed requirement allocations

## Testing
- `python3 -m py_compile FreeCTA.py review_toolbox.py`


------
https://chatgpt.com/codex/tasks/task_b_687dd25c2d348325bb6537c9b16170ea