### PR TITLE
Propagate updates to aggregated parts

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -186,6 +186,11 @@ def rename_block(repo: SysMLRepository, block_id: str, new_name: str) -> None:
     for elem in repo.elements.values():
         if elem.elem_type == "Part" and elem.properties.get("definition") == block_id:
             elem.name = new_name
+            elem.properties["partDefinition"] = new_name
+            for d in repo.diagrams.values():
+                for obj in getattr(d, "objects", []):
+                    if obj.get("element_id") == elem.elem_id:
+                        obj.setdefault("properties", {})["partDefinition"] = new_name
     # update blocks that include this block as a part
     for parent_id in _find_blocks_with_part(repo, block_id):
         parent = repo.elements.get(parent_id)
@@ -321,7 +326,10 @@ def add_composite_aggregation_part(
         "x": 50.0,
         "y": 50.0 + 60.0 * len(existing_defs),
         "element_id": part_elem.elem_id,
-        "properties": {"definition": part_id},
+        "properties": {
+            "definition": part_id,
+            "partDefinition": repo.elements.get(part_id).name or part_id,
+        },
         "locked": True,
     }
     diag.objects.append(obj_dict)
@@ -401,7 +409,10 @@ def _sync_ibd_composite_parts(
             "x": base_x,
             "y": base_y,
             "element_id": part_elem.elem_id,
-            "properties": {"definition": pid},
+            "properties": {
+                "definition": pid,
+                "partDefinition": repo.elements.get(pid).name or pid,
+            },
             "locked": True,
         }
         base_y += 60.0
@@ -462,7 +473,10 @@ def _sync_ibd_aggregation_parts(
             "x": base_x,
             "y": base_y,
             "element_id": part_elem.elem_id,
-            "properties": {"definition": pid},
+            "properties": {
+                "definition": pid,
+                "partDefinition": repo.elements.get(pid).name or pid,
+            },
         }
         base_y += 60.0
         diag.objects.append(obj_dict)
