### PR TITLE
Fix label sizing for resized items

### DIFF
--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -1,0 +1,58 @@
+import unittest
+from gui.architecture import SysMLObject, SysMLDiagramWindow
+from sysml.sysml_repository import SysMLRepository
+
+class DummyFont:
+    def measure(self, text: str) -> int:
+        return len(text)
+
+    def metrics(self, name: str) -> int:
+        return 1
+
+class DummyWindow:
+    def __init__(self):
+        self.repo = SysMLRepository.get_instance()
+        self.zoom = 1.0
+        self.font = DummyFont()
+
+    ensure_text_fits = SysMLDiagramWindow.ensure_text_fits
+    _object_label_lines = SysMLDiagramWindow._object_label_lines
+    _min_block_size = SysMLDiagramWindow._min_block_size
+
+class EnsureTextFitsTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_part_width_expands_for_properties(self):
+        win = DummyWindow()
+        part = SysMLObject(
+            1,
+            "Part",
+            0,
+            0,
+            width=10,
+            height=10,
+            properties={"name": "P", "fit": "123456789"},
+        )
+        part.requirements = []
+        win.ensure_text_fits(part)
+        self.assertGreater(part.width, 10)
+
+    def test_action_width_expands_for_name(self):
+        win = DummyWindow()
+        action = SysMLObject(
+            1,
+            "Action",
+            0,
+            0,
+            width=10,
+            height=10,
+            properties={"name": "LongActionName"},
+        )
+        action.requirements = []
+        win.ensure_text_fits(action)
+        self.assertGreater(action.width, 10)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve size calculations when resizing diagram objects
- include properties when computing object label lines
- test that parts and actions expand to fit text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888cf1bef1c8325b2b8e3ce024e8037