### PR TITLE
Fix constant sizing for decision and merge nodes

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2396,7 +2396,13 @@ class SysMLDiagramWindow(tk.Frame):
         y = self.canvas.canvasy(event.y)
         if self.resizing_obj:
             obj = self.resizing_obj
-            if obj.obj_type in ("Initial", "Final", "Actor"):
+            if obj.obj_type in (
+                "Initial",
+                "Final",
+                "Actor",
+                "Decision",
+                "Merge",
+            ):
                 return
             cx = obj.x * self.zoom
             cy = obj.y * self.zoom
@@ -2932,7 +2938,13 @@ class SysMLDiagramWindow(tk.Frame):
         return None
 
     def hit_resize_handle(self, obj: SysMLObject, x: float, y: float) -> str | None:
-        if obj.obj_type in ("Initial", "Final", "Actor"):
+        if obj.obj_type in (
+            "Initial",
+            "Final",
+            "Actor",
+            "Decision",
+            "Merge",
+        ):
             return None
         margin = 5
         ox = obj.x * self.zoom
@@ -3420,11 +3432,25 @@ class SysMLDiagramWindow(tk.Frame):
         if obj.obj_type in ("Block",):
             # _min_block_size already accounts for text padding
             pass
-        elif obj.obj_type in ("Fork", "Join", "Initial", "Final"):
+        elif obj.obj_type in (
+            "Fork",
+            "Join",
+            "Initial",
+            "Final",
+            "Decision",
+            "Merge",
+        ):
             min_h = obj.height  # height remains unchanged for these types
         if min_w > obj.width:
             obj.width = min_w
-        if obj.obj_type not in ("Fork", "Join", "Initial", "Final") and min_h > obj.height:
+        if obj.obj_type not in (
+            "Fork",
+            "Join",
+            "Initial",
+            "Final",
+            "Decision",
+            "Merge",
+        ) and min_h > obj.height:
             obj.height = min_h
 
     def sort_objects(self) -> None:
@@ -4745,7 +4771,11 @@ class SysMLObjectDialog(simpledialog.Dialog):
         gen_row += 1
         ttk.Label(gen_frame, text="Width:").grid(row=gen_row, column=0, sticky="e", padx=4, pady=2)
         self.width_var = tk.StringVar(value=str(self.obj.width))
-        width_state = "readonly" if self.obj.obj_type in ("Initial", "Final", "Actor") else "normal"
+        width_state = (
+            "readonly"
+            if self.obj.obj_type in ("Initial", "Final", "Actor", "Decision", "Merge")
+            else "normal"
+        )
         ttk.Entry(gen_frame, textvariable=self.width_var, state=width_state).grid(
             row=gen_row, column=1, padx=4, pady=2
         )
@@ -4755,7 +4785,12 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 row=gen_row, column=0, sticky="e", padx=4, pady=2
             )
             self.height_var = tk.StringVar(value=str(self.obj.height))
-            height_state = "readonly" if self.obj.obj_type in ("Initial", "Final", "Actor") else "normal"
+            height_state = (
+                "readonly"
+                if self.obj.obj_type
+                in ("Initial", "Final", "Actor", "Decision", "Merge")
+                else "normal"
+            )
             ttk.Entry(gen_frame, textvariable=self.height_var, state=height_state).grid(
                 row=gen_row, column=1, padx=4, pady=2
             )
@@ -5344,7 +5379,12 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 propagate_block_part_changes(repo, self.obj.element_id)
                 propagate_block_changes(repo, self.obj.element_id)
         try:
-            if self.obj.obj_type not in ("Initial", "Final"):
+            if self.obj.obj_type not in (
+                "Initial",
+                "Final",
+                "Decision",
+                "Merge",
+            ):
                 self.obj.width = float(self.width_var.get())
                 self.obj.height = float(self.height_var.get())
         except ValueError:

--- a/tests/test_diamond_corners.py
+++ b/tests/test_diamond_corners.py
@@ -7,6 +7,7 @@ class DummyWindow:
 
     _nearest_diamond_corner = SysMLDiagramWindow._nearest_diamond_corner
     edge_point = SysMLDiagramWindow.edge_point
+    _segment_intersection = SysMLDiagramWindow._segment_intersection
 
 class DiamondCornerTests(unittest.TestCase):
     def test_edge_point_nearest_corner(self):

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -55,5 +55,31 @@ class EnsureTextFitsTests(unittest.TestCase):
         win.ensure_text_fits(action)
         self.assertEqual(action.width, 10)
 
+    def test_decision_and_merge_sizes_remain_fixed(self):
+        win = DummyWindow()
+        decision = SysMLObject(
+            1,
+            "Decision",
+            0,
+            0,
+            width=40,
+            height=40,
+            properties={"name": "Decide"},
+        )
+        merge = SysMLObject(
+            2,
+            "Merge",
+            0,
+            0,
+            width=40,
+            height=40,
+            properties={"name": "MergeNode"},
+        )
+        for obj in (decision, merge):
+            obj.requirements = []
+            win.ensure_text_fits(obj)
+            self.assertEqual(obj.width, 40)
+            self.assertEqual(obj.height, 40)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- prevent resizing of Decision and Merge nodes
- make width and height entries read-only for these nodes
- keep decision/merge size constant when text changes
- update tests for decision/merge sizing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a5d85bd088325b2030b74eec41f4f