### PR TITLE
Add ISO 21448 validation formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1125,6 +1125,32 @@ Use **Export Product Goal Requirements** in the Requirements menu to generate a 
 
 The **Safety Performance Indicators** tab in the Requirements menu lists each product goal's validation target and acceptance criteria with their descriptions for quick reference.
 
+### Acceptance Criteria and Validation Targets
+
+ISO 21448 derives validation targets from an acceptance criterion using the rate
+of hazardous behaviour (*R*<sub>HB</sub>). For a hazardous behaviour with an
+acceptance criterion *A*<sub>H</sub> and the probabilities of exposure,
+uncontrollability and severity ( *P*<sub>E&#124;HB</sub>,
+*P*<sub>C&#124;E</sub>, *P*<sub>S&#124;C</sub> ), the standard defines:
+
+```
+A_H = R_HB × P_E|HB × P_C|E × P_S|C
+R_HB = A_H / (P_E|HB × P_C|E × P_S|C)
+```
+
+The resulting *R*<sub>HB</sub> can be used to determine the validation effort.
+Assuming no hazardous behaviour is observed during testing, the duration needed
+to meet the acceptance criterion with confidence *C* is:
+
+```
+T = -ln(1 - C) / R_HB
+```
+
+For example, if *A*<sub>H</sub> = 10⁻⁸/h,
+*P*<sub>E&#124;HB</sub> = 5 %, *P*<sub>C&#124;E</sub> = 10 % and
+*P*<sub>S&#124;C</sub> = 1 %, then *R*<sub>HB</sub> = 2×10⁻⁴/h. Demonstrating this
+with 63 % confidence requires roughly 5 000 h of fault‑free testing.
+
 ## Email Setup
 
 When sending review summaries, the application asks for SMTP settings and login details. If you use Gmail with two-factor authentication enabled, create an **app password** and enter it instead of your normal account password. Authentication failures will prompt you to re-enter these settings.

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,0 +1,9 @@
+"""Analysis utilities for AutoML."""
+
+from .sotif_validation import acceptance_rate, hazardous_behavior_rate, validation_time
+
+__all__ = [
+    "acceptance_rate",
+    "hazardous_behavior_rate",
+    "validation_time",
+]

--- a/analysis/sotif_validation.py
+++ b/analysis/sotif_validation.py
@@ -1,0 +1,89 @@
+"""Utilities for acceptance criteria and validation targets per ISO 21448.
+
+This module provides helper functions to derive the rate of hazardous behaviour
+(RHB) and the associated validation time from an acceptance criterion as
+specified in ISO 21448:2022, Annex C. The formulas implemented here correspond
+to equations (C.1) and (C.2) and assume rates are expressed per hour.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def hazardous_behavior_rate(
+    acceptance_rate: float,
+    p_exposure_given_hb: float,
+    p_uncontrollable_given_exposure: float,
+    p_severity_given_uncontrollable: float,
+) -> float:
+    """Derive the rate of hazardous behaviour.
+
+    Parameters
+    ----------
+    acceptance_rate:
+        The acceptance criterion :math:`A_H` (e.g. ``1e-8`` per hour).
+    p_exposure_given_hb:
+        Probability :math:`P_{E|HB}` that the hazardous behaviour occurs in a
+        scenario leading to harm.
+    p_uncontrollable_given_exposure:
+        Probability :math:`P_{C|E}` that the hazardous behaviour cannot be
+        controlled once exposed.
+    p_severity_given_uncontrollable:
+        Probability :math:`P_{S|C}` that the resulting harm reaches the
+        considered severity.
+
+    Returns
+    -------
+    float
+        Rate of hazardous behaviour :math:`R_{HB}` derived using ISO 21448
+        Formula (C.2):
+
+        ``RHB = AH / (P_E|HB * P_C|E * P_S|C)``
+    """
+
+    denominator = (
+        p_exposure_given_hb * p_uncontrollable_given_exposure * p_severity_given_uncontrollable
+    )
+    if denominator <= 0:
+        raise ValueError("Probabilities must be > 0")
+    return acceptance_rate / denominator
+
+
+def acceptance_rate(
+    hazardous_behavior_rate: float,
+    p_exposure_given_hb: float,
+    p_uncontrollable_given_exposure: float,
+    p_severity_given_uncontrollable: float,
+) -> float:
+    """Compute the acceptance rate from the hazardous behaviour rate.
+
+    Implements ISO 21448 Formula (C.1):
+
+    ``AH = RHB * P_E|HB * P_C|E * P_S|C``
+    """
+
+    return (
+        hazardous_behavior_rate
+        * p_exposure_given_hb
+        * p_uncontrollable_given_exposure
+        * p_severity_given_uncontrollable
+    )
+
+
+def validation_time(hazardous_behavior_rate: float, confidence: float) -> float:
+    """Calculate required test time to demonstrate the acceptance criterion.
+
+    Assumes no hazardous behaviour occurs during testing and uses a Poisson
+    distribution to derive the required duration. The formula is::
+
+        T = -ln(1 - C) / RHB
+
+    where ``C`` is the desired confidence level (e.g. ``0.63`` for 63 %).
+    """
+
+    if not 0 < confidence < 1:
+        raise ValueError("confidence must be between 0 and 1")
+    if hazardous_behavior_rate <= 0:
+        raise ValueError("hazardous_behavior_rate must be > 0")
+    return -math.log(1 - confidence) / hazardous_behavior_rate

--- a/tests/test_sotif_validation.py
+++ b/tests/test_sotif_validation.py
@@ -1,0 +1,29 @@
+import math
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.sotif_validation import (
+    acceptance_rate,
+    hazardous_behavior_rate,
+    validation_time,
+)
+
+
+def test_hazardous_behavior_rate_example():
+    # Example values from ISO 21448 Annex C.2.1
+    ah = 1e-8  # acceptance criterion per hour
+    p_e_hb = 0.05
+    p_c_e = 0.1
+    p_s_c = 0.01
+
+    rhb = hazardous_behavior_rate(ah, p_e_hb, p_c_e, p_s_c)
+    assert math.isclose(rhb, 2e-4, rel_tol=1e-9)
+
+    # Round-trip check using Formula C.1
+    assert math.isclose(acceptance_rate(rhb, p_e_hb, p_c_e, p_s_c), ah, rel_tol=1e-9)
+
+    # Validation time for ~63% confidence with zero failures
+    t = validation_time(rhb, 0.63)
+    assert 4900 < t < 5100


### PR DESCRIPTION
## Summary
- introduce SOTIF helper to derive hazardous behaviour rates and validation time from acceptance criteria
- document ISO 21448 formulas for acceptance criteria and validation targets in README
- cover new calculations with unit tests

## Testing
- `pytest tests/test_sotif_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689b4b1f38d883258df43a2d46e88197