### PR TITLE
Fix PMHF bottom-up calculation

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -1387,7 +1387,14 @@ class ADRiskAssessmentHelper:
             return combined
 
     def calculate_probability_recursive(self, node, visited=None):
-        """Recursively propagate failure probabilities using classical FTA rules."""
+        """Return the probability of failure for ``node``.
+
+        The method traverses the fault tree bottom-up, combining child
+        probabilities according to the node's ``gate_type``.  For an AND gate
+        the probabilities are multiplied, while an OR gate uses the
+        ``1 - \u220f(1 - p)`` rule.  Basic events simply return their assigned
+        probability.
+        """
         if visited is None:
             visited = set()
 
@@ -8290,9 +8297,13 @@ class FaultTreeApp:
                 lpf += fit * (1 - dc)
         self.spfm = spf
         self.lpfm = lpf
-        pmhf = (spf + lpf) * 1e-9
+
+        pmhf = 0.0
         for te in self.top_events:
-            te.probability = pmhf
+            prob = AD_RiskAssessment_Helper.calculate_probability_recursive(te)
+            te.probability = prob
+            pmhf += prob
+
         self.update_views()
         msg = f"PMHF = {pmhf:.2e}\nSPFM = {spf:.2f}\nLPFM = {lpf:.2f}"
         messagebox.showinfo("PMHF Calculation", msg)


### PR DESCRIPTION
## Summary
- update PMHF computation to propagate failure probabilities from basic events
- keep SPFM/LPFM summation but derive PMHF from tree structure
- clarify docstring describing OR/AND gate handling
- call helper method when propagating probabilities

## Testing
- `python -m py_compile FreeCTA.py review_toolbox.py mechanisms.py`


------
https://chatgpt.com/codex/tasks/task_b_68802d1a23948325bb7934bd5172f6dd