### PR TITLE
Add basic GSN argumentation diagram support

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -242,6 +242,7 @@ from gui.review_toolbox import (
     VersionCompareDialog,
 )
 from gui.safety_management_toolbox import SafetyManagementToolbox
+from gui.gsn_explorer import GSNExplorer
 from dataclasses import asdict
 from analysis.mechanisms import (
     DiagnosticMechanism,
@@ -2083,6 +2084,7 @@ class FaultTreeApp:
         self.cybersecurity_goals: list[CybersecurityGoal] = []
         self.arch_diagrams = []
         self.management_diagrams = []
+        self.gsn_diagrams = []
         # Track open diagram tabs to avoid duplicates
         self.diagram_tabs: dict[str, ttk.Frame] = {}
         self.top_events = []
@@ -2234,6 +2236,9 @@ class FaultTreeApp:
         libs_menu.add_command(label="Scenario Libraries", command=self.manage_scenario_libraries)
         libs_menu.add_command(label="ODD Libraries", command=self.manage_odd_libraries)
 
+        gsn_menu = tk.Menu(menubar, tearoff=0)
+        gsn_menu.add_command(label="GSN Explorer", command=self.manage_gsn)
+
         # Add menus to the bar in the desired order
         menubar.add_cascade(label="File", menu=file_menu)
         menubar.add_cascade(label="Edit", menu=edit_menu)
@@ -2244,6 +2249,7 @@ class FaultTreeApp:
         menubar.add_cascade(label="Qualitative Analysis", menu=qualitative_menu)
         menubar.add_cascade(label="Quantitative Analysis", menu=quantitative_menu)
         menubar.add_cascade(label="FTA/CTA", menu=fta_menu)
+        menubar.add_cascade(label="GSN", menu=gsn_menu)
         menubar.add_cascade(label="Process", menu=process_menu)
         menubar.add_cascade(label="Review", menu=review_menu)
         help_menu = tk.Menu(menubar, tearoff=0)
@@ -2357,6 +2363,7 @@ class FaultTreeApp:
             "FTA-FMEA Traceability": self.show_traceability_matrix,
             "Safety Management": self.open_safety_management_toolbox,
             "Safety Performance Indicators": self.show_safety_performance_indicators,
+            "GSN Explorer": self.manage_gsn,
         }
 
         self.tool_categories = {
@@ -2412,6 +2419,7 @@ class FaultTreeApp:
             "Safety Management": [
                 "Safety Management",
                 "Safety Performance Indicators",
+                "GSN Explorer",
             ],
         }
 
@@ -15027,6 +15035,15 @@ class FaultTreeApp:
             self._arch_tab = self._new_tab("AutoML Explorer")
             self._arch_window = ArchitectureManagerDialog(self._arch_tab, self)
             self._arch_window.pack(fill=tk.BOTH, expand=True)
+        self.refresh_all()
+
+    def manage_gsn(self):
+        if hasattr(self, "_gsn_tab") and self._gsn_tab.winfo_exists():
+            self.doc_nb.select(self._gsn_tab)
+        else:
+            self._gsn_tab = self._new_tab("GSN Explorer")
+            self._gsn_window = GSNExplorer(self._gsn_tab, self)
+            self._gsn_window.pack(fill=tk.BOTH, expand=True)
         self.refresh_all()
 
     def open_arch_window(self, idx: int) -> None:

--- a/gsn/__init__.py
+++ b/gsn/__init__.py
@@ -1,0 +1,4 @@
+"""GSN argumentation diagram utilities."""
+from .nodes import GSNNode
+from .diagram import GSNDiagram
+__all__ = ["GSNNode", "GSNDiagram"]

