### PR TITLE
Add confusion matrix visualization to ODD element editor

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,9 +1,17 @@
 """Analysis utilities for AutoML."""
 
 from .sotif_validation import acceptance_rate, hazardous_behavior_rate, validation_time
+from .confusion_matrix import (
+    compute_metrics,
+    counts_from_metrics,
+    counts_from_validation,
+)
 
 __all__ = [
     "acceptance_rate",
     "hazardous_behavior_rate",
     "validation_time",
+    "compute_metrics",
+    "counts_from_metrics",
+    "counts_from_validation",
 ]

--- a/analysis/confusion_matrix.py
+++ b/analysis/confusion_matrix.py
@@ -1,0 +1,116 @@
+"""Confusion matrix utilities."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Tuple
+
+
+def compute_metrics(tp: float, fp: float, tn: float, fn: float) -> Dict[str, float]:
+    """Compute common classification metrics from confusion matrix counts.
+
+    Parameters
+    ----------
+    tp, fp, tn, fn:
+        True positives, false positives, true negatives and false negatives.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys ``accuracy``, ``precision``, ``recall`` and ``f1``.
+    """
+    tp = float(tp)
+    fp = float(fp)
+    tn = float(tn)
+    fn = float(fn)
+    total = tp + fp + tn + fn
+    accuracy = (tp + tn) / total if total else 0.0
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    return {
+        "accuracy": accuracy,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+    }
+
+
+def counts_from_metrics(accuracy: float, precision: float, recall: float) -> Dict[str, float]:
+    """Estimate confusion matrix counts from classification metrics.
+
+    The returned counts are normalised such that ``tp`` is 1.0 and the
+    remaining values are scaled accordingly. This is sufficient for visualising
+    the relative distribution of outcomes when only the desired metrics are
+    known.
+
+    Parameters
+    ----------
+    accuracy, precision, recall:
+        Desired metrics in the range ``[0, 1]``. ``f1`` is implicitly derived
+        from ``precision`` and ``recall``.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys ``tp``, ``fp``, ``tn`` and ``fn``.
+    """
+
+    # Avoid division by zero – return an all-zero matrix if any metric is
+    # degenerate.
+    if precision <= 0 or recall <= 0:
+        return {"tp": 0.0, "fp": 0.0, "tn": 0.0, "fn": 0.0}
+    if accuracy >= 1.0:
+        return {"tp": 1.0, "fp": 0.0, "tn": 1.0, "fn": 0.0}
+
+    tp = 1.0
+    fp = tp * (1.0 / precision - 1.0)
+    fn = tp * (1.0 / recall - 1.0)
+
+    denominator = 1.0 - accuracy
+    if denominator <= 0:
+        return {"tp": 0.0, "fp": 0.0, "tn": 0.0, "fn": 0.0}
+
+    total = (fp + fn) / denominator
+    tn = accuracy * total - tp
+
+    return {"tp": tp, "fp": fp, "tn": tn, "fn": fn}
+
+
+def counts_from_validation(entries: Iterable[Tuple[float, float, float]]) -> Dict[str, float]:
+    """Derive confusion matrix counts from validation results.
+
+    Each entry is a tuple ``(result, target, acceptance)`` where ``result`` is
+    the measured hazardous behaviour rate, ``target`` is the validation target
+    and ``acceptance`` is the acceptance criterion.  The predicted class is
+    determined by comparing ``result`` against ``target`` while the ground truth
+    uses ``acceptance``.
+
+    Parameters
+    ----------
+    entries:
+        Iterable of ``(result, target, acceptance)`` values.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys ``tp``, ``fp``, ``tn`` and ``fn``.
+    """
+
+    counts = {"tp": 0.0, "fp": 0.0, "tn": 0.0, "fn": 0.0}
+    for result, target, acceptance in entries:
+        result = float(result)
+        target = float(target)
+        acceptance = float(acceptance)
+        # Predicted positive if result exceeds the validation target.
+        predicted_positive = result > target
+        # Actual positive if result exceeds the acceptance criterion.
+        actual_positive = result > acceptance
+        if predicted_positive and actual_positive:
+            counts["tp"] += 1
+        elif predicted_positive and not actual_positive:
+            counts["fp"] += 1
+        elif not predicted_positive and actual_positive:
+            counts["fn"] += 1
+        else:
+            counts["tn"] += 1
+    return counts
+

--- a/tests/test_confusion_matrix.py
+++ b/tests/test_confusion_matrix.py
@@ -1,0 +1,50 @@
+import math
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from analysis.confusion_matrix import (
+    compute_metrics,
+    counts_from_metrics,
+    counts_from_validation,
+)
+
+
+def test_compute_metrics_basic():
+    metrics = compute_metrics(50, 10, 30, 10)
+    assert math.isclose(metrics["accuracy"], (50 + 30) / (50 + 10 + 30 + 10))
+    assert math.isclose(metrics["precision"], 50 / (50 + 10))
+    assert math.isclose(metrics["recall"], 50 / (50 + 10))
+    prec = 50 / (50 + 10)
+    rec = 50 / (50 + 10)
+    expected_f1 = 2 * prec * rec / (prec + rec)
+    assert math.isclose(metrics["f1"], expected_f1)
+
+
+def test_compute_metrics_zero_division():
+    metrics = compute_metrics(0, 0, 0, 0)
+    assert metrics["accuracy"] == 0.0
+    assert metrics["precision"] == 0.0
+    assert metrics["recall"] == 0.0
+    assert metrics["f1"] == 0.0
+
+
+def test_counts_from_validation():
+    entries = [
+        (2e-5, 1e-5, 1e-6),  # TP
+        (5e-7, 1e-5, 1e-6),  # TN
+        (2e-5, 1e-6, 1e-4),  # FP
+        (2e-5, 5e-5, 1e-6),  # FN
+    ]
+    counts = counts_from_validation(entries)
+    assert counts == {"tp": 1.0, "tn": 1.0, "fp": 1.0, "fn": 1.0}
+
+
+def test_counts_from_metrics_round_trip():
+    counts = counts_from_metrics(0.9, 0.8, 0.7)
+    metrics = compute_metrics(
+        counts["tp"], counts["fp"], counts["tn"], counts["fn"]
+    )
+    assert math.isclose(metrics["accuracy"], 0.9, rel_tol=1e-6)
+    assert math.isclose(metrics["precision"], 0.8, rel_tol=1e-6)
+    assert math.isclose(metrics["recall"], 0.7, rel_tol=1e-6)


### PR DESCRIPTION
## Summary
- derive confusion counts from desired metrics via new `counts_from_metrics` helper
- compute confusion metrics for each ODD element from the worst associated validation target
- expose metric-based confusion helper and add unit test round-tripping metrics to counts
- avoid persisting derived accuracy, precision, recall, and F1 metrics on ODD elements

## Testing
- `pytest tests/test_confusion_matrix.py`


------
https://chatgpt.com/codex/tasks/task_b_689b600017a88325a2c477ec2f43de6f