### PR TITLE
Fix boundary updates when renaming blocks

### DIFF
--- a/sysml/sysml_spec.py
+++ b/sysml/sysml_spec.py
@@ -43,6 +43,9 @@ for p in ('labelX', 'labelY'):
     if p not in SYSML_PROPERTIES['PortUsage']:
         SYSML_PROPERTIES['PortUsage'].append(p)
 
+if 'BlockBoundaryUsage' not in SYSML_PROPERTIES:
+    SYSML_PROPERTIES['BlockBoundaryUsage'] = list(SYSML_PROPERTIES.get('BlockUsage', []))
+
 # ----------------------------------------------------------------------
 # Additional properties for reliability annotations
 # ----------------------------------------------------------------------

--- a/tests/test_block_boundary.py
+++ b/tests/test_block_boundary.py
@@ -1,5 +1,10 @@
 import unittest
-from gui.architecture import set_ibd_father, link_block_to_ibd
+from gui.architecture import (
+    set_ibd_father,
+    link_block_to_ibd,
+    rename_block,
+    propagate_block_port_changes,
+)
 from sysml.sysml_repository import SysMLRepository
 
 class BlockBoundaryTests(unittest.TestCase):
@@ -29,6 +34,31 @@ class BlockBoundaryTests(unittest.TestCase):
         link_block_to_ibd(repo, block.elem_id, ibd.diag_id)
         boundary = next(o for o in ibd.objects if o.get("obj_type") == "Block Boundary")
         self.assertEqual(boundary.get("element_id"), block.elem_id)
+
+    def test_rename_block_updates_boundary_name(self):
+        repo = self.repo
+        block = repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        set_ibd_father(repo, ibd, block.elem_id)
+        rename_block(repo, block.elem_id, "B2")
+        boundary = next(o for o in ibd.objects if o.get("obj_type") == "Block Boundary")
+        self.assertEqual(boundary.get("properties", {}).get("name"), "B2")
+
+    def test_add_port_updates_block_and_boundary(self):
+        repo = self.repo
+        block = repo.create_element("Block", name="B", properties={"ports": "p1"})
+        ibd = repo.create_diagram("Internal Block Diagram")
+        set_ibd_father(repo, ibd, block.elem_id)
+        boundary = next(o for o in ibd.objects if o.get("obj_type") == "Block Boundary")
+        boundary.setdefault("properties", {})["ports"] = "p1, p2"
+        block.properties["ports"] = "p1, p2"
+        propagate_block_port_changes(repo, block.elem_id)
+        names = [
+            o["properties"]["name"]
+            for o in ibd.objects
+            if o.get("obj_type") == "Port" and o.get("properties", {}).get("parent") == str(boundary["obj_id"])
+        ]
+        self.assertIn("p2", names)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure Block Boundary objects expose block properties
- update Block Boundary names when renaming blocks
- propagate block port changes even if no parts reference the block
- sync block updates when editing a Block Boundary
- add tests for renaming blocks and adding ports via boundaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889845b14ac8325bff22abd815b40dc