### PR TITLE
Fix missing validate_float method

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8542,6 +8542,18 @@ class FaultTreeApp:
         for be in self.get_all_basic_events():
             be.failure_prob = self.compute_failure_prob(be)
 
+    def validate_float(self, value):
+        """Return ``True`` if ``value`` can be parsed as a float or is an
+        intermediate input allowed by Tk validation."""
+
+        if value in ("", "-", "+", ".", "-.", "+."):
+            return True
+        try:
+            float(value)
+            return True
+        except ValueError:
+            return False
+
     def compute_failure_prob(self, node, failure_mode_ref=None, formula=None):
         """Return probability of failure for ``node`` based on FIT rate.
 


### PR DESCRIPTION
## Summary
- add a `validate_float` helper to `FaultTreeApp`
- use the helper in Safety Goal dialog to validate numeric entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c601ad1808325b2552ccd0f4c6549