### PR TITLE
Clear previous model when starting new project

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -7847,6 +7847,8 @@ class FaultTreeApp:
         self.canvas.delete("all")
 
         global AutoML_Helper, unique_node_id_counter
+        # Reset the SysML repository so previous project data is discarded
+        SysMLRepository.reset_instance()
         AutoML_Helper = AutoMLHelper()
         unique_node_id_counter = 1
         self.zoom = 1.0

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -100,6 +100,12 @@ class SysMLRepository:
             cls._instance = SysMLRepository()
         return cls._instance
 
+    @classmethod
+    def reset_instance(cls) -> "SysMLRepository":
+        """Return a fresh repository instance, clearing all current data."""
+        cls._instance = SysMLRepository()
+        return cls._instance
+
     # ------------------------------------------------------------
     # Undo support
     # ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `reset_instance` helper to SysML repository
- call `reset_instance` inside `new_model` so old SysML data isn't reused

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688cdf9c0da88325956623879092e171