### PR TITLE
Implement system boundary grouping

### DIFF
--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,4 +1,7 @@
 import unittest
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from sysml_repository import SysMLRepository
 
 class ActionNameTests(unittest.TestCase):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,5 +1,7 @@
 import unittest
 import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from sysml_repository import SysMLRepository
 
 class RepositoryTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- keep system boundary objects at the back by sorting objects
- allow dragging objects attached to boundaries to move the boundary and its contents
- moving a boundary also drags all attached items
- make tests runnable by adding repository path to sys.path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68831fc67b94832588465720757aa428