### PR TITLE
Remove derived actionDefinition property

### DIFF
--- a/sysml/sysml_spec.py
+++ b/sysml/sysml_spec.py
@@ -64,6 +64,10 @@ for prop in ('analysis', 'fit', 'qualification', 'failureModes'):
     if prop not in SYSML_PROPERTIES['BlockUsage']:
         SYSML_PROPERTIES['BlockUsage'].append(prop)
 
+# Remove the derived SysML property 'actionDefinition' from ActionUsage entries.
+if 'actionDefinition' in SYSML_PROPERTIES.get('ActionUsage', []):
+    SYSML_PROPERTIES['ActionUsage'].remove('actionDefinition')
+
 for prop in ('component', 'failureModes', 'asil'):
     if prop not in SYSML_PROPERTIES['PartUsage']:
         SYSML_PROPERTIES['PartUsage'].append(prop)

--- a/tests/test_diamond_corners.py
+++ b/tests/test_diamond_corners.py
@@ -6,6 +6,7 @@ class DummyWindow:
         self.zoom = 1.0
 
     _nearest_diamond_corner = SysMLDiagramWindow._nearest_diamond_corner
+    _segment_intersection = SysMLDiagramWindow._segment_intersection
     edge_point = SysMLDiagramWindow.edge_point
 
 class DiamondCornerTests(unittest.TestCase):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -48,6 +48,14 @@ class RepositoryTests(unittest.TestCase):
         self.assertIn("PortUsage", SYSML_PROPERTIES)
         self.assertIn("direction", SYSML_PROPERTIES["PortUsage"])
 
+    def test_action_usage_property_removed(self):
+        """Ensure derived ActionUsage attributes are excluded."""
+        from sysml.sysml_spec import SYSML_PROPERTIES
+        self.assertNotIn(
+            "actionDefinition",
+            SYSML_PROPERTIES.get("ActionUsage", []),
+        )
+
     def test_packages_and_save_load(self):
         pkg = self.repo.create_package("PkgA")
         blk = self.repo.create_element("Block", name="Engine", owner=pkg.elem_id)


### PR DESCRIPTION
## Summary
- strip `actionDefinition` from ActionUsage properties
- update repository tests to check the property list
- fix diamond corner test dummy window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a5e2366bc8325b81e91150ed7a73b