### PR TITLE
Handle composite parts without IBD

### DIFF
--- a/tests/test_composite_aggregation.py
+++ b/tests/test_composite_aggregation.py
@@ -60,6 +60,30 @@ class CompositeAggregationTests(unittest.TestCase):
         # ensure added list includes the new part
         self.assertTrue(any(d.get("properties", {}).get("definition") == part.elem_id for d in added))
 
+    def test_composite_part_created_without_ibd(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Composite Aggregation", whole.elem_id, part.elem_id)
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id)
+        rel = next(r for r in repo.relationships if r.source == whole.elem_id and r.target == part.elem_id)
+        pid = rel.properties.get("part_elem")
+        self.assertIsNotNone(pid)
+        self.assertEqual(repo.elements[pid].properties.get("force_ibd"), "true")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        set_ibd_father(repo, ibd, whole.elem_id)
+        self.assertTrue(
+            any(
+                o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+                for o in ibd.objects
+            )
+        )
+        obj = next(
+            o for o in ibd.objects if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        )
+        self.assertTrue(obj.get("locked"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `locked` flag to `SysMLObject`
- prevent deletion of locked objects
- store composite aggregation parts even when no IBD exists
- insert stored parts when the IBD is created
- test composite aggregation without an IBD

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888bfbd9be8832595a3104efa6959c7