### PR TITLE
Enforce generalization cycle rules

### DIFF
--- a/tests/test_generalization_validation.py
+++ b/tests/test_generalization_validation.py
@@ -31,6 +31,19 @@ class GeneralizationValidationTests(unittest.TestCase):
         )
         self.assertFalse(valid)
 
+    def test_cycle_invalid(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        repo.create_relationship("Generalization", b.elem_id, a.elem_id)
+        win = DummyWindow()
+        src = SysMLObject(1, "Block", 0, 0, element_id=a.elem_id)
+        dst = SysMLObject(2, "Block", 0, 0, element_id=b.elem_id)
+        valid, _ = SysMLDiagramWindow.validate_connection(
+            win, src, dst, "Generalization"
+        )
+        self.assertFalse(valid)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- prevent circular generalization relationships
- test that generalization cycles are rejected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_b_688d61146b1483279c52771911a3964e