### PR TITLE
Fix connector placement on square actions

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3049,7 +3049,7 @@ class SysMLDiagramWindow(tk.Frame):
         elif obj.obj_type == "System Boundary":
             radius = 12 * self.zoom
         elif obj.obj_type in ("Action Usage", "Action", "CallBehaviorAction"):
-            radius = 8 * self.zoom
+            radius = 0.0
         dx = tx - x
         dy = ty - y
         if obj.obj_type in ("Initial", "Final"):
@@ -3074,20 +3074,16 @@ class SysMLDiagramWindow(tk.Frame):
                         best = (ix, iy, t)
             if best:
                 return best[0], best[1]
-        if abs(dx) > abs(dy):
-            if dx > 0:
-                x += w
-                y += dy * (w / abs(dx)) if dx != 0 else 0
-            else:
-                x -= w
-                y += dy * (w / abs(dx)) if dx != 0 else 0
+        if dx == 0 and dy == 0:
+            return x, y
+        if dx == 0:
+            t = h / abs(dy) if dy != 0 else 0
+        elif dy == 0:
+            t = w / abs(dx)
         else:
-            if dy > 0:
-                y += h
-                x += dx * (h / abs(dy)) if dy != 0 else 0
-            else:
-                y -= h
-                x += dx * (h / abs(dy)) if dy != 0 else 0
+            t = min(w / abs(dx), h / abs(dy))
+        x += dx * t
+        y += dy * t
 
         if radius:
             cx, cy = obj.x * self.zoom, obj.y * self.zoom

--- a/tests/test_edge_point.py
+++ b/tests/test_edge_point.py
@@ -1,0 +1,16 @@
+import unittest
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+
+class EdgePointTests(unittest.TestCase):
+    def setUp(self):
+        self.win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+        self.win.zoom = 1.0
+
+    def test_diagonal_to_square_corner(self):
+        obj = SysMLObject(1, "Action", 0, 0, width=20, height=20)
+        x, y = self.win.edge_point(obj, 20, 20)
+        self.assertAlmostEqual(x, 10.0)
+        self.assertAlmostEqual(y, 10.0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep connectors anchored to square nodes
- ensure edges use geometric intersection for accurate connections
- test intersection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a495ee9908325a4c7b9ecc4b94ed8