### PR TITLE
Fix missing method in FaultTreeApp

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12446,6 +12446,20 @@ class FaultTreeApp:
                 continue  # keep decomposition ASIL
             self.update_requirement_asil(rid)
 
+    def update_base_event_requirement_asil(self):
+        """Update ASIL for requirements allocated to base events."""
+        for node in self.get_all_nodes(self.root_node):
+            if getattr(node, "node_type", "").upper() != "BASIC EVENT":
+                continue
+            for req in getattr(node, "safety_requirements", []):
+                rid = req.get("id")
+                if not rid:
+                    continue
+                asil = self.compute_requirement_asil(rid)
+                req["asil"] = asil
+                if rid in global_requirements:
+                    global_requirements[rid]["asil"] = asil
+
     def ensure_asil_consistency(self):
         """Sync safety goal ASILs from HARAs and update requirement ASILs."""
         self.sync_hara_to_safety_goals()


### PR DESCRIPTION
## Summary
- add `update_base_event_requirement_asil` implementation to `FaultTreeApp`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6883fabb66b8832598e99588da438d3a