### PR TITLE
Fix scenario exposure sync in HARA

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8132,17 +8132,18 @@ class FaultTreeApp:
 
     def get_scenario_exposure(self, name: str) -> int:
         """Return exposure level for the given scenario name."""
+        name = (name or "").strip()
         for lib in self.scenario_libraries:
             for sc in lib.get("scenarios", []):
                 if isinstance(sc, dict):
-                    sc_name = sc.get("name", "")
+                    sc_name = (sc.get("name", "") or "").strip()
                     if sc_name == name:
                         try:
                             return int(sc.get("exposure", 1))
                         except (TypeError, ValueError):
                             return 1
                 else:
-                    if sc == name:
+                    if str(sc).strip() == name:
                         return 1
         return 1
 

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -2329,6 +2329,17 @@ class HaraWindow(tk.Frame):
                     return
             else:
                 setattr(entry, column, value)
+            if column == "scenario":
+                try:
+                    entry.exposure = int(self.app.get_scenario_exposure(value))
+                except (TypeError, ValueError):
+                    entry.exposure = 1
+            entry.asil = calc_asil(entry.severity, entry.controllability, entry.exposure)
+            if self.app.active_hara:
+                self.app.active_hara.status = "draft"
+                self.app.active_hara.approved = False
+                self.app.invalidate_reviews_for_hara(self.app.active_hara.name)
+                self.status_lbl.config(text=f"Status: {self.app.active_hara.status}")
         self.refresh()
 
     def approve_doc(self):


### PR DESCRIPTION
## Summary
- update `get_scenario_exposure` to handle whitespace
- recalc exposure and ASIL when editing HARA scenario inline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c849f3d508325b4fd714f28ce0e3d