### PR TITLE
Fix missing populate method in architecture manager

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -1117,6 +1117,10 @@ class ArchitectureManagerDialog(tk.Toplevel):
         self.bind("<FocusIn>", lambda _e: self.populate())
         self.drag_item = None
         self.cut_item = None
+
+    def populate(self):
+        """Populate the tree view with packages, diagrams and elements."""
+        self.tree.delete(*self.tree.get_children())
         from collections import defaultdict
 
         rel_children = defaultdict(list)


### PR DESCRIPTION
## Summary
- implement `populate` as a method of `ArchitectureManagerDialog`
- call this method during initialization

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688302230a6c8325992e1e766a9cf07c