### PR TITLE
Annotate control flow connections with stereotypes

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2472,6 +2472,14 @@ def format_control_flow_label(
         elem = repo.elements.get(conn.element_id)
         if elem:
             label = elem.name or ""
+    stereotype = ""
+    if diag_type == "Control Flow Diagram":
+        if conn.conn_type == "Control Action":
+            stereotype = "<<control action>>"
+        elif conn.conn_type == "Feedback":
+            stereotype = "<<feedback>>"
+    if stereotype:
+        label = f"{stereotype} {label}".strip()
     if diag_type == "Control Flow Diagram" and conn.conn_type in (
         "Control Action",
         "Feedback",
@@ -3089,8 +3097,15 @@ class SysMLDiagramWindow(tk.Frame):
                         src_id = self.start.element_id
                         dst_id = obj.element_id
                         if src_id and dst_id:
-                            rel = self.repo.create_relationship(t, src_id, dst_id)
-                            self.repo.add_relationship_to_diagram(self.diagram_id, rel.rel_id)
+                            stereo = (
+                                "control action" if t == "Control Action" else "feedback" if t == "Feedback" else None
+                            )
+                            rel = self.repo.create_relationship(
+                                t, src_id, dst_id, stereotype=stereo
+                            )
+                            self.repo.add_relationship_to_diagram(
+                                self.diagram_id, rel.rel_id
+                            )
                         self._sync_to_repository()
                         ConnectionDialog(self, conn)
                     else:
@@ -3594,10 +3609,20 @@ class SysMLDiagramWindow(tk.Frame):
                                     conn.arrow = "both"
                     self.connections.append(conn)
                     if self.start.element_id and obj.element_id:
-                        rel = self.repo.create_relationship(
-                            self.current_tool, self.start.element_id, obj.element_id
+                        stereo = (
+                            "control action"
+                            if self.current_tool == "Control Action"
+                            else "feedback" if self.current_tool == "Feedback" else None
                         )
-                        self.repo.add_relationship_to_diagram(self.diagram_id, rel.rel_id)
+                        rel = self.repo.create_relationship(
+                            self.current_tool,
+                            self.start.element_id,
+                            obj.element_id,
+                            stereotype=stereo,
+                        )
+                        self.repo.add_relationship_to_diagram(
+                            self.diagram_id, rel.rel_id
+                        )
                         if self.current_tool == "Generalization":
                             inherit_block_properties(self.repo, self.start.element_id)
                     self._sync_to_repository()

--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -305,6 +305,8 @@ class StpaWindow(tk.Frame):
                     label = format_control_flow_label(
                         conn_obj, repo, "Control Flow Diagram"
                     )
+                    if label.startswith("<<control action>>"):
+                        label = label[len("<<control action>>"):].strip()
                     if not label:
                         src_name = obj_map.get(conn_obj.src, str(conn_obj.src))
                         dst_name = obj_map.get(conn_obj.dst, str(conn_obj.dst))

--- a/tests/test_control_flow_guard.py
+++ b/tests/test_control_flow_guard.py
@@ -58,7 +58,7 @@ class ControlFlowGuardTests(unittest.TestCase):
         )
         diag.connections = [conn.__dict__]
         label = format_control_flow_label(conn, repo, "Control Flow Diagram")
-        self.assertEqual(label, "[g1\nAND g2\nOR g3] / Do")
+        self.assertEqual(label, "[g1\nAND g2\nOR g3] / <<control action>> Do")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_control_flow_stereotype.py
+++ b/tests/test_control_flow_stereotype.py
@@ -1,0 +1,86 @@
+import types
+import types
+import unittest
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+class DummyCanvas:
+    def canvasx(self, x):
+        return x
+
+    def canvasy(self, y):
+        return y
+
+    def configure(self, **kwargs):
+        pass
+
+
+class ControlFlowStereotypeTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+        from gui import architecture
+        self._orig_conn_dialog = architecture.ConnectionDialog
+
+    def tearDown(self):
+        from gui import architecture
+        architecture.ConnectionDialog = self._orig_conn_dialog
+
+    def _create_window(self, tool, src, dst, diag):
+        win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+        win.repo = self.repo
+        win.diagram_id = diag.diag_id
+        win.zoom = 1
+        win.canvas = DummyCanvas()
+        win.find_object = lambda x, y, prefer_port=False: src if win.start is None else dst
+        win.validate_connection = SysMLDiagramWindow.validate_connection.__get__(win, SysMLDiagramWindow)
+        win.update_property_view = lambda: None
+        win.redraw = lambda: None
+        win.current_tool = tool
+        win.start = None
+        win.temp_line_end = None
+        win.selected_obj = None
+        win.connections = []
+        win._sync_to_repository = lambda: None
+        from gui import architecture
+        architecture.ConnectionDialog = lambda *args, **kwargs: None
+        return win
+
+    def test_control_action_relationship_stereotype(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="A")
+        e2 = repo.create_element("Block", name="B")
+        diag = repo.create_diagram("Control Flow Diagram", name="CF")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(1, "Existing Element", 0, 0, element_id=e1.elem_id)
+        o2 = SysMLObject(2, "Existing Element", 0, 100, element_id=e2.elem_id)
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Control Action", o1, o2, diag)
+        event = types.SimpleNamespace(x=0, y=0, state=0)
+        SysMLDiagramWindow.on_left_press(win, event)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        SysMLDiagramWindow.on_left_press(win, event2)
+        self.assertEqual(repo.relationships[0].stereotype, "control action")
+
+    def test_feedback_relationship_stereotype(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="A")
+        e2 = repo.create_element("Block", name="B")
+        diag = repo.create_diagram("Control Flow Diagram", name="CF")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(1, "Existing Element", 0, 0, element_id=e1.elem_id)
+        o2 = SysMLObject(2, "Existing Element", 0, 100, element_id=e2.elem_id)
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Feedback", o1, o2, diag)
+        event = types.SimpleNamespace(x=0, y=0, state=0)
+        SysMLDiagramWindow.on_left_press(win, event)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        SysMLDiagramWindow.on_left_press(win, event2)
+        self.assertEqual(repo.relationships[0].stereotype, "feedback")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prefix control action and feedback connections on control flow diagrams with the `<<control action>>` or `<<feedback>>` stereotype
- record these stereotypes on the created relationships and strip them when collecting STPA actions
- add tests covering connection stereotype handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68950d4857c883258c39be1711da8d1e