### PR TITLE
Add requirements explorer with filtering support

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -343,6 +343,7 @@ from gui.toolboxes import (
     HaraWindow,
     TC2FIWindow,
     HazardExplorerWindow,
+    RequirementsExplorerWindow,
 )
 
 
@@ -1944,6 +1945,7 @@ class FaultTreeApp:
         requirements_menu = tk.Menu(menubar, tearoff=0)
         requirements_menu.add_command(label="Requirements Matrix", command=self.show_requirements_matrix)
         requirements_menu.add_command(label="Requirements Editor", command=self.show_requirements_editor)
+        requirements_menu.add_command(label="Requirements Explorer", command=self.show_requirements_explorer)
         requirements_menu.add_command(label="Safety Goals Matrix", command=self.show_safety_goals_matrix)
         requirements_menu.add_command(label="Safety Goals Editor", command=self.show_safety_goals_editor)
         requirements_menu.add_command(label="Export SG Requirements", command=self.export_safety_goal_requirements)
@@ -2090,6 +2092,7 @@ class FaultTreeApp:
             "TC2FI Analysis": self.open_tc2fi_window,
             "AutoML Explorer": self.manage_architecture,
             "Requirements Editor": self.show_requirements_editor,
+            "Requirements Explorer": self.show_requirements_explorer,
             "Safety Goals Editor": self.show_safety_goals_editor,
             "Start Peer Review": self.start_peer_review,
             "Start Joint Review": self.start_joint_review,
@@ -2115,6 +2118,7 @@ class FaultTreeApp:
             "Design": [
                 "AutoML Explorer",
                 "Requirements Editor",
+                "Requirements Explorer",
             ],
             "Safety Analysis": [
                 "FMEA Manager",
@@ -12461,6 +12465,12 @@ class FaultTreeApp:
             self._haz_exp_window.lift()
             return
         self._haz_exp_window = HazardExplorerWindow(self)
+
+    def show_requirements_explorer(self):
+        if hasattr(self, "_req_exp_window") and self._req_exp_window.winfo_exists():
+            self._req_exp_window.lift()
+            return
+        self._req_exp_window = RequirementsExplorerWindow(self)
 
     def _register_close(self, win, collection):
         def _close():

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The **HARA Analysis** view builds on the safety relevant malfunctions from one o
 
 The calculated ASIL from each row is propagated to the referenced safety goal so that inherited ASIL levels appear consistently in all analyses and documentation, including FTA top level events.
 
-The **Hazard Explorer** window lists all hazards from every HARA in a read-only table for quick review or CSV export.
+The **Hazard Explorer** window lists all hazards from every HARA in a read-only table for quick review or CSV export. A **Requirements Explorer** window lets you query global requirements with filters for text, type, ASIL and status.
 
 ## Requirements Creation and Management
 


### PR DESCRIPTION
## Summary
- implement a new `RequirementsExplorerWindow` to browse global requirements
- open the new explorer from the Requirements menu and tools pane
- document the feature in the README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688701b5b4fc83259f1ff3774e766e7c