### PR TITLE
Remove fit qualification fields from Part properties

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -1391,7 +1391,7 @@ class SysMLObjectDialog(simpledialog.Dialog):
             else:
                 prop_row += 1
 
-        # Always display FIT and qualification values if present
+        # Always display inherited FIT and qualification values if present
         for prop in ("fit", "qualification"):
             if prop not in self.entries and self.obj.properties.get(prop, ""):
                 ttk.Label(rel_frame, text=f"{prop}:").grid(row=rel_row, column=0, sticky="e", padx=4, pady=2)

--- a/sysml_spec.py
+++ b/sysml_spec.py
@@ -58,6 +58,6 @@ for prop in ('circuit', 'fit', 'qualification', 'failureModes'):
     if prop not in SYSML_PROPERTIES['BlockUsage']:
         SYSML_PROPERTIES['BlockUsage'].append(prop)
 
-for prop in ('component', 'fit', 'qualification', 'failureModes'):
+for prop in ('component', 'failureModes'):
     if prop not in SYSML_PROPERTIES['PartUsage']:
         SYSML_PROPERTIES['PartUsage'].append(prop)


### PR DESCRIPTION
## Summary
- keep reliability FIT and qualification fields for blocks only
- remove FIT and qualification from `PartUsage` properties
- show inherited FIT/qualification values for parts (read-only)

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688335d8b8048325900ea03255837592