### PR TITLE
Improve cut set window output

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -9469,18 +9469,35 @@ class FaultTreeApp:
         messagebox.showinfo("Export", "Safety goal requirements exported.")
 
     def show_cut_sets(self):
+        """Display minimal cut sets for every top event."""
         if not self.top_events:
             return
-        te = self.top_events[0]
-        cut_sets = self.calculate_cut_sets(te)
         win = tk.Toplevel(self.root)
         win.title("FTA Cut Sets")
-        tree = ttk.Treeview(win, columns=["Cut Set"], show="headings")
-        tree.heading("Cut Set", text="Basic Events")
+        columns = ("Top Event", "Cut Set #", "Basic Events")
+        tree = ttk.Treeview(win, columns=columns, show="headings")
+        for c in columns:
+            tree.heading(c, text=c)
         tree.pack(fill=tk.BOTH, expand=True)
-        for cs in cut_sets:
-            names = ", ".join(str(uid) for uid in sorted(cs))
-            tree.insert("", "end", values=[names])
+
+        for te in self.top_events:
+            nodes_by_id = {}
+
+            def map_nodes(n):
+                nodes_by_id[n.unique_id] = n
+                for child in n.children:
+                    map_nodes(child)
+
+            map_nodes(te)
+            cut_sets = self.calculate_cut_sets(te)
+            te_label = te.user_name or f"Top Event {te.unique_id}"
+            for idx, cs in enumerate(cut_sets, start=1):
+                names = ", ".join(
+                    f"{nodes_by_id[uid].user_name or nodes_by_id[uid].node_type} [{uid}]"
+                    for uid in sorted(cs)
+                )
+                tree.insert("", "end", values=(te_label, idx, names))
+                te_label = ""
 
         def export_csv():
             path = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV", "*.csv")])
@@ -9488,9 +9505,9 @@ class FaultTreeApp:
                 return
             with open(path, "w", newline="") as f:
                 writer = csv.writer(f)
-                writer.writerow(["Cut Set"])
-                for cs in cut_sets:
-                    writer.writerow([", ".join(str(uid) for uid in sorted(cs))])
+                writer.writerow(["Top Event", "Cut Set #", "Basic Events"])
+                for iid in tree.get_children():
+                    writer.writerow(tree.item(iid, "values"))
             messagebox.showinfo("Export", "Cut sets exported")
 
         ttk.Button(win, text="Export CSV", command=export_csv).pack(pady=5)
@@ -9556,18 +9573,35 @@ class FaultTreeApp:
         ttk.Button(btn_frame, text="Export CSV", command=export_csv).pack(side=tk.LEFT, padx=5, pady=5)
 
     def show_cut_sets(self):
+        """Display minimal cut sets for every top event."""
         if not self.top_events:
             return
-        te = self.top_events[0]
-        cut_sets = self.calculate_cut_sets(te)
         win = tk.Toplevel(self.root)
         win.title("FTA Cut Sets")
-        tree = ttk.Treeview(win, columns=["Cut Set"], show="headings")
-        tree.heading("Cut Set", text="Basic Events")
+        columns = ("Top Event", "Cut Set #", "Basic Events")
+        tree = ttk.Treeview(win, columns=columns, show="headings")
+        for c in columns:
+            tree.heading(c, text=c)
         tree.pack(fill=tk.BOTH, expand=True)
-        for cs in cut_sets:
-            names = ", ".join(str(uid) for uid in sorted(cs))
-            tree.insert("", "end", values=[names])
+
+        for te in self.top_events:
+            nodes_by_id = {}
+
+            def map_nodes(n):
+                nodes_by_id[n.unique_id] = n
+                for child in n.children:
+                    map_nodes(child)
+
+            map_nodes(te)
+            cut_sets = self.calculate_cut_sets(te)
+            te_label = te.user_name or f"Top Event {te.unique_id}"
+            for idx, cs in enumerate(cut_sets, start=1):
+                names = ", ".join(
+                    f"{nodes_by_id[uid].user_name or nodes_by_id[uid].node_type} [{uid}]"
+                    for uid in sorted(cs)
+                )
+                tree.insert("", "end", values=(te_label, idx, names))
+                te_label = ""
 
         def export_csv():
             path = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV", "*.csv")])
@@ -9575,9 +9609,9 @@ class FaultTreeApp:
                 return
             with open(path, "w", newline="") as f:
                 writer = csv.writer(f)
-                writer.writerow(["Cut Set"])
-                for cs in cut_sets:
-                    writer.writerow([", ".join(str(uid) for uid in sorted(cs))])
+                writer.writerow(["Top Event", "Cut Set #", "Basic Events"])
+                for iid in tree.get_children():
+                    writer.writerow(tree.item(iid, "values"))
             messagebox.showinfo("Export", "Cut sets exported")
 
         ttk.Button(win, text="Export CSV", command=export_csv).pack(pady=5)
@@ -9643,18 +9677,35 @@ class FaultTreeApp:
         ttk.Button(btn_frame, text="Export CSV", command=export_csv).pack(side=tk.LEFT, padx=5, pady=5)
 
     def show_cut_sets(self):
