### PR TITLE
Fix FMEDA metrics when no BOM

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -8937,11 +8937,14 @@ class FaultTreeApp:
                 comp_name = (
                     src.parents[0].user_name if src.parents else getattr(src, "fmea_component", "")
                 )
-                fit = comp_fit.get(comp_name, 0.0)
+                fit = comp_fit.get(comp_name)
                 frac = src.fmeda_fault_fraction
                 if frac > 1.0:
                     frac /= 100.0
-                be.fmeda_fit = fit * frac
+                if fit is not None:
+                    be.fmeda_fit = fit * frac
+                else:
+                    be.fmeda_fit = getattr(src, "fmeda_fit", 0.0)
                 if src.fmeda_fault_type == "permanent":
                     be.fmeda_spfm = be.fmeda_fit * (1 - src.fmeda_diag_cov)
                     be.fmeda_lpfm = 0.0

--- a/toolboxes.py
+++ b/toolboxes.py
@@ -354,11 +354,14 @@ class ReliabilityWindow(tk.Toplevel):
             comp_name = (
                 be.parents[0].user_name if be.parents else getattr(be, "fmea_component", "")
             )
-            fit = comp_fit.get(comp_name, 0.0)
+            fit = comp_fit.get(comp_name)
             frac = be.fmeda_fault_fraction
             if frac > 1.0:
                 frac /= 100.0
-            fit_mode = fit * frac
+            if fit is not None:
+                fit_mode = fit * frac
+            else:
+                fit_mode = getattr(be, "fmeda_fit", 0.0) * frac
             total_modes += fit_mode
             if be.fmeda_fault_type == "permanent":
                 spf += fit_mode * (1 - be.fmeda_diag_cov)


### PR DESCRIPTION
## Summary
- avoid zeroing FMEDA FIT values when no BOM is loaded
- preserve manual FIT in reliability calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68834e4ec3f88325ab9bcb4deeb80cca