### PR TITLE
Improve FI2TC/TC2FI editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,16 +679,26 @@ Two additional tables support tracing between these elements:
 
 * **FI2TC Analysis** – links each functional insufficiency to the triggering
   conditions, scenarios and mitigation measures that reveal the hazard. The
-  table includes dedicated **triggering_conditions** and
-  **functional_insufficiencies** columns populated via comboboxes so new items
-  can be added on the fly.
-  The **design_measures** column now offers a multi-select list of all existing
-  requirements labelled as *functional modification* for quick selection.
-  Hold **Ctrl** while clicking to choose multiple items.
+  table now supports editing directly in the list by double clicking any cell.
+  Dedicated **triggering_conditions** and **functional_insufficiencies**
+  columns remain populated via comboboxes so new items can be added on the fly.
+  The **design_measures** column still offers a multi-select list of all
+  requirements labelled as *functional modification*. Hold **Ctrl** while
+  clicking to choose multiple items.
 * **TC2FI Analysis** – starts from the triggering condition and lists the
-  impacted functions, architecture elements and related insufficiencies. The
-  **triggering_conditions** and **functional_insufficiencies** fields mirror
-  those in the FI2TC table to keep the relationships consistent.
+  impacted functions, architecture elements and related insufficiencies. This
+  table also allows in-place editing. The **triggering_conditions** and
+  **functional_insufficiencies** fields mirror those in the FI2TC table to keep
+  the relationships consistent.
+
+The analyses approach the problem from opposite directions:
+
+| Aspect | FI2TC | TC2FI |
+| --- | --- | --- |
+| Start Point | Known functional weakness | Known environmental/operational condition |
+| Goal | Identify triggering conditions | Identify affected functions |
+| Focus | Understanding cause of known issues | Discovering issues from known situations |
+| Role in SOTIF | Verifying known risks are well covered | Expanding coverage for unknown risks |
 
 HARA values such as severity and the associated safety goal flow into these tables so SOTIF considerations remain connected to the overall risk assessment. Minimal cut sets calculated from the FTAs highlight combinations of FIs and TCs that form *CTAs*. From a CTA entry you can generate a functional modification requirement describing how the design must change to avoid the unsafe behaviour.
 

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -600,22 +600,22 @@ class ReliabilityWindow(tk.Frame):
 class FI2TCWindow(tk.Frame):
     COLS = [
         "id",
+        "functional_insufficiencies",
         "system_function",
         "allocation",
         "interfaces",
-        "functional_insufficiencies",
         "scene",
         "scenario",
         "driver_behavior",
         "occurrence",
+        "triggering_conditions",
         "vehicle_effect",
         "severity",
+        "worst_case",
+        "tc_effect",
         "design_measures",
         "verification",
         "measure_effectiveness",
-        "triggering_conditions",
-        "worst_case",
-        "tc_effect",
         "mitigation",
         "acceptance",
     ]
@@ -659,7 +659,7 @@ class FI2TCWindow(tk.Frame):
         hsb.grid(row=1, column=0, sticky="ew")
         tree_frame.grid_columnconfigure(0, weight=1)
         tree_frame.grid_rowconfigure(0, weight=1)
-        self.tree.bind("<Double-1>", lambda e: self.edit_row())
+        self.tree.bind("<Double-1>", self.start_cell_edit)
         btn = ttk.Frame(self)
         btn.pack(fill=tk.X)
         add_row_btn = ttk.Button(btn, text="Add", command=self.add_row)
@@ -684,6 +684,39 @@ class FI2TCWindow(tk.Frame):
         for row in self.app.fi2tc_entries:
             vals = [_wrap_val(row.get(k, "")) for k in self.COLS]
             self.tree.insert("", "end", values=vals)
+
+    def start_cell_edit(self, event=None, item=None, column=None):
+        if event:
+            item = item or self.tree.identify_row(event.y)
+            column = column or self.tree.identify_column(event.x)
+        if not item or not column:
+            return
+        col_idx = int(column[1:]) - 1
+        col_key = self.COLS[col_idx]
+        x, y, w, h = self.tree.bbox(item, column)
+        if not w:
+            return
+        value = self.tree.set(item, col_key)
+        entry = tk.Entry(self.tree)
+        entry.insert(0, value)
+        entry.select_range(0, tk.END)
+        entry.focus()
+        entry.place(x=x, y=y, width=w, height=h)
+
+        def save(event=None):
+            new_val = entry.get()
+            self.tree.set(item, col_key, _wrap_val(new_val))
+            idx = self.tree.index(item)
+            old_val = self.app.fi2tc_entries[idx].get(col_key, "")
+            self.app.fi2tc_entries[idx][col_key] = new_val
+            if col_key == "functional_insufficiencies" and old_val and new_val != old_val:
+                self.app.rename_functional_insufficiency(old_val, new_val)
+            elif col_key == "triggering_conditions" and old_val and new_val != old_val:
+                self.app.rename_triggering_condition(old_val, new_val)
+            entry.destroy()
+
+        entry.bind("<Return>", save)
+        entry.bind("<FocusOut>", save)
 
     class RowDialog(simpledialog.Dialog):
         def __init__(self, parent, app, data=None):
