### PR TITLE
Add minimum window sizes

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -15586,6 +15586,9 @@ class PageDiagram:
 
 def main():
     root = tk.Tk()
+    # Prevent the main window from being resized so small that
+    # widgets and toolbars become unusable.
+    root.minsize(1200, 700)
     # Hide the main window while prompting for user info
     root.withdraw()
     users = load_all_users()

--- a/gui/faults_gui.py
+++ b/gui/faults_gui.py
@@ -475,6 +475,9 @@ class FaultsWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("Autonomous Truck Fault Prioritization")
         self.resize(1400, 800)
+        # Keep the window large enough for the table, toolbar and status bar
+        # to remain fully visible when the user resizes it.
+        self.setMinimumSize(1200, 700)
 
         # thresholds
         self.sev_hi = SEVERITY_HI_TH


### PR DESCRIPTION
## Summary
- prevent main Tk window from shrinking too small
- keep the Qt fault prioritization window large enough for its widgets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888eb7cb9648325a77eaad5a06e09b9