### PR TITLE
Resize threat entry dialog and expose action buttons

### DIFF
--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -240,6 +240,7 @@ class ThreatDialog(simpledialog.Dialog):
         self.refresh_ds()
         return nb
 
+
     # ------------------------------------------------------------------
     # Data helpers
     # ------------------------------------------------------------------
@@ -524,16 +525,22 @@ class ThreatDialog(simpledialog.Dialog):
 
     # ------------------------------------------------------------------
     def buttonbox(self):
-        """Add visible OK/Cancel buttons to the dialog."""
+        """Add visible Accept/Cancel buttons and resize the dialog."""
         box = ttk.Frame(self)
-        ok_btn = ttk.Button(box, text="OK", width=10, command=self.ok)
+
+        ok_btn = ttk.Button(box, text="Accept", width=10, command=self.ok)
         ok_btn.pack(side=tk.LEFT, padx=5, pady=5)
         cancel_btn = ttk.Button(box, text="Cancel", width=10, command=self.cancel)
         cancel_btn.pack(side=tk.LEFT, padx=5, pady=5)
+
+        box.pack(side=tk.BOTTOM, fill=tk.X)
+
         self.bind("<Return>", self.ok)
         self.bind("<Escape>", self.cancel)
-        box.pack(side=tk.BOTTOM, fill=tk.X)
+
+        # Reduce dialog height to half while keeping computed width
         self.update_idletasks()
+        width = self.winfo_reqwidth()
         height = self.winfo_reqheight() // 2
-        self.geometry(f"700x{height}")
+        self.geometry(f"{width}x{height}")
         self.resizable(False, False)


### PR DESCRIPTION
## Summary
- Ensure Threat Entry dialog shows visible Accept/Cancel buttons
- Shrink dialog height to half of its default size for a more compact view

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b491b8c1c83259eaab5b66bdeda56