### PR TITLE
Derive confusion counts from validation targets

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14123,28 +14123,47 @@ class FaultTreeApp:
                 nb.add(self.attr_frame, text="Attributes")
                 self.attr_rows = []
                 for k, v in self.data.items():
-                    if k not in {"name", "tp", "fp", "tn", "fn"}:
+                    if k not in {"name", "p", "n", "tp", "fp", "tn", "fn"}:
                         self.add_attr_row(k, v)
                 ttk.Button(self.attr_frame, text="Add Attribute", command=self.add_attr_row).grid(row=99, column=0, columnspan=2, pady=5)
 
                 # Confusion matrix tab
                 cm_frame = ttk.Frame(nb)
                 nb.add(cm_frame, text="Confusion Matrix")
+                self.p_var = tk.DoubleVar(value=float(self.data.get("p", 0) or 0))
+                self.n_var = tk.DoubleVar(value=float(self.data.get("n", 0) or 0))
                 self.tp_var = tk.DoubleVar(value=float(self.data.get("tp", 0) or 0))
                 self.fp_var = tk.DoubleVar(value=float(self.data.get("fp", 0) or 0))
                 self.tn_var = tk.DoubleVar(value=float(self.data.get("tn", 0) or 0))
                 self.fn_var = tk.DoubleVar(value=float(self.data.get("fn", 0) or 0))
+                self.vt_type_var = tk.StringVar(value="FP")
+
+                inputs = ttk.Frame(cm_frame)
+                inputs.grid(row=0, column=0, pady=5)
+                ttk.Label(inputs, text="Actual P").grid(row=0, column=0)
+                ttk.Entry(inputs, textvariable=self.p_var, width=6).grid(row=0, column=1)
+                ttk.Label(inputs, text="Actual N").grid(row=0, column=2)
+                ttk.Entry(inputs, textvariable=self.n_var, width=6).grid(row=0, column=3)
+                ttk.Label(inputs, text="Type").grid(row=0, column=4)
+                type_box = ttk.Combobox(
+                    inputs,
+                    values=["TP", "FP", "TN", "FN"],
+                    textvariable=self.vt_type_var,
+                    width=5,
+                    state="readonly",
+                )
+                type_box.grid(row=0, column=5)
 
                 matrix = ttk.Frame(cm_frame)
-                matrix.grid(row=0, column=0, pady=5)
+                matrix.grid(row=1, column=0, pady=5)
                 ttk.Label(matrix, text="TP").grid(row=0, column=0)
-                ttk.Entry(matrix, textvariable=self.tp_var, width=6).grid(row=0, column=1)
+                ttk.Label(matrix, textvariable=self.tp_var, width=6).grid(row=0, column=1)
                 ttk.Label(matrix, text="FN").grid(row=0, column=2)
-                ttk.Entry(matrix, textvariable=self.fn_var, width=6).grid(row=0, column=3)
+                ttk.Label(matrix, textvariable=self.fn_var, width=6).grid(row=0, column=3)
                 ttk.Label(matrix, text="FP").grid(row=1, column=0)
-                ttk.Entry(matrix, textvariable=self.fp_var, width=6).grid(row=1, column=1)
+                ttk.Label(matrix, textvariable=self.fp_var, width=6).grid(row=1, column=1)
                 ttk.Label(matrix, text="TN").grid(row=1, column=2)
-                ttk.Entry(matrix, textvariable=self.tn_var, width=6).grid(row=1, column=3)
+                ttk.Label(matrix, textvariable=self.tn_var, width=6).grid(row=1, column=3)
 
                 metrics_frame = ttk.Frame(cm_frame)
                 metrics_frame.grid(row=1, column=0, sticky="nsew")
@@ -14156,26 +14175,61 @@ class FaultTreeApp:
                 self.prec_var = tk.StringVar()
                 self.rec_var = tk.StringVar()
                 self.f1_var = tk.StringVar()
+                self.tpr_var = tk.StringVar()
+                self.tnr_var = tk.StringVar()
+                self.fpr_var = tk.StringVar()
+                self.fnr_var = tk.StringVar()
                 ttk.Label(metrics_frame, textvariable=self.acc_var).grid(row=0, column=1, sticky="w")
                 ttk.Label(metrics_frame, textvariable=self.prec_var).grid(row=1, column=1, sticky="w")
                 ttk.Label(metrics_frame, textvariable=self.rec_var).grid(row=2, column=1, sticky="w")
                 ttk.Label(metrics_frame, textvariable=self.f1_var).grid(row=3, column=1, sticky="w")
