### PR TITLE
Add extra columns to HAZOP view

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,12 @@ JSON model so results remain consistent when reloading the file.
 ### HAZOP Analysis
 
 The **HAZOP Analysis** window lets you list system functions with one or more
-associated malfunctions. Each malfunction is categorized as *No/Not*,
-*Excessive*, *Insufficient*, *Unintended* or *Reverse* and can be marked as
-safety relevant along with a rationale. When a function is allocated to an
-active component in a reliability analysis, its malfunctions become selectable
-failure modes in the FMEDA table.
+associated malfunctions. Each entry records the malfunction guideword
+(*No/Not*, *Unintended*, *Excessive*, *Insufficient* or *Reverse*), the related
+scenario, driving conditions and hazard, and whether it is safety relevant.
+Covered malfunctions may reference other entries as mitigation. When a function
+is allocated to an active component in a reliability analysis, its malfunctions
+become selectable failure modes in the FMEDA table.
 
 ## License
 


### PR DESCRIPTION
## Summary
- extend `HazopEntry` to store scenario, conditions, hazard and coverage info
- show these new fields in the HAZOP table
- update HAZOP row dialog with combo boxes and text fields
- adjust model loading for backward compatibility
- document the expanded HAZOP analysis UI

## Testing
- `python3 -m py_compile AutoSafeguard.py mechanisms.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_6880635122b4832589cc230a2dcb6fd3