### PR TITLE
Fix malfunction selection and duplicates

### DIFF
--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -1,0 +1,18 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+"""Utility helpers for analysis package."""
+
+from typing import List
+
+
+def append_unique_insensitive(items: List[str], name: str) -> None:
+    """Append ``name`` to ``items`` if not already present (case-insensitive)."""
+    if not name:
+        return
+    name = name.strip()
+    if not name:
+        return
+    lower = name.lower()
+    for existing in items:
+        if existing.lower() == lower:
+            return
+    items.append(name)

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -881,7 +881,11 @@ class HazopWindow(tk.Frame):
 
             ttk.Label(master, text="Malfunction").grid(row=1, column=0, sticky="e", padx=5, pady=5)
             self.mal = tk.StringVar(value=self.row.malfunction)
-            ttk.Entry(master, textvariable=self.mal).grid(row=1, column=1, padx=5, pady=5)
+            ttk.Combobox(
+                master,
+                textvariable=self.mal,
+                values=sorted(self.app.malfunctions),
+            ).grid(row=1, column=1, padx=5, pady=5)
 
             ttk.Label(master, text="Type").grid(row=2, column=0, sticky="e", padx=5, pady=5)
             self.typ = tk.StringVar(value=self.row.mtype)
@@ -929,6 +933,7 @@ class HazopWindow(tk.Frame):
         def apply(self):
             self.row.function = self.func.get()
             self.row.malfunction = self.mal.get()
+            self.app.add_malfunction(self.row.malfunction)
             self.row.mtype = self.typ.get()
             self.row.scenario = self.scen.get()
             self.row.conditions = self.cond.get()

--- a/tests/test_malfunctions.py
+++ b/tests/test_malfunctions.py
@@ -1,0 +1,16 @@
+import unittest
+from analysis.utils import append_unique_insensitive
+
+class MalfunctionUtilsTests(unittest.TestCase):
+    def test_append_unique_insensitive(self):
+        items = ['Brake Failure', 'Sensor Fault']
+        append_unique_insensitive(items, 'brake failure')
+        self.assertEqual(len(items), 2)
+        append_unique_insensitive(items, '  SENSOR FAULT  ')
+        self.assertEqual(len(items), 2)
+        append_unique_insensitive(items, 'Power Loss')
+        self.assertEqual(items[-1], 'Power Loss')
+        self.assertEqual(len(items), 3)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add helper to append unique malfunctions
- load malfunctions uniquely and use helper across GUI dialogs
- allow selecting existing malfunctions in HAZOP rows
- test helper logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886c9008dfc832596043eaff082601b