@@ -532,7 +546,10 @@ def _sync_ibd_partproperty_parts(
         part_elem = repo.create_element(
             "Part",
             name=part_name,
-            properties={"definition": target_id},
+            properties={
+                "definition": target_id,
+                "partDefinition": repo.elements.get(target_id).name or target_id,
+            },
             owner=repo.root_package.elem_id,
         )
         repo.add_element_to_diagram(diag.diag_id, part_elem.elem_id)
@@ -542,7 +559,10 @@ def _sync_ibd_partproperty_parts(
             "x": base_x,
             "y": base_y,
             "element_id": part_elem.elem_id,
-            "properties": {"definition": target_id},
+            "properties": {
+                "definition": target_id,
+                "partDefinition": repo.elements.get(target_id).name or target_id,
+            },
         }
         base_y += 60.0
         diag.objects.append(obj_dict)
@@ -1385,6 +1405,16 @@ class SysMLDiagramWindow(tk.Frame):
             elif conn_type in ("Aggregation", "Composite Aggregation"):
                 if src.obj_type != "Block" or dst.obj_type != "Block":
                     return False, "Aggregations must connect Blocks"
+                # Prevent duplicate aggregations when inherited via generalization
+                parents = _collect_generalization_parents(self.repo, src.element_id)
+                for p in parents:
+                    if any(
+                        r.rel_type in ("Aggregation", "Composite Aggregation")
+                        and r.source == p
+                        and r.target == dst.element_id
+                        for r in self.repo.relationships
+                    ):
+                        return False, "Target already aggregated through generalization"
 
         elif diag_type == "Internal Block Diagram":
             if conn_type == "Connector":
@@ -4016,10 +4046,28 @@ class SysMLObjectDialog(simpledialog.Dialog):
             cur_id = self.obj.properties.get("definition", "")
             cur_name = next((n for n, i in idmap.items() if i == cur_id), "")
             self.def_var = tk.StringVar(value=cur_name)
-            ttk.Combobox(link_frame, textvariable=self.def_var, values=list(idmap.keys())).grid(
+            cb = ttk.Combobox(
+                link_frame, textvariable=self.def_var, values=list(idmap.keys())
+            )
+            cb.grid(row=link_row, column=1, padx=4, pady=2)
+            link_row += 1
+            ttk.Label(link_frame, text="partDefinition:").grid(
+                row=link_row, column=0, sticky="e", padx=4, pady=2
+            )
+            pname = repo.elements.get(cur_id).name if cur_id in repo.elements else ""
+            self.part_def_var = tk.StringVar(value=pname)
+            ttk.Entry(link_frame, textvariable=self.part_def_var, state="readonly").grid(
                 row=link_row, column=1, padx=4, pady=2
             )
             link_row += 1
+
+            def sync_part_def(_):
+                name = self.def_var.get()
+                did = self.def_map.get(name)
+                if did and did in repo.elements:
+                    self.part_def_var.set(repo.elements[did].name or did)
+
+            cb.bind("<<ComboboxSelected>>", sync_part_def)
 
         # Requirement allocation section
         req_row = 0
@@ -4319,7 +4367,10 @@ class SysMLObjectDialog(simpledialog.Dialog):
         self.obj.properties["name"] = self.name_var.get()
         repo = SysMLRepository.get_instance()
         if self.obj.element_id and self.obj.element_id in repo.elements:
-            repo.elements[self.obj.element_id].name = self.name_var.get()
+            if self.obj.obj_type == "Block":
+                rename_block(repo, self.obj.element_id, self.name_var.get())
+            else:
+                repo.elements[self.obj.element_id].name = self.name_var.get()
         for prop, var in self.entries.items():
             self.obj.properties[prop] = var.get()
             if self.obj.element_id and self.obj.element_id in repo.elements:
@@ -4410,8 +4461,12 @@ class SysMLObjectDialog(simpledialog.Dialog):
             def_id = self.def_map.get(name)
             if def_id:
                 self.obj.properties["definition"] = def_id
+                self.obj.properties["partDefinition"] = repo.elements.get(def_id).name or def_id
                 if self.obj.element_id and self.obj.element_id in repo.elements:
                     repo.elements[self.obj.element_id].properties["definition"] = def_id
+                    repo.elements[self.obj.element_id].properties["partDefinition"] = (
+                        repo.elements.get(def_id).name or def_id
+                    )
         if hasattr(self, "ucdef_var"):
             name = self.ucdef_var.get()
             def_id = self.ucdef_map.get(name)

--- a/tests/test_aggregation_generalization_rule.py
+++ b/tests/test_aggregation_generalization_rule.py
@@ -1,0 +1,44 @@
+import unittest
+from gui.architecture import SysMLObject, SysMLDiagramWindow
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+class DummyWindow:
+    def __init__(self):
+        self.repo = SysMLRepository.get_instance()
+        diag = SysMLDiagram(diag_id="d", diag_type="Block Diagram")
+        self.repo.diagrams[diag.diag_id] = diag
+        self.diagram_id = diag.diag_id
+
+class AggregationGeneralizationRuleTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_duplicate_aggregation_prevented(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Aggregation", parent.elem_id, part.elem_id)
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        win = DummyWindow()
+        src = SysMLObject(1, "Block", 0, 0, element_id=child.elem_id)
+        dst = SysMLObject(2, "Block", 0, 0, element_id=part.elem_id)
+        valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Aggregation")
+        self.assertFalse(valid)
+
+    def test_duplicate_composite_prevented(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Composite Aggregation", parent.elem_id, part.elem_id)
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        win = DummyWindow()
+        src = SysMLObject(1, "Block", 0, 0, element_id=child.elem_id)
+        dst = SysMLObject(2, "Block", 0, 0, element_id=part.elem_id)
+        valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Composite Aggregation")
+        self.assertFalse(valid)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_inherit_parts.py
+++ b/tests/test_inherit_parts.py
@@ -209,6 +209,11 @@ class InheritPartsTests(unittest.TestCase):
                 for o in ibd.objects
             )
         )
+        obj = next(o for o in ibd.objects if o.get("obj_type") == "Part")
+        self.assertEqual(
+            repo.elements[obj["element_id"]].properties.get("partDefinition"),
+            "B",
+        )
         self.assertTrue(
             any(d.get("properties", {}).get("definition") == part_blk.elem_id for d in added)
         )
@@ -227,6 +232,11 @@ class InheritPartsTests(unittest.TestCase):
                 and repo.elements[o.get("element_id")].name == "p"
                 for o in ibd.objects
             )
+        )
+        obj = next(o for o in ibd.objects if o.get("obj_type") == "Part")
+        self.assertEqual(
+            repo.elements[obj["element_id"]].properties.get("partDefinition"),
+            "B",
         )
         self.assertTrue(
             any(d.get("properties", {}).get("definition") == part_blk.elem_id for d in added)

--- a/tests/test_rename_block.py
+++ b/tests/test_rename_block.py
@@ -32,6 +32,12 @@ class RenameBlockTests(unittest.TestCase):
                 and o.get("properties", {}).get("definition") == part.elem_id
             )
         )
+        pid = next(
+            o["element_id"]
+            for o in ibd.objects
+            if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        )
+        self.assertEqual(repo.elements[pid].properties.get("partDefinition"), "NewPart")
 
     def test_rename_block_propagates_to_generalization(self):
         repo = self.repo


### PR DESCRIPTION
## Summary
- ensure renaming a block updates `partDefinition` on referencing parts
- include `partDefinition` when generating parts in IBDs
- show read-only partDefinition field in part properties
- sync partDefinition when changing part definition
- tests for partDefinition propagation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888dca5e88c832599ae3f67b7983923