@@ -865,20 +898,15 @@ class FI2TCWindow(tk.Frame):
             self.result = True
 
     def add_row(self):
-        dlg = self.RowDialog(self, self.app)
-        if getattr(dlg, "result", None):
-            self.app.fi2tc_entries.append(dlg.data)
-            self.refresh()
+        data = {k: "" for k in self.COLS}
+        self.app.fi2tc_entries.append(data)
+        self.refresh()
 
     def edit_row(self):
         sel = self.tree.focus()
         if not sel:
             return
-        idx = self.tree.index(sel)
-        data = self.app.fi2tc_entries[idx]
-        dlg = self.RowDialog(self, self.app, data)
-        if getattr(dlg, "result", None):
-            self.refresh()
+        self.start_cell_edit(item=sel, column="#1")
 
     def del_row(self):
         sel = self.tree.selection()
@@ -1671,22 +1699,22 @@ class HaraWindow(tk.Frame):
 class TC2FIWindow(tk.Frame):
     COLS = [
         "id",
-        "known_use_case",
+        "triggering_conditions",
+        "scene",
+        "scenario",
+        "driver_behavior",
         "occurrence",
+        "known_use_case",
         "impacted_function",
         "arch_elements",
         "interfaces",
         "functional_insufficiencies",
         "vehicle_effect",
         "severity",
+        "tc_effect",
         "design_measures",
         "verification",
         "measure_effectiveness",
-        "scene",
-        "scenario",
-        "driver_behavior",
-        "triggering_conditions",
-        "tc_effect",
         "mitigation",
         "acceptance",
     ]
@@ -1731,7 +1759,7 @@ class TC2FIWindow(tk.Frame):
         hsb.grid(row=1, column=0, sticky="ew")
         tree_frame.grid_columnconfigure(0, weight=1)
         tree_frame.grid_rowconfigure(0, weight=1)
-        self.tree.bind("<Double-1>", lambda e: self.edit_row())
+        self.tree.bind("<Double-1>", self.start_cell_edit)
         btn = ttk.Frame(self)
         btn.pack()
         ttk.Button(btn, text="Add", command=self.add_row).pack(
@@ -1756,6 +1784,39 @@ class TC2FIWindow(tk.Frame):
         for row in self.app.tc2fi_entries:
             vals = [_wrap_val(row.get(k, "")) for k in self.COLS]
             self.tree.insert("", "end", values=vals)
+
+    def start_cell_edit(self, event=None, item=None, column=None):
+        if event:
+            item = item or self.tree.identify_row(event.y)
+            column = column or self.tree.identify_column(event.x)
+        if not item or not column:
+            return
+        col_idx = int(column[1:]) - 1
+        col_key = self.COLS[col_idx]
+        x, y, w, h = self.tree.bbox(item, column)
+        if not w:
+            return
+        value = self.tree.set(item, col_key)
+        entry = tk.Entry(self.tree)
+        entry.insert(0, value)
+        entry.select_range(0, tk.END)
+        entry.focus()
+        entry.place(x=x, y=y, width=w, height=h)
+
+        def save(event=None):
+            new_val = entry.get()
+            self.tree.set(item, col_key, _wrap_val(new_val))
+            idx = self.tree.index(item)
+            old_val = self.app.tc2fi_entries[idx].get(col_key, "")
+            self.app.tc2fi_entries[idx][col_key] = new_val
+            if col_key == "functional_insufficiencies" and old_val and new_val != old_val:
+                self.app.rename_functional_insufficiency(old_val, new_val)
+            elif col_key == "triggering_conditions" and old_val and new_val != old_val:
+                self.app.rename_triggering_condition(old_val, new_val)
+            entry.destroy()
+
+        entry.bind("<Return>", save)
+        entry.bind("<FocusOut>", save)
 
     class RowDialog(simpledialog.Dialog):
         def __init__(self, parent, app, data=None):
@@ -1943,20 +2004,15 @@ class TC2FIWindow(tk.Frame):
             self.result = True
 
     def add_row(self):
-        dlg = self.RowDialog(self, self.app)
-        if getattr(dlg, "result", None):
-            self.app.tc2fi_entries.append(dlg.data)
-            self.refresh()
+        data = {k: "" for k in self.COLS}
+        self.app.tc2fi_entries.append(data)
+        self.refresh()
 
     def edit_row(self):
         sel = self.tree.focus()
         if not sel:
             return
-        idx = self.tree.index(sel)
-        data = self.app.tc2fi_entries[idx]
-        dlg = self.RowDialog(self, self.app, data)
-        if getattr(dlg, "result", None):
-            self.refresh()
+        self.start_cell_edit(item=sel, column="#1")
 
     def del_row(self):
         sel = self.tree.selection()


### PR DESCRIPTION
## Summary
- enable inline cell editing for FI2TC and TC2FI tables
- reorder FI2TC/TC2FI columns to reflect analysis workflow
- document differences between FI2TC and TC2FI analyses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68870954640483258dfd5c637236f6aa