+        """Display minimal cut sets for every top event."""
         if not self.top_events:
             return
-        te = self.top_events[0]
-        cut_sets = self.calculate_cut_sets(te)
         win = tk.Toplevel(self.root)
         win.title("FTA Cut Sets")
-        tree = ttk.Treeview(win, columns=["Cut Set"], show="headings")
-        tree.heading("Cut Set", text="Basic Events")
+        columns = ("Top Event", "Cut Set #", "Basic Events")
+        tree = ttk.Treeview(win, columns=columns, show="headings")
+        for c in columns:
+            tree.heading(c, text=c)
         tree.pack(fill=tk.BOTH, expand=True)
-        for cs in cut_sets:
-            names = ", ".join(str(uid) for uid in sorted(cs))
-            tree.insert("", "end", values=[names])
+
+        for te in self.top_events:
+            nodes_by_id = {}
+
+            def map_nodes(n):
+                nodes_by_id[n.unique_id] = n
+                for child in n.children:
+                    map_nodes(child)
+
+            map_nodes(te)
+            cut_sets = self.calculate_cut_sets(te)
+            te_label = te.user_name or f"Top Event {te.unique_id}"
+            for idx, cs in enumerate(cut_sets, start=1):
+                names = ", ".join(
+                    f"{nodes_by_id[uid].user_name or nodes_by_id[uid].node_type} [{uid}]"
+                    for uid in sorted(cs)
+                )
+                tree.insert("", "end", values=(te_label, idx, names))
+                te_label = ""
 
         def export_csv():
             path = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV", "*.csv")])
@@ -9662,9 +9713,9 @@ class FaultTreeApp:
                 return
             with open(path, "w", newline="") as f:
                 writer = csv.writer(f)
-                writer.writerow(["Cut Set"])
-                for cs in cut_sets:
-                    writer.writerow([", ".join(str(uid) for uid in sorted(cs))])
+                writer.writerow(["Top Event", "Cut Set #", "Basic Events"])
+                for iid in tree.get_children():
+                    writer.writerow(tree.item(iid, "values"))
             messagebox.showinfo("Export", "Cut sets exported")
 
         ttk.Button(win, text="Export CSV", command=export_csv).pack(pady=5)
@@ -9730,18 +9781,35 @@ class FaultTreeApp:
         ttk.Button(btn_frame, text="Export CSV", command=export_csv).pack(side=tk.LEFT, padx=5, pady=5)
 
     def show_cut_sets(self):
+        """Display minimal cut sets for every top event."""
         if not self.top_events:
             return
-        te = self.top_events[0]
-        cut_sets = self.calculate_cut_sets(te)
         win = tk.Toplevel(self.root)
         win.title("FTA Cut Sets")
-        tree = ttk.Treeview(win, columns=["Cut Set"], show="headings")
-        tree.heading("Cut Set", text="Basic Events")
+        columns = ("Top Event", "Cut Set #", "Basic Events")
+        tree = ttk.Treeview(win, columns=columns, show="headings")
+        for c in columns:
+            tree.heading(c, text=c)
         tree.pack(fill=tk.BOTH, expand=True)
-        for cs in cut_sets:
-            names = ", ".join(str(uid) for uid in sorted(cs))
-            tree.insert("", "end", values=[names])
+
+        for te in self.top_events:
+            nodes_by_id = {}
+
+            def map_nodes(n):
+                nodes_by_id[n.unique_id] = n
+                for child in n.children:
+                    map_nodes(child)
+
+            map_nodes(te)
+            cut_sets = self.calculate_cut_sets(te)
+            te_label = te.user_name or f"Top Event {te.unique_id}"
+            for idx, cs in enumerate(cut_sets, start=1):
+                names = ", ".join(
+                    f"{nodes_by_id[uid].user_name or nodes_by_id[uid].node_type} [{uid}]"
+                    for uid in sorted(cs)
+                )
+                tree.insert("", "end", values=(te_label, idx, names))
+                te_label = ""
 
         def export_csv():
             path = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV", "*.csv")])
@@ -9749,9 +9817,9 @@ class FaultTreeApp:
                 return
             with open(path, "w", newline="") as f:
                 writer = csv.writer(f)
-                writer.writerow(["Cut Set"])
-                for cs in cut_sets:
-                    writer.writerow([", ".join(str(uid) for uid in sorted(cs))])
+                writer.writerow(["Top Event", "Cut Set #", "Basic Events"])
+                for iid in tree.get_children():
+                    writer.writerow(tree.item(iid, "values"))
             messagebox.showinfo("Export", "Cut sets exported")
 
         ttk.Button(win, text="Export CSV", command=export_csv).pack(pady=5)


### PR DESCRIPTION
## Summary
- enhance `show_cut_sets` to show cut sets per top event
- list event IDs and names for easier reading
- export the updated table to CSV

## Testing
- `python -m py_compile FreeCTA.py`

------
https://chatgpt.com/codex/tasks/task_b_68802d78486083259b843037eb650336