--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -1,0 +1,70 @@
+"""Simple rendering support for GSN diagrams."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Set
+
+from .nodes import GSNNode
+from gui.drawing_helper import GSNDrawingHelper
+
+
+@dataclass
+class GSNDiagram:
+    """A very small helper to render a GSN argumentation diagram.
+
+    This class is intentionally lightweight; it mirrors a subset of the
+    fault tree diagram functionality so that GSN diagrams can reuse the
+    existing drawing infrastructure.
+    """
+
+    root: GSNNode
+    drawing_helper: GSNDrawingHelper = field(default_factory=GSNDrawingHelper)
+
+    # ------------------------------------------------------------------
+    def _traverse(self) -> Iterable[GSNNode]:
+        visited: Set[str] = set()
+
+        def rec(node: GSNNode):
+            if node.unique_id in visited:
+                return
+            visited.add(node.unique_id)
+            yield node
+            for child in node.children:
+                yield from rec(child)
+
+        yield from rec(self.root)
+
+    # ------------------------------------------------------------------
+    def draw(self, canvas) -> None:  # pragma: no cover - requires tkinter
+        """Render the diagram on a :class:`tkinter.Canvas` instance."""
+        for node in self._traverse():
+            self._draw_node(canvas, node)
+
+    # ------------------------------------------------------------------
+    def _draw_node(self, canvas, node: GSNNode) -> None:  # pragma: no cover - requires tkinter
+        x, y = node.x, node.y
+        scale = 40
+        typ = node.node_type.lower()
+        if typ == "solution":
+            if node.is_primary_instance:
+                self.drawing_helper.draw_solution_shape(canvas, x, y, scale)
+            else:
+                self.drawing_helper.draw_away_solution_shape(canvas, x, y, scale)
+        elif typ == "goal":
+            if node.is_primary_instance:
+                self.drawing_helper.draw_goal_shape(canvas, x, y, scale)
+            else:
+                self.drawing_helper.draw_away_goal_shape(canvas, x, y, scale)
+        elif typ == "strategy":
+            self.drawing_helper.draw_strategy_shape(canvas, x, y, scale)
+        elif typ == "assumption":
+            self.drawing_helper.draw_assumption_shape(canvas, x, y, scale)
+        elif typ == "justification":
+            self.drawing_helper.draw_justification_shape(canvas, x, y, scale)
+        elif typ == "context":
+            self.drawing_helper.draw_context_shape(canvas, x, y, scale)
+        elif typ == "module":
+            if node.is_primary_instance:
+                self.drawing_helper.draw_goal_shape(canvas, x, y, scale)
+            else:
+                self.drawing_helper.draw_away_module_shape(canvas, x, y, scale)

--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -1,0 +1,63 @@
+"""Basic data structures for GSN argumentation diagrams."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+import uuid
+
+
+@dataclass
+class GSNNode:
+    """Represents a node in a GSN argumentation diagram.
+
+    Parameters
+    ----------
+    user_name:
+        Human readable label for the node.
+    node_type:
+        One of ``Goal``, ``Strategy``, ``Solution``, ``Assumption``,
+        ``Justification`` or ``Context``.
+    x, y:
+        Optional coordinates used when rendering the diagram.
+    """
+
+    user_name: str
+    node_type: str
+    x: float = 50
+    y: float = 50
+    children: List["GSNNode"] = field(default_factory=list)
+    parents: List["GSNNode"] = field(default_factory=list)
+    is_primary_instance: bool = True
+    original: Optional["GSNNode"] = field(default=None, repr=False)
+    unique_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        # A freshly created node is considered its own original instance.
+        if self.original is None:
+            self.original = self
+
+    # ------------------------------------------------------------------
+    def add_child(self, child: "GSNNode") -> None:
+        """Attach *child* to this node, updating parent/child lists."""
+        self.children.append(child)
+        child.parents.append(self)
+
+    # ------------------------------------------------------------------
+    def clone(self, parent: Optional["GSNNode"] = None) -> "GSNNode":
+        """Return a copy of this node referencing the same original.
+
+        The clone shares the ``original`` reference with the primary
+        instance, enabling multiple diagram occurrences similar to away
+        solutions in GSN 2.0.
+        """
+        clone = GSNNode(
+            self.user_name,
+            self.node_type,
+            x=self.x,
+            y=self.y,
+            is_primary_instance=False,
+            original=self.original,
+        )
+        if parent is not None:
+            parent.add_child(clone)
+        return clone

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -803,3 +803,229 @@ class FTADrawingHelper:
                            
 # Create a single FTADrawingHelper object that can be used by other classes
 fta_drawing_helper = FTADrawingHelper()
