### PR TITLE
Expand global undo/redo coverage

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2274,8 +2274,8 @@ class FaultTreeApp:
         root.bind("<Control-x>", lambda event: self.cut_node())
         root.bind("<Control-v>", lambda event: self.paste_node())
         root.bind("<Control-p>", lambda event: self.save_diagram_png())
-        root.bind("<Control-z>", lambda event: self.undo())
-        root.bind("<Control-y>", lambda event: self.redo())
+        root.bind_all("<Control-z>", lambda event: self.undo())
+        root.bind_all("<Control-y>", lambda event: self.redo())
         root.bind("<F1>", lambda event: self.show_about())
         self.main_pane = tk.PanedWindow(root, orient=tk.HORIZONTAL)
         self.log_frame = logger.init_log_window(root)
@@ -3555,6 +3555,7 @@ class FaultTreeApp:
         self.update_views()
 
     def update_hazard_severity(self, hazard: str, severity: int | str) -> None:
+        self.push_undo_state()
         try:
             severity = int(severity)
         except Exception:
@@ -9722,6 +9723,7 @@ class FaultTreeApp:
         return False
 
     def add_node_of_type(self, event_type):
+        self.push_undo_state()
         # If a node is selected, ensure it is a primary instance.
         if self.selected_node:
             if not self.selected_node.is_primary_instance:
@@ -9774,6 +9776,7 @@ class FaultTreeApp:
         self.update_views()
 
     def add_basic_event_from_fmea(self):
+        self.push_undo_state()
         events = list(self.fmea_entries)
         for doc in self.fmeas:
             events.extend(doc.get("entries", []))
@@ -9816,6 +9819,7 @@ class FaultTreeApp:
         self.update_views()
 
     def add_basic_event_from_fmea(self):
+        self.push_undo_state()
         events = list(self.fmea_entries)
         for doc in self.fmeas:
             events.extend(doc.get("entries", []))
@@ -9858,6 +9862,7 @@ class FaultTreeApp:
         self.update_views()
 
     def add_basic_event_from_fmea(self):
+        self.push_undo_state()
         events = list(self.fmea_entries)
         for doc in self.fmeas:
             events.extend(doc.get("entries", []))
@@ -9901,6 +9906,7 @@ class FaultTreeApp:
 
 
     def remove_node(self):
+        self.push_undo_state()
         sel = self.analysis_tree.selection()
         target = None
         if sel:
@@ -9919,6 +9925,7 @@ class FaultTreeApp:
             messagebox.showwarning("Invalid", "Cannot remove the root node.")
 
     def remove_connection(self, node):
+        self.push_undo_state()
         if node and node != self.root_node:
             if node.parents:
                 for p in node.parents:
@@ -9936,6 +9943,7 @@ class FaultTreeApp:
             messagebox.showwarning("Remove Connection", "Cannot disconnect the root node.")
 
     def delete_node_and_subtree(self, node):
+        self.push_undo_state()
         if node:
             if node in self.top_events:
                 self.top_events.remove(node)
@@ -9954,6 +9962,7 @@ class FaultTreeApp:
     # ------------------------------------------------------------------
     def create_top_event_for_malfunction(self, name: str) -> None:
         """Create a new top level event linked to the given malfunction."""
+        self.push_undo_state()
         new_event = FaultTreeNode("", "TOP EVENT")
         new_event.x, new_event.y = 300, 200
         new_event.is_top_event = True
@@ -9964,6 +9973,7 @@ class FaultTreeApp:
 
     def delete_top_events_for_malfunction(self, name: str) -> None:
         """Remove all FTAs tied to the malfunction ``name``."""
+        self.push_undo_state()
         removed = [te for te in self.top_events if getattr(te, "malfunction", "") == name]
         if not removed:
             return
@@ -9974,6 +9984,7 @@ class FaultTreeApp:
         self.update_views()
 
     def add_gate_from_failure_mode(self):
+        self.push_undo_state()
         modes = self.get_available_failure_modes_for_gates()
         if not modes:
             messagebox.showinfo("No Failure Modes", "No failure modes available.")
