### PR TITLE
Bug fixes for FMEDA and review UI

### DIFF
--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -582,7 +582,8 @@ class ReviewToolbox(tk.Toplevel):
         if not self.app.review_data:
             messagebox.showwarning("Document", "No review selected")
             return
-        ReviewDocumentDialog(self, self.app, self.app.review_data)
+        dlg = ReviewDocumentDialog(self, self.app, self.app.review_data)
+        dlg.lift()
 
     def open_comment(self, event):
         selection = self.comment_list.curselection()


### PR DESCRIPTION
## Summary
- keep selected BOM with each FMEDA and restore it when reloading a model
- allow editing the BOM name in FMEDA tables and save it on close
- make the Mechanism Library dialog resizable
- ensure Review Document opens correctly from the toolbox

## Testing
- `python -m py_compile FreeCTA.py review_toolbox.py mechanisms.py`

------
https://chatgpt.com/codex/tasks/task_b_68804648b41c832594cbd7385469d694