### PR TITLE
Fix port selection for IBD connectors

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1918,6 +1918,8 @@ class SysMLDiagramWindow(tk.Frame):
                     "Part",
                 ):
                     return False, "Connectors must link Parts or Ports"
+                if src.obj_type == "Block Boundary" or dst.obj_type == "Block Boundary":
+                    return False, "Connectors must link Parts or Ports"
                 if src.obj_type == "Port" and dst.obj_type == "Port":
                     dir_a = src.properties.get("direction", "inout").lower()
                     dir_b = dst.properties.get("direction", "inout").lower()
@@ -2031,7 +2033,20 @@ class SysMLDiagramWindow(tk.Frame):
     def on_left_press(self, event):
         x = self.canvas.canvasx(event.x)
         y = self.canvas.canvasy(event.y)
-        obj = self.find_object(x, y)
+        conn_tools = (
+            "Association",
+            "Include",
+            "Extend",
+            "Flow",
+            "Connector",
+            "Generalize",
+            "Generalization",
+            "Communication Path",
+            "Aggregation",
+            "Composite Aggregation",
+        )
+        prefer = self.current_tool in conn_tools
+        obj = self.find_object(x, y, prefer_port=prefer)
         t = self.current_tool
 
         if t in (
@@ -2429,7 +2444,11 @@ class SysMLDiagramWindow(tk.Frame):
         ):
             x = self.canvas.canvasx(event.x)
             y = self.canvas.canvasy(event.y)
-            obj = self.find_object(x, y)
+            obj = self.find_object(
+                x,
+                y,
+                prefer_port=True,
+            )
             if obj and obj != self.start:
                 valid, msg = self.validate_connection(self.start, obj, self.current_tool)
                 if valid:
@@ -2525,7 +2544,7 @@ class SysMLDiagramWindow(tk.Frame):
         if self.dragging_endpoint is not None and self.selected_conn:
             x = self.canvas.canvasx(event.x)
             y = self.canvas.canvasy(event.y)
-            obj = self.find_object(x, y)
+            obj = self.find_object(x, y, prefer_port=True)
             src_obj = self.get_object(self.selected_conn.src)
             dst_obj = self.get_object(self.selected_conn.dst)
             if obj and obj not in (src_obj, dst_obj):
@@ -2834,7 +2853,23 @@ class SysMLDiagramWindow(tk.Frame):
     # ------------------------------------------------------------
     # Utility methods
     # ------------------------------------------------------------
-    def find_object(self, x: float, y: float) -> SysMLObject | None:
+    def find_object(self, x: float, y: float, prefer_port: bool = False) -> SysMLObject | None:
+        """Return the diagram object under ``(x, y)``.
+
+        When ``prefer_port`` is ``True`` ports are looked up first so they
+        are selected over overlapping parent objects like a Block Boundary.
+        """
+        if prefer_port:
+            for obj in reversed(self.objects):
+                if obj.obj_type != "Port":
+                    continue
+                ox = obj.x * self.zoom
+                oy = obj.y * self.zoom
+                w = obj.width * self.zoom / 2
+                h = obj.height * self.zoom / 2
+                if ox - w <= x <= ox + w and oy - h <= y <= oy + h:
+                    return obj
+
         for obj in reversed(self.objects):
             ox = obj.x * self.zoom
             oy = obj.y * self.zoom

--- a/tests/test_boundary_port_selection.py
+++ b/tests/test_boundary_port_selection.py
@@ -1,0 +1,25 @@
+import unittest
+from gui.architecture import SysMLDiagramWindow, SysMLObject, set_ibd_father
+from sysml.sysml_repository import SysMLRepository
+
+class BoundaryPortSelectionTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_find_object_prefers_port_over_boundary(self):
+        repo = self.repo
+        block = repo.create_element("Block", name="B", properties={"ports": "p"})
+        diag = repo.create_diagram("Internal Block Diagram")
+        set_ibd_father(repo, diag, block.elem_id)
+        win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
+        win.objects = [SysMLObject(**o) for o in diag.objects]
+        win.zoom = 1.0
+        port_obj = next(o for o in win.objects if o.obj_type == "Port")
+        obj = win.find_object(port_obj.x, port_obj.y, prefer_port=True)
+        self.assertEqual(obj.obj_type, "Port")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `find_object` to prioritize ports so they don't get overshadowed by the IBD boundary
- prefer port objects when creating or editing connections
- reject connectors made directly to a Block Boundary
- test that ports are selected ahead of the boundary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a0631b73883258ff9d3514f4c541d