### PR TITLE
Fix duplicate parts when inheriting with BOM

### DIFF
--- a/tests/test_inherit_parts.py
+++ b/tests/test_inherit_parts.py
@@ -293,5 +293,31 @@ class InheritPartsTests(unittest.TestCase):
             )
         )
 
+    def test_inherit_father_parts_preserves_existing(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent", properties={"partProperties": "B"})
+        child = repo.create_element("Block", name="Child")
+        part_blk = repo.create_element("Block", name="B")
+        df = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(parent.elem_id, df.diag_id)
+        _sync_ibd_partproperty_parts(repo, parent.elem_id, visible=True)
+
+        dc = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(child.elem_id, dc.diag_id)
+        dc.father = parent.elem_id
+        inherit_father_parts(repo, dc)
+
+        # replace parent's part with a new element
+        df.objects = []
+        _sync_ibd_partproperty_parts(repo, parent.elem_id, visible=True)
+
+        inherit_father_parts(repo, dc)
+        parts = [
+            o
+            for o in dc.objects
+            if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part_blk.elem_id
+        ]
+        self.assertEqual(len(parts), 1)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_partproperty_multiplicity.py
+++ b/tests/test_partproperty_multiplicity.py
@@ -28,5 +28,23 @@ class PartPropertyMultiplicityTests(unittest.TestCase):
         parts = [o for o in ibd.objects if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id]
         self.assertEqual(len(parts), 1)
 
+    def test_skip_existing_bracketed_parts(self):
+        repo = self.repo
+        blk = repo.create_element("Block", name="A", properties={"partProperties": "B"})
+        part_blk = repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(blk.elem_id, ibd.diag_id)
+
+        p1 = repo.create_element("Part", name="B[1]", properties={"definition": part_blk.elem_id})
+        p2 = repo.create_element("Part", name="B[2]", properties={"definition": part_blk.elem_id})
+        repo.add_element_to_diagram(ibd.diag_id, p1.elem_id)
+        repo.add_element_to_diagram(ibd.diag_id, p2.elem_id)
+        ibd.objects.append({"obj_id": 1, "obj_type": "Part", "x": 0, "y": 0, "element_id": p1.elem_id, "properties": {"definition": part_blk.elem_id}})
+        ibd.objects.append({"obj_id": 2, "obj_type": "Part", "x": 0, "y": 0, "element_id": p2.elem_id, "properties": {"definition": part_blk.elem_id}})
+
+        _sync_ibd_partproperty_parts(repo, blk.elem_id, visible=True)
+        parts = [o for o in ibd.objects if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part_blk.elem_id]
+        self.assertEqual(len(parts), 2)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- avoid copying parts with the same canonical name when inheriting
- handle underscore numbering in `_part_prop_key`
- add regression test for preserving inherited parts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688cc776efbc8325b9a47170ede9974d