+                ttk.Label(metrics_frame, text="TPR:").grid(row=4, column=0, sticky="e")
+                ttk.Label(metrics_frame, text="TNR:").grid(row=5, column=0, sticky="e")
+                ttk.Label(metrics_frame, text="FPR:").grid(row=6, column=0, sticky="e")
+                ttk.Label(metrics_frame, text="FNR:").grid(row=7, column=0, sticky="e")
+                ttk.Label(metrics_frame, textvariable=self.tpr_var).grid(row=4, column=1, sticky="w")
+                ttk.Label(metrics_frame, textvariable=self.tnr_var).grid(row=5, column=1, sticky="w")
+                ttk.Label(metrics_frame, textvariable=self.fpr_var).grid(row=6, column=1, sticky="w")
+                ttk.Label(metrics_frame, textvariable=self.fnr_var).grid(row=7, column=1, sticky="w")
 
                 def update_metrics(*_):
-                    from analysis.confusion_matrix import compute_metrics
+                    from analysis.confusion_matrix import compute_metrics, compute_rates
 
-                    tp = self.tp_var.get()
-                    fp = self.fp_var.get()
-                    tn = self.tn_var.get()
-                    fn = self.fn_var.get()
-                    metrics = compute_metrics(tp, fp, tn, fn)
+                    p = self.p_var.get()
+                    n = self.n_var.get()
+                    tau_on = getattr(self, "current_tau_on", 0.0)
+                    val_target = None
+                    if getattr(self, "selected_goal", None) is not None:
+                        val_target = getattr(self.selected_goal, "validation_target", None)
+                    rates = compute_rates(
+                        hours=tau_on or 0.0,
+                        validation_target=val_target,
+                        p=p,
+                        n=n,
+                        target_type=self.vt_type_var.get().lower(),
+                    )
+                    self.tp_var.set(rates["tp"])
+                    self.fp_var.set(rates["fp"])
+                    self.tn_var.set(rates["tn"])
+                    self.fn_var.set(rates["fn"])
+                    metrics = compute_metrics(rates["tp"], rates["fp"], rates["tn"], rates["fn"])
+                    self.tpr_var.set(f"{rates['tpr']:.3f}")
+                    self.tnr_var.set(f"{rates['tnr']:.3f}")
+                    self.fpr_var.set(f"{rates['fpr']:.3f}")
+                    self.fnr_var.set(f"{rates['fnr']:.3f}")
                     self.acc_var.set(f"{metrics['accuracy']:.3f}")
                     self.prec_var.set(f"{metrics['precision']:.3f}")
                     self.rec_var.set(f"{metrics['recall']:.3f}")
                     self.f1_var.set(f"{metrics['f1']:.3f}")
 
-                for var in (self.tp_var, self.fp_var, self.tn_var, self.fn_var):
+                def on_type_change(*_):
+                    if getattr(self, "selected_goal", None) is not None:
+                        setattr(self.selected_goal, "cm_type", self.vt_type_var.get().lower())
+                    update_metrics()
+
+                for var in (self.p_var, self.n_var):
                     var.trace_add("write", update_metrics)
+                self.vt_type_var.trace_add("write", on_type_change)
                 update_metrics()
 
                 vt_frame = ttk.Frame(cm_frame)
@@ -14194,12 +14248,37 @@ class FaultTreeApp:
                     width = 120 if c in ("Product Goal", "Validation Target") else 200
                     self.vt_tree.column(c, width=width, anchor="center")
                 self.vt_tree.pack(fill=tk.BOTH, expand=True)
+                self.vt_item_to_goal = {}
+                self.selected_goal = None
+                self.current_tau_on = 0.0
+
+                def on_vt_select(event=None):
+                    sel = self.vt_tree.selection()
+                    if not sel:
+                        self.selected_goal = None
+                        self.current_tau_on = 0.0
+                    else:
+                        sg = self.vt_item_to_goal.get(sel[0])
+                        self.selected_goal = sg
+                        tau_on = 0.0
+                        mp_name = getattr(sg, "mission_profile", "")
+                        if mp_name:
+                            for mp in self.app.mission_profiles:
+                                if mp.name == mp_name:
+                                    tau_on = mp.tau_on
+                                    break
+                        self.current_tau_on = tau_on
+                        self.vt_type_var.set(getattr(sg, "cm_type", "fp").upper())
+                    update_metrics()
+
+                self.vt_tree.bind("<<TreeviewSelect>>", on_vt_select)
 
                 def refresh_vt(*_):
                     self.vt_tree.delete(*self.vt_tree.get_children())
