### PR TITLE
Enable editing of risk assessment document links

### DIFF
--- a/tests/test_edit_risk_assessment.py
+++ b/tests/test_edit_risk_assessment.py
@@ -1,0 +1,34 @@
+import types
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.models import HaraDoc
+from gui.toolboxes import RiskAssessmentWindow
+
+
+def test_edit_doc_updates_selections(monkeypatch):
+    doc = HaraDoc("RA1", ["HZ1"], [], False, "draft", stpa="STPA1", threat="TA1")
+    app = types.SimpleNamespace(
+        active_hara=doc,
+        hara_docs=[doc],
+        update_views=lambda: None,
+    )
+
+    window = RiskAssessmentWindow.__new__(RiskAssessmentWindow)
+    window.app = app
+    window.refresh_docs = lambda: None
+    window.refresh = lambda: None
+
+    class DummyDialog:
+        def __init__(self, *a, **k):
+            self.result = ("HZ2", "STPA2", "TA2")
+
+    monkeypatch.setattr(RiskAssessmentWindow, "EditAssessmentDialog", DummyDialog)
+
+    window.edit_doc()
+
+    assert doc.hazops == ["HZ2"]
+    assert doc.stpa == "STPA2"
+    assert doc.threat == "TA2"


### PR DESCRIPTION
## Summary
- add Edit button in risk assessment window for modifying linked HAZOP, STPA and threat analyses
- implement dialog and handler to update document associations
- cover edit flow with unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b6f98cb6083258aa233a9be347692