### PR TITLE
Add auto-calculated ASIL for IBD parts

### DIFF
--- a/sysml_spec.py
+++ b/sysml_spec.py
@@ -58,6 +58,6 @@ for prop in ('circuit', 'fit', 'qualification', 'failureModes'):
     if prop not in SYSML_PROPERTIES['BlockUsage']:
         SYSML_PROPERTIES['BlockUsage'].append(prop)
 
-for prop in ('component', 'failureModes'):
+for prop in ('component', 'failureModes', 'asil'):
     if prop not in SYSML_PROPERTIES['PartUsage']:
         SYSML_PROPERTIES['PartUsage'].append(prop)

--- a/tests/test_part_asil.py
+++ b/tests/test_part_asil.py
@@ -1,0 +1,21 @@
+import unittest
+from architecture import calculate_allocated_asil
+from models import global_requirements
+
+class PartASILTests(unittest.TestCase):
+    def setUp(self):
+        global_requirements.clear()
+
+    def test_highest_asil(self):
+        global_requirements["R1"] = {"id": "R1", "asil": "B"}
+        global_requirements["R2"] = {"id": "R2", "asil": "D"}
+        reqs = [global_requirements["R1"], global_requirements["R2"]]
+        self.assertEqual(calculate_allocated_asil(reqs), "D")
+
+    def test_missing_asil_defaults_qm(self):
+        global_requirements["R3"] = {"id": "R3"}
+        reqs = [global_requirements["R3"]]
+        self.assertEqual(calculate_allocated_asil(reqs), "QM")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support ASIL on PartUsage elements
- compute ASIL based on allocated requirements
- display ASIL in internal block diagram parts
- test highest ASIL calculation for part requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68835849ea088325ae7dc5990397f98d