### PR TITLE
Ensure composite parts persist in IBD

### DIFF
--- a/tests/test_composite_aggregation.py
+++ b/tests/test_composite_aggregation.py
@@ -3,6 +3,8 @@ from gui.architecture import (
     add_composite_aggregation_part,
     remove_aggregation_part,
     set_ibd_father,
+    SysMLObject,
+    SysMLDiagramWindow,
 )
 from sysml.sysml_repository import SysMLRepository
 
@@ -26,6 +28,9 @@ class CompositeAggregationTests(unittest.TestCase):
                 for o in ibd.objects
             )
         )
+        # ensure composite flag is set
+        obj = next(o for o in ibd.objects if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id)
+        self.assertEqual(obj.get("properties", {}).get("composite"), "true")
 
     def test_remove_composite_part_from_ibd(self):
         repo = self.repo
@@ -59,6 +64,47 @@ class CompositeAggregationTests(unittest.TestCase):
         )
         # ensure added list includes the new part
         self.assertTrue(any(d.get("properties", {}).get("definition") == part.elem_id for d in added))
+
+    def test_composite_part_created_without_ibd(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id)
+        # no IBD linked yet - element should still exist with composite flag
+        elem = next(
+            e
+            for e in repo.elements.values()
+            if e.elem_type == "Part"
+            and e.properties.get("definition") == part.elem_id
+            and e.properties.get("whole") == whole.elem_id
+        )
+        self.assertEqual(elem.properties.get("composite"), "true")
+
+    def test_cannot_delete_composite_part_object(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id)
+        obj_dict = next(o for o in ibd.objects if o.get("obj_type") == "Part")
+
+        class DummyWin:
+            def __init__(self):
+                self.repo = repo
+                self.diagram_id = ibd.diag_id
+                self.objects = [SysMLObject(**obj_dict)]
+                self.connections = []
+
+            def _sync_to_repository(self):
+                diag = self.repo.diagrams.get(self.diagram_id)
+                diag.objects = [obj.__dict__ for obj in self.objects]
+                diag.connections = []
+
+        win = DummyWin()
+        SysMLDiagramWindow.remove_object(win, win.objects[0])
+        # object should still be present
+        self.assertEqual(len(win.objects), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- auto-create Part elements for composite aggregations
- render composite parts when linking or editing IBDs
- prevent manual deletion of composite aggregated parts
- clean up Part elements when composite connections are removed
- add tests for composite part persistence and deletion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888c166ac4083258d4a6ee846bd0cd9