+                    self.vt_item_to_goal.clear()
                     name = self.name_var.get().strip()
                     for sg in self.app.get_validation_targets_for_odd(name):
-                        self.vt_tree.insert(
+                        iid = self.vt_tree.insert(
                             "",
                             "end",
                             values=[
@@ -14209,6 +14288,11 @@ class FaultTreeApp:
                                 getattr(sg, "acceptance_criteria", ""),
                             ],
                         )
+                        self.vt_item_to_goal[iid] = sg
+                    items = self.vt_tree.get_children()
+                    if items:
+                        self.vt_tree.selection_set(items[0])
+                        on_vt_select()
 
                 refresh_vt()
                 self.name_var.trace_add("write", refresh_vt)
@@ -14219,14 +14303,28 @@ class FaultTreeApp:
                     key = k_var.get().strip()
                     if key:
                         new_data[key] = v_var.get()
-                tp = float(self.tp_var.get())
-                fp = float(self.fp_var.get())
-                tn = float(self.tn_var.get())
-                fn = float(self.fn_var.get())
-                from analysis.confusion_matrix import compute_metrics
+                p = float(self.p_var.get())
+                n = float(self.n_var.get())
+                from analysis.confusion_matrix import compute_metrics, compute_rates
 
-                new_data.update({"tp": tp, "fp": fp, "tn": tn, "fn": fn})
-                new_data.update(compute_metrics(tp, fp, tn, fn))
+                tau_on = getattr(self, "current_tau_on", 0.0)
+                val_target = None
+                if getattr(self, "selected_goal", None) is not None:
+                    val_target = getattr(self.selected_goal, "validation_target", None)
+                rates = compute_rates(
+                    hours=tau_on or 0.0,
+                    validation_target=val_target,
+                    p=p,
+                    n=n,
+                    target_type=self.vt_type_var.get().lower(),
+                )
+                metrics = compute_metrics(rates["tp"], rates["fp"], rates["tn"], rates["fn"])
+                new_data.update({
+                    "p": p,
+                    "n": n,
+                })
+                new_data.update(rates)
+                new_data.update(metrics)
                 self.data = new_data
 
         def add_lib():

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,11 +1,13 @@
 """Analysis utilities for AutoML."""
 
 from .sotif_validation import acceptance_rate, hazardous_behavior_rate, validation_time
-from .confusion_matrix import compute_metrics
+from .confusion_matrix import compute_metrics, compute_counts, compute_rates
 
 __all__ = [
     "acceptance_rate",
     "hazardous_behavior_rate",
     "validation_time",
     "compute_metrics",
+    "compute_counts",
+    "compute_rates",
 ]

--- a/analysis/confusion_matrix.py
+++ b/analysis/confusion_matrix.py
@@ -32,3 +32,167 @@ def compute_metrics(tp: float, fp: float, tn: float, fn: float) -> Dict[str, flo
         "recall": recall,
         "f1": f1,
     }
+
+
+def compute_counts(
+    tp: float | None = None,
+    fp: float | None = None,
+    tn: float | None = None,
+    fn: float | None = None,
+    *,
+    hours: float = 0.0,
+    validation_target: float | None = None,
+    p: float | None = None,
+    n: float | None = None,
+    target_type: str = "fp",
+) -> Dict[str, float]:
+    """Derive confusion-matrix counts from dataset size and a target rate.
+
+    The helper operates on explicit confusion-matrix counts (``tp``, ``fp``,
+    ``tn``, ``fn``) or, when these are not provided, derives one of the counts
+    from an allowed event rate (``validation_target``, in events/hour) over a
+    mission duration ``hours``. The ``target_type`` argument indicates which
+    confusion-matrix term the validation target represents (``"tp"``,
+    ``"fp"``, ``"tn"`` or ``"fn"``).
+
+    Parameters
+    ----------
+    tp, fp, tn, fn:
+        Explicit confusion-matrix counts. If any are ``None`` then ``p`` and
+        ``n`` must be provided so counts can be derived from the target rate.
+    hours:
+        Total test duration in hours (mission profile ``TAU ON``).
+    validation_target:
+        Allowed events per hour for the selected validation target.
+    p, n:
+        Dataset sizes for actual positives and negatives. Required when
+        explicit confusion-matrix counts are not supplied.
+    target_type:
+        Which count the validation target constrains (``"tp"``, ``"fp"``,
+        ``"tn"`` or ``"fn"``).
+
+    Returns
+    -------
+    dict
+        Dictionary containing the confusion-matrix counts (``tp``, ``fp``,
+        ``tn``, ``fn``) and totals ``p`` and ``n``.
+    """
+
+    hours = float(hours)
+    if tp is None or fp is None or tn is None or fn is None:
+        if p is None or n is None:
+            raise ValueError(
+                "Either confusion matrix counts or dataset sizes P and N must be provided"
+            )
+        p = float(p)
+        n = float(n)
+        rate = float(validation_target or 0.0)
+        count = rate * hours
+        tt = target_type.lower()
+        if tt not in {"tp", "fp", "tn", "fn"}:
+            raise ValueError("target_type must be one of 'tp', 'fp', 'tn', 'fn'")
+        tp = p
+        tn = n
+        fp = 0.0
+        fn = 0.0
+        if tt == "fp":
+            fp = count
+            tn = max(n - fp, 0.0)
+        elif tt == "fn":
+            fn = count
+            tp = max(p - fn, 0.0)
+        elif tt == "tp":
+            tp = count
+            fn = max(p - tp, 0.0)
+        elif tt == "tn":
+            tn = count
+            fp = max(n - tn, 0.0)
+    else:
+        tp = float(tp)
+        fp = float(fp)
+        tn = float(tn)
+        fn = float(fn)
+        p = tp + fn
+        n = tn + fp
+
+    return {"tp": tp, "fp": fp, "tn": tn, "fn": fn, "p": p, "n": n}
+
+
+def compute_rates(
+    tp: float | None = None,
+    fp: float | None = None,
+    tn: float | None = None,
+    fn: float | None = None,
+    *,
+    hours: float = 0.0,
+    validation_target: float | None = None,
+    p: float | None = None,
+    n: float | None = None,
+    target_type: str = "fp",
+) -> Dict[str, float]:
+    """Compute confusion-matrix rates and per-hour limits.
+
+    Parameters
+    ----------
+    tp, fp, tn, fn:
+        Explicit confusion-matrix counts. If any are ``None`` then ``p`` and
+        ``n`` must be provided so counts can be derived from the target rate.
+    hours:
+        Total test duration in hours (mission profile ``TAU ON``).
+    validation_target:
+        Allowed events per hour for the selected validation target.
+    p, n:
+        Dataset sizes for actual positives and negatives. Required when
+        explicit confusion-matrix counts are not supplied.
+    target_type:
+        Which count the validation target constrains (``"tp"``, ``"fp"``,
+        ``"tn"`` or ``"fn"``).
+
+    Returns
+    -------
+    dict
+        Dictionary containing counts, dataset totals and rate metrics:
+        ``tpr``, ``tnr``, ``fpr`` and ``fnr``. Per-hour limits ``l_tp``,
+        ``l_tn``, ``l_fp`` and ``l_fn`` are also included.
+    """
+
+    counts = compute_counts(
+        tp,
+        fp,
+        tn,
+        fn,
+        hours=hours,
+        validation_target=validation_target,
+        p=p,
+        n=n,
+        target_type=target_type,
+    )
+
+    tp = counts["tp"]
+    fp = counts["fp"]
+    tn = counts["tn"]
+    fn = counts["fn"]
+    p = counts["p"]
+    n = counts["n"]
+
+    tpr = tp / p if p else 0.0
+    tnr = tn / n if n else 0.0
+    fpr = fp / n if n else 0.0
+    fnr = fn / p if p else 0.0
+
+    rate_tp = tp / hours if hours else 0.0
+    rate_tn = tn / hours if hours else 0.0
+    rate_fp = fp / hours if hours else 0.0
+    rate_fn = fn / hours if hours else 0.0
+
+    return {
+        **counts,
+        "tpr": tpr,
+        "tnr": tnr,
+        "fpr": fpr,
+        "fnr": fnr,
+        "l_tp": rate_tp,
+        "l_tn": rate_tn,
+        "l_fp": rate_fp,
+        "l_fn": rate_fn,
+    }

--- a/tests/test_confusion_matrix.py
+++ b/tests/test_confusion_matrix.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from analysis.confusion_matrix import compute_metrics
+from analysis.confusion_matrix import compute_metrics, compute_counts, compute_rates
 
 
 def test_compute_metrics_basic():
@@ -23,3 +23,71 @@ def test_compute_metrics_zero_division():
     assert metrics["precision"] == 0.0
     assert metrics["recall"] == 0.0
     assert metrics["f1"] == 0.0
+
+
+def test_compute_counts_basic():
+    counts = compute_counts(50, 10, 30, 10)
+    assert math.isclose(counts["tp"], 50)
+    assert math.isclose(counts["fp"], 10)
+    assert math.isclose(counts["tn"], 30)
+    assert math.isclose(counts["fn"], 10)
+    assert math.isclose(counts["p"], 60)
+    assert math.isclose(counts["n"], 40)
+
+
+def test_compute_counts_auto_fp():
+    counts = compute_counts(hours=100, validation_target=0.01, p=60, n=40, target_type="fp")
+    assert math.isclose(counts["fp"], 0.01 * 100)
+    assert math.isclose(counts["tn"], 40 - 0.01 * 100)
+    assert math.isclose(counts["tp"], 60)
+    assert math.isclose(counts["fn"], 0.0)
+    assert math.isclose(counts["p"], 60)
+    assert math.isclose(counts["n"], 40)
+
+
+def test_compute_counts_auto_fn():
+    counts = compute_counts(hours=100, validation_target=0.02, p=60, n=40, target_type="fn")
+    assert math.isclose(counts["fn"], 0.02 * 100)
+    assert math.isclose(counts["tp"], 60 - 0.02 * 100)
+    assert math.isclose(counts["tn"], 40)
+    assert math.isclose(counts["fp"], 0.0)
+
+
+def test_compute_counts_auto_tp():
+    counts = compute_counts(hours=100, validation_target=0.5, p=60, n=40, target_type="tp")
+    assert math.isclose(counts["tp"], 0.5 * 100)
+    assert math.isclose(counts["fn"], 60 - 0.5 * 100)
+    assert math.isclose(counts["tn"], 40)
+    assert math.isclose(counts["fp"], 0.0)
+
+
+def test_compute_counts_auto_tn():
+    counts = compute_counts(hours=100, validation_target=0.2, p=60, n=40, target_type="tn")
+    assert math.isclose(counts["tn"], 0.2 * 100)
+    assert math.isclose(counts["fp"], 40 - 0.2 * 100)
+    assert math.isclose(counts["tp"], 60)
+    assert math.isclose(counts["fn"], 0.0)
+
+
+def test_compute_counts_zero_hours():
+    counts = compute_counts(hours=0, validation_target=0.1, p=10, n=10, target_type="fp")
+    assert counts["tp"] == 10
+    assert counts["tn"] == 10
+    assert counts["fp"] == 0.0
+    assert counts["fn"] == 0.0
+
+
+def test_compute_rates_basic():
+    rates = compute_rates(50, 10, 30, 10)
+    assert math.isclose(rates["tpr"], 50 / (50 + 10))
+    assert math.isclose(rates["tnr"], 30 / (30 + 10))
+    assert math.isclose(rates["fpr"], 10 / (30 + 10))
+    assert math.isclose(rates["fnr"], 10 / (50 + 10))
+
+
+def test_compute_rates_from_target():
+    rates = compute_rates(hours=100, validation_target=0.01, p=60, n=40, target_type="fp")
+    assert math.isclose(rates["fpr"], (0.01 * 100) / 40)
+    assert math.isclose(rates["tnr"], 1 - (0.01 * 100) / 40)
+    assert math.isclose(rates["fp"], 0.01 * 100)
+    assert math.isclose(rates["tn"], 40 - 0.01 * 100)


### PR DESCRIPTION
## Summary
- compute TPR/TNR/FPR/FNR and per-hour limits from validation targets and dataset sizes
- surface auto-calculated rates alongside confusion-matrix metrics in the ODD element editor
- add regression tests for the new rate calculations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b763b62f48325ac89872846937c62