### PR TITLE
Fix HARA exposure lookup

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8132,18 +8132,18 @@ class FaultTreeApp:
 
     def get_scenario_exposure(self, name: str) -> int:
         """Return exposure level for the given scenario name."""
-        name = (name or "").strip()
+        name = (name or "").strip().lower()
         for lib in self.scenario_libraries:
             for sc in lib.get("scenarios", []):
                 if isinstance(sc, dict):
-                    sc_name = (sc.get("name", "") or "").strip()
+                    sc_name = (sc.get("name", "") or "").strip().lower()
                     if sc_name == name:
                         try:
                             return int(sc.get("exposure", 1))
                         except (TypeError, ValueError):
                             return 1
                 else:
-                    if str(sc).strip() == name:
+                    if str(sc).strip().lower() == name:
                         return 1
         return 1
 


### PR DESCRIPTION
## Summary
- handle scenario names case-insensitively when looking up exposure levels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c86d1ede48325b42c2d2804f91648