### PR TITLE
Fix duplicate labels in control flow diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5159,17 +5159,19 @@ class SysMLDiagramWindow(tk.Frame):
                 outline=outline,
                 fill="",
             )
-            label = obj.properties.get("name", "")
-            if label:
-                lx = x
-                ly = y - h - 4 * self.zoom
-                self.canvas.create_text(
-                    lx,
-                    ly,
-                    text=label,
-                    anchor="s",
-                    font=self.font,
-                )
+            diag = self.repo.diagrams.get(self.diagram_id)
+            if not diag or diag.diag_type != "Control Flow Diagram":
+                label = obj.properties.get("name", "")
+                if label:
+                    lx = x
+                    ly = y - h - 4 * self.zoom
+                    self.canvas.create_text(
+                        lx,
+                        ly,
+                        text=label,
+                        anchor="s",
+                        font=self.font,
+                    )
         elif obj.obj_type in ("Action Usage", "Action", "CallBehaviorAction", "Part", "Port"):
             dash = ()
             if obj.obj_type == "Part":

--- a/tests/test_control_flow_label.py
+++ b/tests/test_control_flow_label.py
@@ -1,0 +1,73 @@
+import unittest
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+
+class DummyCanvas:
+    def __init__(self):
+        self.texts = []
+
+    def create_text(self, *args, **kwargs):
+        self.texts.append((args, kwargs))
+
+    def create_image(self, *args, **kwargs):
+        pass
+
+    def create_rectangle(self, *args, **kwargs):
+        pass
+
+    def create_polygon(self, *args, **kwargs):
+        pass
+
+    def create_line(self, *args, **kwargs):
+        pass
+
+    def create_oval(self, *args, **kwargs):
+        pass
+
+
+class DummyWindow:
+    def __init__(self):
+        self.repo = SysMLRepository.get_instance()
+        diag = SysMLDiagram(diag_id="d", diag_type="Control Flow Diagram")
+        self.repo.diagrams[diag.diag_id] = diag
+        self.diagram_id = diag.diag_id
+        self.zoom = 1
+        self.font = None
+        self.canvas = DummyCanvas()
+        self.gradient_cache = {}
+        self.selected_objs = []
+        self.selected_obj = None
+        self._draw_gradient_rect = lambda *args, **kwargs: None
+        self._create_round_rect = lambda *args, **kwargs: None
+        self._draw_subdiagram_marker = lambda *args, **kwargs: None
+
+
+class ControlFlowLabelTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+
+    def test_existing_element_single_label(self):
+        win = DummyWindow()
+        element = win.repo.create_element("Block", name="Controller")
+        win.repo.add_element_to_diagram(win.diagram_id, element.elem_id)
+        obj = SysMLObject(
+            1,
+            "Existing Element",
+            10,
+            20,
+            width=40,
+            height=20,
+            element_id=element.elem_id,
+            properties={"name": element.name},
+        )
+        SysMLDiagramWindow.draw_object(win, obj)
+        self.assertEqual(len(win.canvas.texts), 1)
+        args, kwargs = win.canvas.texts[0]
+        self.assertEqual((args[0], args[1]), (obj.x, obj.y))
+        self.assertEqual(kwargs.get("anchor"), "center")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid drawing external labels for existing elements on control flow diagrams
- add regression test ensuring only a single label appears inside each element

## Testing
- `pytest` *(fails: No module named 'networkx')*
- `pip install networkx` *(fails: Could not find a version that satisfies the requirement networkx)*
- `PYTHONPATH=. pytest tests/test_control_flow_label.py`


------
https://chatgpt.com/codex/tasks/task_b_688e45dd0a208327a30d1c375e9f223a