@@ -10017,6 +10028,7 @@ class FaultTreeApp:
         self.update_views()
 
     def add_fault_event(self):
+        self.push_undo_state()
         dialog = self.SelectFaultDialog(self.root, sorted(self.faults), allow_new=True)
         fault = dialog.selected
         if fault == "NEW":

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -575,7 +575,7 @@ def add_aggregation_part(
             None,
         )
     if not rel:
-        rel = repo.create_relationship("Aggregation", whole_id, part_id)
+        rel = repo.create_relationship("Aggregation", whole_id, part_id, record_undo=False)
     if multiplicity:
         rel.properties["multiplicity"] = multiplicity
     else:
@@ -624,7 +624,7 @@ def add_composite_aggregation_part(
         None,
     )
     if not rel:
-        rel = repo.create_relationship("Composite Aggregation", whole_id, part_id)
+        rel = repo.create_relationship("Composite Aggregation", whole_id, part_id, record_undo=False)
     if multiplicity:
         rel.properties["multiplicity"] = multiplicity
     else:

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -352,7 +352,9 @@ class SysMLRepository:
         if self.root_package is None:
             self.root_package = self.create_element("Package", name="Root")
 
-    def create_relationship(self, rel_type: str, source: str, target: str, stereotype: Optional[str] = None, properties: Optional[Dict[str, str]] = None) -> SysMLRelationship:
+    def create_relationship(self, rel_type: str, source: str, target: str, stereotype: Optional[str] = None, properties: Optional[Dict[str, str]] = None, record_undo: bool = True) -> SysMLRelationship:
+        if record_undo:
+            self.push_undo_state()
         rel_id = str(uuid.uuid4())
         rel = SysMLRelationship(
             rel_id,
@@ -372,8 +374,10 @@ class SysMLRepository:
     # ------------------------------------------------------------
     # Diagram linkage helpers
     # ------------------------------------------------------------
-    def link_diagram(self, elem_id: str, diag_id: Optional[str]) -> None:
+    def link_diagram(self, elem_id: str, diag_id: Optional[str], record_undo: bool = True) -> None:
         """Associate an element with a diagram implementing it."""
+        if record_undo:
+            self.push_undo_state()
         if diag_id:
             self.element_diagrams[elem_id] = diag_id
         else:

--- a/tests/test_fta_undo.py
+++ b/tests/test_fta_undo.py
@@ -1,0 +1,67 @@
+import unittest
+import types
+import os
+import sys
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from AutoML import FaultTreeApp, FaultTreeNode
+from sysml.sysml_repository import SysMLRepository
+
+class FTAUndoRedoTests(unittest.TestCase):
+    def setUp(self):
+        # minimal app without Tk initialization
+        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app.top_events = []
+        self.app.root_node = None
+        self.app.selected_node = None
+        # stub analysis tree and view updates
+        self.app.analysis_tree = types.SimpleNamespace(selection=lambda: ())
+        self.app.update_views = lambda: None
+        self.app._undo_stack = []
+        self.app._redo_stack = []
+        # minimal persistence of state for undo/redo
+        self.app.export_model_data = lambda include_versions=False: {
+            "top_events": [n.to_dict() for n in self.app.top_events],
+            "root_node": self.app.root_node.to_dict() if self.app.root_node else None,
+        }
+        def apply_model_data(state):
+            self.app.top_events = [FaultTreeNode.from_dict(d) for d in state["top_events"]]
+            self.app.root_node = (
+                FaultTreeNode.from_dict(state["root_node"]) if state["root_node"] else None
+            )
+        self.app.apply_model_data = apply_model_data
+        SysMLRepository.reset_instance()
+
+    def test_undo_redo_top_event_creation_and_deletion(self):
+        self.app.create_top_event_for_malfunction("M1")
+        self.assertEqual(len(self.app.top_events), 1)
+        self.app.undo()
+        self.assertEqual(len(self.app.top_events), 0)
+        self.app.redo()
+        self.assertEqual(len(self.app.top_events), 1)
+        self.app.delete_top_events_for_malfunction("M1")
+        self.assertEqual(len(self.app.top_events), 0)
+        self.app.undo()
+        self.assertEqual(len(self.app.top_events), 1)
+        self.app.redo()
+        self.assertEqual(len(self.app.top_events), 0)
+
+    def test_undo_redo_add_node(self):
+        self.app.create_top_event_for_malfunction("M1")
+        self.app.selected_node = self.app.root_node
+        self.app.add_node_of_type("GATE")
+        self.assertEqual(len(self.app.root_node.children), 1)
+        self.app.undo()
+        self.assertEqual(len(self.app.root_node.children), 0)
+        self.app.redo()
+        self.assertEqual(len(self.app.root_node.children), 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hazard_undo.py
+++ b/tests/test_hazard_undo.py
@@ -1,0 +1,45 @@
+import unittest
+import types
+import os
+import sys
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from AutoML import FaultTreeApp
+from sysml.sysml_repository import SysMLRepository
+
+class HazardSeverityUndoRedoTests(unittest.TestCase):
+    def setUp(self):
+        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app.hazard_severity = {"H1": 1}
+        self.app.hazards = ["H1"]
+        self.app.hara_docs = []
+        self.app.fi2tc_docs = []
+        self.app.tc2fi_docs = []
+        self.app.update_views = lambda: None
+        self.app._undo_stack = []
+        self.app._redo_stack = []
+        self.app.export_model_data = lambda include_versions=False: {
+            "hazard_severity": self.app.hazard_severity.copy()
+        }
+        def apply_model_data(state):
+            self.app.hazard_severity = state["hazard_severity"].copy()
+        self.app.apply_model_data = apply_model_data
+        SysMLRepository.reset_instance()
+
+    def test_undo_redo_update_hazard_severity(self):
+        self.app.update_hazard_severity("H1", 5)
+        self.assertEqual(self.app.hazard_severity["H1"], 5)
+        self.app.undo()
+        self.assertEqual(self.app.hazard_severity["H1"], 1)
+        self.app.redo()
+        self.assertEqual(self.app.hazard_severity["H1"], 5)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -54,5 +54,25 @@ class UndoTests(unittest.TestCase):
         self.assertTrue(self.repo.redo())
         self.assertEqual(self.repo.elements[blk.elem_id].name, "B")
 
+    def test_undo_redo_relationship(self):
+        src = self.repo.create_element("Block", name="Src")
+        tgt = self.repo.create_element("Block", name="Tgt")
+        rel = self.repo.create_relationship("Association", src.elem_id, tgt.elem_id)
+        self.assertIn(rel, self.repo.relationships)
+        self.assertTrue(self.repo.undo())
+        self.assertNotIn(rel, self.repo.relationships)
+        self.assertTrue(self.repo.redo())
+        self.assertIn(rel, self.repo.relationships)
+
+    def test_undo_redo_link_diagram(self):
+        elem = self.repo.create_element("Block", name="A")
+        diag = self.repo.create_diagram("ibd", name="D")
+        self.repo.link_diagram(elem.elem_id, diag.diag_id)
+        self.assertEqual(self.repo.get_linked_diagram(elem.elem_id), diag.diag_id)
+        self.assertTrue(self.repo.undo())
+        self.assertIsNone(self.repo.get_linked_diagram(elem.elem_id))
+        self.assertTrue(self.repo.redo())
+        self.assertEqual(self.repo.get_linked_diagram(elem.elem_id), diag.diag_id)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure hazard severity edits record undo checkpoints
- allow repository relationship and diagram link operations to optionally skip undo to keep compound actions atomic
- test undo/redo for relationships, diagram links, and hazard severity updates
- bind undo/redo shortcuts globally so Ctrl+Z/Y work regardless of focused widget

## Testing
- `pytest tests/test_undo.py tests/test_hazard_undo.py tests/test_fta_undo.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bb20188088325a26a930ca073576d