+
+
+class GSNDrawingHelper(FTADrawingHelper):
+    """Drawing helper providing shapes for GSN argumentation diagrams."""
+
+    def draw_goal_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Goal",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        if font_obj is None:
+            font_obj = tkFont.Font(family="Arial", size=int(10))
+        w = scale
+        h = scale * 0.6
+        left = x - w / 2
+        top = y - h / 2
+        right = x + w / 2
+        bottom = y + h / 2
+        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(x, y, text=text, font=font_obj, anchor="center", width=w - 4)
+
+    def draw_strategy_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Strategy",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        if font_obj is None:
+            font_obj = tkFont.Font(family="Arial", size=int(10))
+        w = scale
+        h = scale * 0.5
+        offset = w * 0.2
+        points = [
+            (x - w / 2 + offset, y - h / 2),
+            (x + w / 2, y - h / 2),
+            (x + w / 2 - offset, y + h / 2),
+            (x - w / 2, y + h / 2),
+        ]
+        self._fill_gradient_polygon(canvas, points, fill)
+        canvas.create_polygon(points, outline=outline_color, width=line_width, fill="", tags=(obj_id,))
+        canvas.create_text(x, y, text=text, font=font_obj, anchor="center", width=w - 4)
+
+    def draw_solution_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=40.0,
+        top_text="Solution",
+        bottom_text="",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        radius = scale / 2
+        self.draw_circle_event_shape(
+            canvas,
+            x,
+            y,
+            radius,
+            top_text=top_text,
+            bottom_text=bottom_text,
+            fill=fill,
+            outline_color=outline_color,
+            line_width=line_width,
+            font_obj=font_obj,
+            base_event=True,
+            obj_id=obj_id,
+        )
+
+    def draw_assumption_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Assumption",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        if font_obj is None:
+            font_obj = tkFont.Font(family="Arial", size=int(10))
+        w = scale
+        h = scale * 0.5
+        left = x - w / 2
+        top = y - h / 2
+        right = x + w / 2
+        bottom = y + h / 2
+        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill="",
+            outline=outline_color,
+            dash=(4, 2),
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(x, y, text=text, font=font_obj, anchor="center", width=w - 4)
+
+    def draw_justification_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Justification",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        if font_obj is None:
+            font_obj = tkFont.Font(family="Arial", size=int(10))
+        w = scale
+        h = scale * 0.5
+        left = x - w / 2
+        top = y - h / 2
+        right = x + w / 2
+        bottom = y + h / 2
+        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        inset = 4
+        canvas.create_rectangle(
+            left + inset,
+            top + inset,
+            right - inset,
+            bottom - inset,
+            outline=outline_color,
+            width=line_width,
+        )
+        canvas.create_text(x, y, text=text, font=font_obj, anchor="center", width=w - 4)
+
+    def draw_context_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Context",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        if font_obj is None:
+            font_obj = tkFont.Font(family="Arial", size=int(10))
+        w = scale
+        h = scale * 0.5
+        left = x - w / 2
+        top = y - h / 2
+        right = x + w / 2
+        bottom = y + h / 2
+        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(x, y, text=text, font=font_obj, anchor="center", width=w - 4)
+
+    def draw_away_solution_shape(self, canvas, x, y, scale=40.0, **kwargs):
+        self.draw_solution_shape(canvas, x, y, scale=scale, **kwargs)
+        radius = scale / 2
+        self.draw_shared_marker(canvas, x + radius, y - radius, 1)
+
+    def draw_away_goal_shape(self, canvas, x, y, scale=60.0, **kwargs):
+        self.draw_goal_shape(canvas, x, y, scale=scale, **kwargs)
+        self.draw_shared_marker(canvas, x + scale / 2, y - scale * 0.3, 1)
+
+    def draw_away_module_shape(self, canvas, x, y, scale=60.0, **kwargs):
+        self.draw_goal_shape(canvas, x, y, scale=scale, **kwargs)
+        self.draw_shared_marker(canvas, x + scale / 2, y - scale * 0.3, 1)
+
+
+# Create a single GSNDrawingHelper object for convenience
+
+gsn_drawing_helper = GSNDrawingHelper()

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -1,0 +1,70 @@
+"""Simple explorer window for GSN argumentation diagrams."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk, simpledialog
+
+from gsn import GSNNode, GSNDiagram
+
+
+class GSNExplorer(tk.Frame):
+    """Manage and view GSN argumentation diagrams and their nodes."""
+
+    def __init__(self, master, app=None):
+        if isinstance(master, tk.Toplevel):
+            container = master
+        else:
+            container = master
+        super().__init__(container)
+        self.app = app
+        if isinstance(master, tk.Toplevel):
+            master.title("GSN Explorer")
+            master.geometry("350x400")
+            self.pack(fill=tk.BOTH, expand=True)
+
+        tree_frame = ttk.Frame(self)
+        tree_frame.pack(fill=tk.BOTH, expand=True, padx=4, pady=4)
+        self.tree = ttk.Treeview(tree_frame)
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
+        hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.tree.xview)
+        self.tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+        tree_frame.rowconfigure(0, weight=1)
+        tree_frame.columnconfigure(0, weight=1)
+
+        btns = ttk.Frame(self)
+        btns.pack(fill=tk.X, padx=4, pady=4)
+        ttk.Button(btns, text="New Diagram", command=self.new_diagram).pack(side=tk.LEFT)
+        ttk.Button(btns, text="Refresh", command=self.populate).pack(side=tk.LEFT, padx=5)
+
+        self.populate()
+
+    # ------------------------------------------------------------------
+    def populate(self):
+        """Fill the tree view with the available GSN diagrams."""
+        self.tree.delete(*self.tree.get_children(""))
+        if not self.app:
+            return
+        for idx, diag in enumerate(getattr(self.app, "gsn_diagrams", [])):
+            root_id = self.tree.insert("", "end", f"diag_{idx}", text=diag.root.user_name)
+            self._add_children(root_id, diag.root)
+
+    # ------------------------------------------------------------------
+    def _add_children(self, parent_id, node: GSNNode):
+        for child in node.children:
+            child_id = self.tree.insert(parent_id, "end", text=child.user_name, values=(child.node_type,))
+            self._add_children(child_id, child)
+
+    # ------------------------------------------------------------------
+    def new_diagram(self):
+        """Create a new GSN diagram with a single goal node as root."""
+        if not self.app:
+            return
+        name = simpledialog.askstring("New GSN Diagram", "Root goal name:", parent=self)
+        if not name:
+            return
+        root = GSNNode(name, "Goal")
+        self.app.gsn_diagrams.append(GSNDiagram(root))
+        self.populate()


### PR DESCRIPTION
## Summary
- extend drawing helpers with shapes for GSN goals, strategies, solutions and context objects
- add simple data structures and renderer for GSN diagrams with support for away/clone solutions
- add menu and tools integration with a lightweight GSN Explorer for argumentation modules and nodes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bbac0742c83258456cbb0f19d3d1e