### PR TITLE
Change default style to pastel

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,9 +931,9 @@ prompt instead so any error messages remain visible.
 ## Diagram Styles
 
 Several XML files in the `styles` directory control the colors used for
-diagram elements. The default `modern.xml` uses a Material-inspired palette.
-`pastel.xml` provides softer tones like peach actions and steel-blue nodes.
-Open the Style Editor via **View → Style Editor**, click **Load** and choose
+diagram elements. The default style `pastel.xml` provides softer tones like
+peach actions and steel-blue nodes. `modern.xml` offers a Material-inspired
+palette for a different look. Open the Style Editor via **View → Style Editor**, click **Load** and choose
 the desired style. All open diagrams update immediately.
 
 ## License

--- a/gui/style_manager.py
+++ b/gui/style_manager.py
@@ -1,7 +1,7 @@
 import os
 import xml.etree.ElementTree as ET
 
-_DEFAULT_STYLE = os.path.join(os.path.dirname(__file__), '..', 'styles', 'modern.xml')
+_DEFAULT_STYLE = os.path.join(os.path.dirname(__file__), '..', 'styles', 'pastel.xml')
 
 class StyleManager:
     """Singleton manager for diagram styles loaded from XML files."""

--- a/styles/pastel.xml
+++ b/styles/pastel.xml
@@ -1,8 +1,8 @@
 <style>
   <object type="Actor" color="#F4D698" />
   <object type="Use Case" color="#B0E0E6" />
-  <object type="System Boundary" color="#FFFFFF" />
-  <object type="Block Boundary" color="#FFFFFF" />
+  <object type="System Boundary" color="#CFD8DC" />
+  <object type="Block Boundary" color="#F5F5F5" />
   <object type="Action Usage" color="#FAD7A0" />
   <object type="Action" color="#FAD7A0" />
   <object type="CallBehaviorAction" color="#FAD7A0" />


### PR DESCRIPTION
## Summary
- use pastel.xml as the default style
- tweak pastel.xml colors
- update docs about the new default style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c5bf8a03c8325aee8865e06c4651e