### PR TITLE
Add additional diagram style options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.1.3
+version: 0.1.4
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -29,6 +29,7 @@ AutoML is an automotive modeling language. It lets you model items, operating sc
   - [Safety Goal Export](#safety-goal-export)
 - [Email Setup](#email-setup)
 - [Dependencies](#dependencies)
+- [Diagram Styles](#diagram-styles)
 - [License](#license)
 - [Building the Executable](#building-the-executable)
 - [Version History](#version-history)
@@ -956,6 +957,13 @@ bundled correctly.
 If double‑clicking `AutoML.py` closes immediately, launch it from a command
 prompt instead so any error messages remain visible.
 
+## Diagram Styles
+
+Several example style files are provided in the `styles` directory:
+`modern.xml`, `dark.xml`, `light.xml` and `vibrant.xml`. Load these from the
+Style Editor to quickly switch the color scheme or create your own based on
+them.
+
 ## License
 
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.
@@ -985,6 +993,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.1.4 - Added example style files and documentation.
 - 0.1.3 - Added context menu actions to remove parts from a diagram or from the model.
 - 0.1.2 - Clarified systems safety focus in description and About dialog.
 - 0.1.1 - Updated description and About dialog.

--- a/styles/dark.xml
+++ b/styles/dark.xml
@@ -1,0 +1,14 @@
+<style>
+  <object type="Actor" color="#0D47A1" />
+  <object type="Use Case" color="#FF8F00" />
+  <object type="System Boundary" color="#37474F" />
+  <object type="Block Boundary" color="#263238" />
+  <object type="Action Usage" color="#1B5E20" />
+  <object type="Action" color="#1B5E20" />
+  <object type="CallBehaviorAction" color="#1B5E20" />
+  <object type="Part" color="#F57F17" />
+  <object type="Port" color="#4A148C" />
+  <object type="Block" color="#455A64" />
+  <object type="Decision" color="#006064" />
+  <object type="Merge" color="#006064" />
+</style>

--- a/styles/light.xml
+++ b/styles/light.xml
@@ -1,0 +1,14 @@
+<style>
+  <object type="Actor" color="#BBDEFB" />
+  <object type="Use Case" color="#FFF9C4" />
+  <object type="System Boundary" color="#CFD8DC" />
+  <object type="Block Boundary" color="#F5F5F5" />
+  <object type="Action Usage" color="#C8E6C9" />
+  <object type="Action" color="#C8E6C9" />
+  <object type="CallBehaviorAction" color="#C8E6C9" />
+  <object type="Part" color="#FFF9C4" />
+  <object type="Port" color="#E1BEE7" />
+  <object type="Block" color="#B0BEC5" />
+  <object type="Decision" color="#B2EBF2" />
+  <object type="Merge" color="#B2EBF2" />
+</style>

--- a/styles/vibrant.xml
+++ b/styles/vibrant.xml
@@ -1,0 +1,14 @@
+<style>
+  <object type="Actor" color="#1976D2" />
+  <object type="Use Case" color="#FFC107" />
+  <object type="System Boundary" color="#607D8B" />
+  <object type="Block Boundary" color="#E0E0E0" />
+  <object type="Action Usage" color="#43A047" />
+  <object type="Action" color="#43A047" />
+  <object type="CallBehaviorAction" color="#43A047" />
+  <object type="Part" color="#FDD835" />
+  <object type="Port" color="#8E24AA" />
+  <object type="Block" color="#546E7A" />
+  <object type="Decision" color="#00ACC1" />
+  <object type="Merge" color="#00ACC1" />
+</style>


### PR DESCRIPTION
## Summary
- create new style files: `dark.xml`, `light.xml` and `vibrant.xml`
- document style files and bump version to 0.1.4
- mention style section in README index and version history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c541f02e88325a755361c7af586a5