### PR TITLE
Prevent cyclic generalizations

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2680,6 +2680,12 @@ class SysMLDiagramWindow(tk.Frame):
                     self.repo, src.element_id, dst.element_id
                 ):
                     return False, "Blocks already share a generalized parent"
+                if dst.element_id in _collect_generalization_parents(
+                    self.repo, src.element_id
+                ) or src.element_id in _collect_generalization_parents(
+                    self.repo, dst.element_id
+                ):
+                    return False, "Blocks cannot generalize each other"
             elif conn_type in ("Aggregation", "Composite Aggregation"):
                 if src.obj_type != "Block" or dst.obj_type != "Block":
                     return False, "Aggregations must connect Blocks"

--- a/tests/test_generalization_validation.py
+++ b/tests/test_generalization_validation.py
@@ -31,6 +31,34 @@ class GeneralizationValidationTests(unittest.TestCase):
         )
         self.assertFalse(valid)
 
+    def test_reciprocal_generalization_invalid(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        repo.create_relationship("Generalization", a.elem_id, b.elem_id)
+        win = DummyWindow()
+        src = SysMLObject(1, "Block", 0, 0, element_id=b.elem_id)
+        dst = SysMLObject(2, "Block", 0, 0, element_id=a.elem_id)
+        valid, _ = SysMLDiagramWindow.validate_connection(
+            win, src, dst, "Generalization"
+        )
+        self.assertFalse(valid)
+
+    def test_cycle_generalization_invalid(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        c = repo.create_element("Block", name="C")
+        repo.create_relationship("Generalization", b.elem_id, a.elem_id)
+        repo.create_relationship("Generalization", c.elem_id, b.elem_id)
+        win = DummyWindow()
+        src = SysMLObject(3, "Block", 0, 0, element_id=a.elem_id)
+        dst = SysMLObject(4, "Block", 0, 0, element_id=c.elem_id)
+        valid, _ = SysMLDiagramWindow.validate_connection(
+            win, src, dst, "Generalization"
+        )
+        self.assertFalse(valid)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- forbid creating cyclic generalization relationships
- test invalid reciprocal and cycle generalizations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_b_688d61146b1483279c52771911a3964e