### PR TITLE
Fix FMEA row dialog init error

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9139,7 +9139,6 @@ class FaultTreeApp:
                                 self.cause_list.select_set(i)
             
             self.mode_combo.bind("<<ComboboxSelected>>", mode_sel)
-            mode_sel(None)
 
             self.effect_text = tk.Text(gen_frame, width=30, height=3)
             self.effect_text.insert("1.0", self.node.fmea_effect)
@@ -9328,6 +9327,7 @@ class FaultTreeApp:
 
             self.comp_combo.bind("<<ComboboxSelected>>", comp_sel)
             comp_sel()
+            mode_sel(None)
 
             row += 1
             ttk.Label(metric_frame, text="DC Target:").grid(row=row, column=0, sticky="e", padx=5, pady=5)


### PR DESCRIPTION
## Summary
- fix initialization order in `FMEARowDialog`
- ensure component selector is defined before invoking `mode_sel`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886cb18bfe4832599ba4c296051e171