### PR TITLE
Fix probability formula propagation

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -7733,8 +7733,6 @@ class FaultTreeApp:
         mode is converted to a failure rate in events per hour, then the
         probability is derived for the mission profile time ``tau``.
         """
-        if not self.mission_profiles:
-            return
         for be in self.get_all_basic_events():
             be.failure_prob = self.compute_failure_prob(be)
 
@@ -7755,7 +7753,7 @@ class FaultTreeApp:
         if formula == "exponential":
             return 1 - math.exp(-lam * t)
         elif formula == "constant":
-            return lam
+            return fit
         else:
             return lam * t
 
@@ -7765,8 +7763,8 @@ class FaultTreeApp:
             if getattr(be, "failure_mode_ref", None) == fm_node.unique_id:
                 be.fmeda_fit = fm_node.fmeda_fit
                 be.fmeda_diag_cov = fm_node.fmeda_diag_cov
-                if not getattr(be, "prob_formula", None):
-                    be.prob_formula = fm_node.prob_formula
+                # Always propagate the formula so edits take effect
+                be.prob_formula = fm_node.prob_formula
                 be.failure_prob = self.compute_failure_prob(be)
 
     def insert_node_in_tree(self, parent_item, node):


### PR DESCRIPTION
## Summary
- ensure failure mode formula changes propagate to all referencing basic events
- constant probability formula now returns the FIT value directly
- always recompute basic event probabilities

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68803766c96c8325b597ab3046b4749d