### PR TITLE
Fix FMEDA metrics when no safety goal set

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -4264,6 +4264,13 @@ class FaultTreeApp:
                 return result
         return None
 
+    def get_safety_goal_asil(self, sg_name):
+        """Return the ASIL level for a safety goal name."""
+        for te in self.top_events:
+            if sg_name and (sg_name == te.user_name or sg_name == te.safety_goal_description):
+                return te.safety_goal_asil or "QM"
+        return "QM"
+
     def edit_selected(self):
         sel = self.treeview.selection()
         target = None


### PR DESCRIPTION
## Summary
- add `get_safety_goal_asil` to `FaultTreeApp`

## Testing
- `python -m py_compile FreeCTA.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_687fdcc265fc83258151f0673fc0c5ce