### PR TITLE
Add basic GSN argumentation diagram support

### DIFF
--- a/gsn/__init__.py
+++ b/gsn/__init__.py
@@ -1,0 +1,4 @@
+"""GSN argumentation diagram utilities."""
+from .nodes import GSNNode
+from .diagram import GSNDiagram
+__all__ = ["GSNNode", "GSNDiagram"]

--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -1,0 +1,70 @@
+"""Simple rendering support for GSN diagrams."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Set
+
+from .nodes import GSNNode
+from gui.drawing_helper import GSNDrawingHelper
+
+
+@dataclass
+class GSNDiagram:
+    """A very small helper to render a GSN argumentation diagram.
+
+    This class is intentionally lightweight; it mirrors a subset of the
+    fault tree diagram functionality so that GSN diagrams can reuse the
+    existing drawing infrastructure.
+    """
+
+    root: GSNNode
+    drawing_helper: GSNDrawingHelper = field(default_factory=GSNDrawingHelper)
+
+    # ------------------------------------------------------------------
+    def _traverse(self) -> Iterable[GSNNode]:
+        visited: Set[str] = set()
+
+        def rec(node: GSNNode):
+            if node.unique_id in visited:
+                return
+            visited.add(node.unique_id)
+            yield node
+            for child in node.children:
+                yield from rec(child)
+
+        yield from rec(self.root)
+
+    # ------------------------------------------------------------------
+    def draw(self, canvas) -> None:  # pragma: no cover - requires tkinter
+        """Render the diagram on a :class:`tkinter.Canvas` instance."""
+        for node in self._traverse():
+            self._draw_node(canvas, node)
+
+    # ------------------------------------------------------------------
+    def _draw_node(self, canvas, node: GSNNode) -> None:  # pragma: no cover - requires tkinter
+        x, y = node.x, node.y
+        scale = 40
+        typ = node.node_type.lower()
+        if typ == "solution":
+            if node.is_primary_instance:
+                self.drawing_helper.draw_solution_shape(canvas, x, y, scale)
+            else:
+                self.drawing_helper.draw_away_solution_shape(canvas, x, y, scale)
+        elif typ == "goal":
+            if node.is_primary_instance:
+                self.drawing_helper.draw_goal_shape(canvas, x, y, scale)
+            else:
+                self.drawing_helper.draw_away_goal_shape(canvas, x, y, scale)
+        elif typ == "strategy":
+            self.drawing_helper.draw_strategy_shape(canvas, x, y, scale)
+        elif typ == "assumption":
+            self.drawing_helper.draw_assumption_shape(canvas, x, y, scale)
+        elif typ == "justification":
+            self.drawing_helper.draw_justification_shape(canvas, x, y, scale)
+        elif typ == "context":
+            self.drawing_helper.draw_context_shape(canvas, x, y, scale)
+        elif typ == "module":
+            if node.is_primary_instance:
+                self.drawing_helper.draw_goal_shape(canvas, x, y, scale)
+            else:
+                self.drawing_helper.draw_away_module_shape(canvas, x, y, scale)

--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -1,0 +1,63 @@
+"""Basic data structures for GSN argumentation diagrams."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+import uuid
+
+
+@dataclass
+class GSNNode:
+    """Represents a node in a GSN argumentation diagram.
+
+    Parameters
+    ----------
+    user_name:
+        Human readable label for the node.
+    node_type:
+        One of ``Goal``, ``Strategy``, ``Solution``, ``Assumption``,
+        ``Justification`` or ``Context``.
+    x, y:
+        Optional coordinates used when rendering the diagram.
+    """
+
+    user_name: str
+    node_type: str
+    x: float = 50
+    y: float = 50
+    children: List["GSNNode"] = field(default_factory=list)
+    parents: List["GSNNode"] = field(default_factory=list)
+    is_primary_instance: bool = True
+    original: Optional["GSNNode"] = field(default=None, repr=False)
+    unique_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        # A freshly created node is considered its own original instance.
+        if self.original is None:
+            self.original = self
+
+    # ------------------------------------------------------------------
+    def add_child(self, child: "GSNNode") -> None:
+        """Attach *child* to this node, updating parent/child lists."""
+        self.children.append(child)
+        child.parents.append(self)
+
+    # ------------------------------------------------------------------
+    def clone(self, parent: Optional["GSNNode"] = None) -> "GSNNode":
+        """Return a copy of this node referencing the same original.
+
+        The clone shares the ``original`` reference with the primary
+        instance, enabling multiple diagram occurrences similar to away
+        solutions in GSN 2.0.
+        """
+        clone = GSNNode(
+            self.user_name,
+            self.node_type,
+            x=self.x,
+            y=self.y,
+            is_primary_instance=False,
+            original=self.original,
+        )
+        if parent is not None:
+            parent.add_child(clone)
+        return clone

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -803,3 +803,229 @@ class FTADrawingHelper:
                            
 # Create a single FTADrawingHelper object that can be used by other classes
 fta_drawing_helper = FTADrawingHelper()
