### PR TITLE
Fix FMEDA mission profile dialog error

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -4264,6 +4264,13 @@ class FaultTreeApp:
                 return result
         return None
 
+    def get_safety_goal_asil(self, sg_name):
+        """Return the ASIL level for a safety goal name."""
+        for te in self.top_events:
+            if sg_name and (sg_name == te.user_name or sg_name == te.safety_goal_description):
+                return te.safety_goal_asil or "QM"
+        return "QM"
+
     def edit_selected(self):
         sel = self.treeview.selection()
         target = None
@@ -10743,6 +10750,8 @@ class FaultTreeApp:
         def refresh():
             listbox.delete(0, tk.END)
             for mp in self.mission_profiles:
+                if mp is None:
+                    continue
                 info = (
                     f"{mp.name} (on: {mp.tau_on}h, off: {mp.tau_off}h, "
                     f"board: {mp.board_temp}\u00b0C, ambient: {mp.ambient_temp}\u00b0C)"
@@ -10813,7 +10822,7 @@ class FaultTreeApp:
 
         def add_profile():
             dlg = MPDialog(win)
-            if hasattr(dlg, "result"):
+            if getattr(dlg, "result", None) is not None:
                 self.mission_profiles.append(dlg.result)
                 refresh()
 
@@ -10823,7 +10832,7 @@ class FaultTreeApp:
                 return
             mp = self.mission_profiles[sel[0]]
             dlg = MPDialog(win, mp)
-            if hasattr(dlg, "result"):
+            if getattr(dlg, "result", None) is not None:
                 refresh()
 
         def delete_profile():


### PR DESCRIPTION
## Summary
- avoid appending `None` when mission profile dialogs are canceled
- skip `None` entries when listing mission profiles

## Testing
- `python -m py_compile FreeCTA.py review_toolbox.py`


------
https://chatgpt.com/codex/tasks/task_b_687fdcc265fc83258151f0673fc0c5ce