### PR TITLE
Update SOTIF docs with FI2TC/TC2FI flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ flowchart TD
     end
     X --> R([Reliability analysis<br/>inputs: BOM<br/>outputs: FIT rates & parts])
     A([System functions & architecture]) --> B([HAZOP<br/>inputs: functions<br/>outputs: malfunctions])
-    B --> C([HARA<br/>inputs: malfunctions<br/>outputs: hazards, ASIL, safety goals])
+    A --> S([FI2TC / TC2FI<br/>inputs: functions<br/>outputs: hazards, FIs & TCs, severity])
+    B --> C([HARA<br/>inputs: malfunctions & SOTIF severity<br/>outputs: hazards, ASIL, safety goals])
+    S --> C
     A --> D([FMEA / FMEDA<br/>inputs: architecture, malfunctions, reliability<br/>outputs: failure modes])
     R --> D
     C --> D
@@ -26,7 +28,7 @@ flowchart TD
     G --> H([ASIL propagation to SGs, FMEAs and FTAs])
 ```
 
-The workflow begins by entering system functions and architecture elements. A **BOM** is imported into a **Reliability analysis** which produces FIT rates and component lists used by the **FMEA/FMEDA** tables. A **HAZOP** analysis identifies malfunctions which become inputs to the **HARA** and FMEAs. The HARA assigns hazards and ASIL ratings to safety goals which then inform FMEDAs and **FTA** diagrams. Fault trees and failure modes generate safety requirements that go through peer or joint **reviews**. When a review is approved any changes to requirements or analyses automatically update the ASIL values traced back to the safety goals, FMEAs and FTAs.
+The workflow begins by entering system functions and architecture elements. A **BOM** is imported into a **Reliability analysis** which produces FIT rates and component lists used by the **FMEA/FMEDA** tables. A **HAZOP** analysis identifies malfunctions while the **FI2TC/TC2FI** tables capture SOTIF hazards, functional insufficiencies and triggering conditions along with their severities. The **HARA** inherits these severities and assigns hazards and ASIL ratings to safety goals which then inform FMEDAs and **FTA** diagrams. Fault trees and failure modes generate safety requirements that go through peer or joint **reviews**. When a review is approved any changes to requirements or analyses automatically update the ASIL values traced back to the safety goals, FMEAs and FTAs.
 
 ## HAZOP Analysis
 
@@ -38,7 +40,8 @@ The **HARA Analysis** view builds on the safety relevant malfunctions from one o
 
 1. **Malfunction** – combo box listing malfunctions flagged as safety relevant in the chosen HAZOP documents.
 2. **Hazard** – textual description of the resulting hazard.
-3. **Severity** – ISO&nbsp;26262 severity level (1–3).
+3. **Severity** – ISO&nbsp;26262 severity level (1–3). Values from FI2TC and
+   TC2FI analyses are inherited here so the HARA reflects SOTIF hazards.
 4. **Severity Rationale** – free text explanation for the chosen severity.
 5. **Controllability** – ISO&nbsp;26262 controllability level (1–3).
 6. **Controllability Rationale** – free text explanation for the chosen controllability.
@@ -295,8 +298,13 @@ classDiagram
     FI2TCEntry --> FunctionalInsufficiency
     FI2TCEntry --> TriggeringCondition
     FI2TCEntry --> Scenario
+    FI2TCEntry --> Hazard : hazard
+    FI2TCEntry --> HaraEntry : severity
     TC2FIEntry --> TriggeringCondition
     TC2FIEntry --> FunctionalInsufficiency
+    TC2FIEntry --> Hazard : hazard
+    TC2FIEntry --> HaraEntry : severity
+    SysMLRepository --> "*" Hazard
     SysMLRepository --> "*" FunctionalModification
     FunctionalModification --> "*" AcceptanceCriteria
     SysMLRepository --> "*" AcceptanceCriteria
@@ -306,6 +314,8 @@ classDiagram
     SysMLRepository --> "*" Failure
     class FI2TCEntry
     class TC2FIEntry
+    class Hazard
+    class HaraEntry
     class TriggeringCondition
     class FunctionalInsufficiency
     class FunctionalModification
@@ -677,20 +687,23 @@ The **Qualitative Analysis** menu also provides dedicated SOTIF tools. Selecting
 
 Two additional tables support tracing between these elements:
 
-* **FI2TC Analysis** – links each functional insufficiency to the triggering
-  conditions, scenarios and mitigation measures that reveal the hazard. The
+* **FI2TC Analysis** – analogue of HAZOP for SOTIF. Each row links a functional
+  insufficiency to the triggering conditions, scenarios and mitigation measures
+  that reveal the hazard. The hazard and its **severity** are recorded here. The
   table includes dedicated **triggering_conditions** and
   **functional_insufficiencies** columns populated via comboboxes so new items
-  can be added on the fly.
-  The **design_measures** column now offers a multi-select list of all existing
-  requirements labelled as *functional modification* for quick selection.
-  Hold **Ctrl** while clicking to choose multiple items.
-* **TC2FI Analysis** – starts from the triggering condition and lists the
-  impacted functions, architecture elements and related insufficiencies. The
-  **triggering_conditions** and **functional_insufficiencies** fields mirror
-  those in the FI2TC table to keep the relationships consistent.
+  can be added on the fly. The **design_measures** column now offers a
+  multi-select list of all existing requirements labelled as *functional
+  modification* for quick selection. Hold **Ctrl** while clicking to choose
+  multiple items.
+* **TC2FI Analysis** – also mirrors HAZOP concepts for SOTIF. It starts from the
+  triggering condition and lists the impacted functions, architecture elements
+  and related insufficiencies. The identified hazard and its **severity** are
+  noted in each entry. The **triggering_conditions** and
+  **functional_insufficiencies** fields mirror those in the FI2TC table to keep
+  the relationships consistent.
 
-HARA values such as severity and the associated safety goal flow into these tables so SOTIF considerations remain connected to the overall risk assessment. Minimal cut sets calculated from the FTAs highlight combinations of FIs and TCs that form *CTAs*. From a CTA entry you can generate a functional modification requirement describing how the design must change to avoid the unsafe behaviour.
+Severity recorded in FI2TC and TC2FI entries is inherited by the HARA so the risk graph reflects the SOTIF findings. Other HARA values such as the associated safety goal flow into these tables so SOTIF considerations remain connected to the overall risk assessment. Minimal cut sets calculated from the FTAs highlight combinations of FIs and TCs that form *CTAs*. From a CTA entry you can generate a functional modification requirement describing how the design must change to avoid the unsafe behaviour.
 
 All FI2TC and TC2FI documents appear under the **Analyses** tab so they can be opened alongside HARA tables, FTAs and CTAs for a complete view of functional safety and SOTIF issues.
 
@@ -706,6 +719,8 @@ classDiagram
     class FunctionalInsufficiency
     class FI2TCDoc
     class TC2FIDoc
+    class Hazard
+    class HaraEntry
     class FunctionalModification
     class AcceptanceCriteria
     class FaultTreeDiagram
@@ -718,6 +733,10 @@ classDiagram
     FunctionalInsufficiency --> TC2FIDoc : entry
     FunctionalInsufficiency --> FunctionalModification : mitigatedBy
     FunctionalModification --> AcceptanceCriteria : validatedBy
+    FI2TCDoc --> Hazard : hazard
+    TC2FIDoc --> Hazard : hazard
+    FI2TCDoc --> HaraEntry : severity
+    TC2FIDoc --> HaraEntry : severity
     SafetyGoal --> FaultTreeDiagram : topEvent
     FaultTreeDiagram --> "*" FaultTreeNode : nodes
     TriggeringCondition --> FaultTreeNode : cta


### PR DESCRIPTION
## Summary
- extend workflow diagram with FI2TC/TC2FI analyses
- clarify SOTIF tables as hazop analogues
- inherit severity from FI2TC/TC2FI into HARA
- extend metamodel diagrams for hazard and severity links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68870e0119d08325950d68361f4ab230