+
+
+class GSNDrawingHelper(FTADrawingHelper):
+    """Drawing helper providing shapes for GSN argumentation diagrams."""
+
+    def draw_goal_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Goal",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        if font_obj is None:
+            font_obj = tkFont.Font(family="Arial", size=int(10))
+        w = scale
+        h = scale * 0.6
+        left = x - w / 2
+        top = y - h / 2
+        right = x + w / 2
+        bottom = y + h / 2
+        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(x, y, text=text, font=font_obj, anchor="center", width=w - 4)
+
+    def draw_strategy_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Strategy",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        if font_obj is None:
+            font_obj = tkFont.Font(family="Arial", size=int(10))
+        w = scale
+        h = scale * 0.5
+        offset = w * 0.2
+        points = [
+            (x - w / 2 + offset, y - h / 2),
+            (x + w / 2, y - h / 2),
+            (x + w / 2 - offset, y + h / 2),
+            (x - w / 2, y + h / 2),
+        ]
+        self._fill_gradient_polygon(canvas, points, fill)
+        canvas.create_polygon(points, outline=outline_color, width=line_width, fill="", tags=(obj_id,))
+        canvas.create_text(x, y, text=text, font=font_obj, anchor="center", width=w - 4)
+
+    def draw_solution_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=40.0,
+        top_text="Solution",
+        bottom_text="",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        radius = scale / 2
+        self.draw_circle_event_shape(
+            canvas,
+            x,
+            y,
+            radius,
+            top_text=top_text,
+            bottom_text=bottom_text,
+            fill=fill,
+            outline_color=outline_color,
+            line_width=line_width,
+            font_obj=font_obj,
+            base_event=True,
+            obj_id=obj_id,
+        )
+
+    def draw_assumption_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Assumption",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        if font_obj is None:
+            font_obj = tkFont.Font(family="Arial", size=int(10))
+        w = scale
+        h = scale * 0.5
+        left = x - w / 2
+        top = y - h / 2
+        right = x + w / 2
+        bottom = y + h / 2
+        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill="",
+            outline=outline_color,
+            dash=(4, 2),
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(x, y, text=text, font=font_obj, anchor="center", width=w - 4)
+
+    def draw_justification_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Justification",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        if font_obj is None:
+            font_obj = tkFont.Font(family="Arial", size=int(10))
+        w = scale
+        h = scale * 0.5
+        left = x - w / 2
+        top = y - h / 2
+        right = x + w / 2
+        bottom = y + h / 2
+        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        inset = 4
+        canvas.create_rectangle(
+            left + inset,
+            top + inset,
+            right - inset,
+            bottom - inset,
+            outline=outline_color,
+            width=line_width,
+        )
+        canvas.create_text(x, y, text=text, font=font_obj, anchor="center", width=w - 4)
+
+    def draw_context_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Context",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        if font_obj is None:
+            font_obj = tkFont.Font(family="Arial", size=int(10))
+        w = scale
+        h = scale * 0.5
+        left = x - w / 2
+        top = y - h / 2
+        right = x + w / 2
+        bottom = y + h / 2
+        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(x, y, text=text, font=font_obj, anchor="center", width=w - 4)
+
+    def draw_away_solution_shape(self, canvas, x, y, scale=40.0, **kwargs):
+        self.draw_solution_shape(canvas, x, y, scale=scale, **kwargs)
+        radius = scale / 2
+        self.draw_shared_marker(canvas, x + radius, y - radius, 1)
+
+    def draw_away_goal_shape(self, canvas, x, y, scale=60.0, **kwargs):
+        self.draw_goal_shape(canvas, x, y, scale=scale, **kwargs)
+        self.draw_shared_marker(canvas, x + scale / 2, y - scale * 0.3, 1)
+
+    def draw_away_module_shape(self, canvas, x, y, scale=60.0, **kwargs):
+        self.draw_goal_shape(canvas, x, y, scale=scale, **kwargs)
+        self.draw_shared_marker(canvas, x + scale / 2, y - scale * 0.3, 1)
+
+
+# Create a single GSNDrawingHelper object for convenience
+
+gsn_drawing_helper = GSNDrawingHelper()


### PR DESCRIPTION
## Summary
- extend drawing helpers with shapes for GSN goals, strategies, solutions and context objects
- add simple data structures and renderer for GSN diagrams with support for away/clone solutions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689bbac0742c83258456cbb0f19d3d1e