### PR TITLE
Fix connection to ports on block boundary

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3394,10 +3394,25 @@ class SysMLDiagramWindow(tk.Frame):
             obj.height = min_h
 
     def sort_objects(self) -> None:
-        """Ensure System Boundaries are drawn and selected behind others."""
-        self.objects.sort(
-            key=lambda o: 0 if o.obj_type in ("System Boundary", "Block Boundary") else 1
-        )
+        """Order objects so boundaries render behind and their ports above."""
+
+        def key(o: SysMLObject) -> int:
+            if o.obj_type in ("System Boundary", "Block Boundary"):
+                return 0
+            if o.obj_type == "Port":
+                parent_id = o.properties.get("parent")
+                if parent_id:
+                    try:
+                        pid = int(parent_id)
+                    except (TypeError, ValueError):
+                        pid = None
+                    if pid is not None:
+                        for obj in self.objects:
+                            if obj.obj_id == pid and obj.obj_type == "Block Boundary":
+                                return 2
+            return 1
+
+        self.objects.sort(key=key)
 
     def redraw(self):
         self.canvas.delete("all")

--- a/tests/test_boundary_port_selection.py
+++ b/tests/test_boundary_port_selection.py
@@ -21,5 +21,33 @@ class BoundaryPortSelectionTests(unittest.TestCase):
         obj = win.find_object(port_obj.x, port_obj.y, prefer_port=True)
         self.assertEqual(obj.obj_type, "Port")
 
+    def test_find_object_prefers_boundary_port_over_part(self):
+        repo = self.repo
+        block = repo.create_element("Block", name="B", properties={"ports": "p"})
+        diag = repo.create_diagram("Internal Block Diagram")
+        set_ibd_father(repo, diag, block.elem_id)
+        port_obj = next(o for o in diag.objects if o["obj_type"] == "Port")
+        part_elem = repo.create_element("Block", name="P")
+        part = repo.create_element("Part", properties={"definition": part_elem.elem_id})
+        diag.objects.append(
+            {
+                "obj_id": max(o["obj_id"] for o in diag.objects) + 1,
+                "obj_type": "Part",
+                "x": port_obj["x"],
+                "y": port_obj["y"],
+                "element_id": part.elem_id,
+                "properties": {"definition": part_elem.elem_id},
+            }
+        )
+        win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
+        win.objects = [SysMLObject(**o) for o in diag.objects]
+        win.zoom = 1.0
+        win.sort_objects()
+        port = next(o for o in win.objects if o.obj_type == "Port")
+        obj = win.find_object(port.x, port.y, prefer_port=True)
+        self.assertEqual(obj.obj_type, "Port")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- draw ports on block boundary above all other objects so connectors can snap to them
- add regression test for finding boundary ports even when a part overlaps

## Testing
- `PYTHONPATH=. pytest -q tests/test_boundary_port_selection.py -k boundary_port`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a4d915384832589e2767a0266f03d