### PR TITLE
Ensure control flow connectors stay vertical

### DIFF
--- a/tests/test_control_flow_arrow.py
+++ b/tests/test_control_flow_arrow.py
@@ -1,0 +1,51 @@
+import unittest
+import tkinter as tk
+from gui.architecture import SysMLDiagramWindow, SysMLObject, DiagramConnection
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+
+class DummyCanvas:
+    def __init__(self):
+        self.last_line = None
+    def create_line(self, *args, **kwargs):
+        self.last_line = (args, kwargs)
+    def create_text(self, *args, **kwargs):
+        pass
+
+
+class DummyWindow:
+    def __init__(self):
+        self.repo = SysMLRepository.get_instance()
+        diag = SysMLDiagram(diag_id="d", diag_type="Control Flow Diagram")
+        self.repo.diagrams[diag.diag_id] = diag
+        self.diagram_id = diag.diag_id
+        self.zoom = 1
+        self.font = None
+        self.canvas = DummyCanvas()
+        self.edge_point = lambda obj, _x, _y, _r: (obj.x, obj.y)
+
+
+def reset_repo():
+    SysMLRepository._instance = None
+    return SysMLRepository.get_instance()
+
+
+class ControlFlowArrowTests(unittest.TestCase):
+    def setUp(self):
+        reset_repo()
+
+    def test_arrow_up(self):
+        win = DummyWindow()
+        a = SysMLObject(1, "Existing Element", 0, 100)
+        b = SysMLObject(2, "Existing Element", 0, 0)
+        conn = DiagramConnection(1, 2, "Control Action")
+        SysMLDiagramWindow.draw_connection(win, a, b, conn)
+        args, kwargs = win.canvas.last_line
+        self.assertEqual(kwargs.get("arrow"), tk.LAST)
+        x1, y1, x2, y2 = args
+        self.assertEqual(x1, x2)
+        self.assertGreater(y1, y2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_control_flow_drag.py
+++ b/tests/test_control_flow_drag.py
@@ -1,0 +1,43 @@
+import unittest
+from gui.architecture import SysMLDiagramWindow, SysMLObject, DiagramConnection
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+
+class DummyWindow:
+    def __init__(self):
+        self.repo = SysMLRepository.get_instance()
+        diag = SysMLDiagram(diag_id="d", diag_type="Control Flow Diagram")
+        self.repo.diagrams[diag.diag_id] = diag
+        self.diagram_id = diag.diag_id
+        self.objects = [
+            SysMLObject(1, "Existing Element", 0, 0),
+            SysMLObject(2, "Existing Element", 0, 100),
+        ]
+        self.connections = [DiagramConnection(1, 2, "Control Action")]
+
+
+def reset_repo():
+    SysMLRepository._instance = None
+    return SysMLRepository.get_instance()
+
+
+class ControlFlowDragTests(unittest.TestCase):
+    def setUp(self):
+        reset_repo()
+
+    def test_horizontal_move_restricted(self):
+        win = DummyWindow()
+        obj = win.objects[1]
+        new_x = SysMLDiagramWindow._constrain_horizontal_movement(win, obj, 50)
+        self.assertEqual(new_x, win.objects[0].x)
+
+    def test_unconnected_move_free(self):
+        win = DummyWindow()
+        obj = SysMLObject(3, "Existing Element", 50, 200)
+        win.objects.append(obj)
+        new_x = SysMLDiagramWindow._constrain_horizontal_movement(win, obj, 80)
+        self.assertEqual(new_x, 80)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- render existing elements in control-flow diagrams with solid outlines and gradient fills
- constrain horizontal movement so linked elements keep vertical connectors
- force control-flow connectors to draw vertically with upward arrowheads
- add unit tests for control-flow movement and connector orientation

## Testing
- `pip install networkx -q` *(fails: Could not find a version that satisfies the requirement networkx)*
- `PYTHONPATH=. pytest tests/test_control_flow_drag.py tests/test_control_flow_arrow.py tests/test_control_flow_vertical.py tests/test_control_flow_guard.py -q`


------
https://chatgpt.com/codex/tasks/task_b_688e434732788327b8b9e0e1828b4f02