### PR TITLE
Ensure all governance diagrams appear in safety management explorer

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -129,6 +129,30 @@ class SafetyManagementToolbox:
         self.diagrams[new] = diag_id
 
     def list_diagrams(self) -> List[str]:
-        """Return the names of all managed diagrams."""
+        """Return the names of all managed diagrams.
+
+        Any Activity Diagram in the repository tagged with
+        ``"safety-management"`` should appear in the toolbox even if it
+        was created outside of :meth:`create_diagram`. To ensure the list is
+        complete we rescan the repository on each call and synchronize the
+        internal ``diagrams`` mapping.
+        """
+        self._sync_diagrams()
         return list(self.diagrams.keys())
+
+    # ------------------------------------------------------------------
+    def _sync_diagrams(self) -> None:
+        """Synchronize ``self.diagrams`` with repository contents.
+
+        Any diagram tagged ``"safety-management"`` is added to the mapping
+        and entries for diagrams that no longer exist are dropped.
+        """
+        repo = SysMLRepository.get_instance()
+        current = {
+            d.name: d.diag_id
+            for d in repo.diagrams.values()
+            if "safety-management" in getattr(d, "tags", [])
+        }
+        self.diagrams.clear()
+        self.diagrams.update(current)
 

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -243,3 +243,15 @@ def test_safety_diagrams_visible_in_analysis_tree():
     assert "Safety & Security Governance Diagrams" in texts
     assert "Gov" in texts
     assert "Arch" in texts
+
+
+def test_external_safety_diagrams_load_in_toolbox_list():
+    """Diagrams tagged for governance appear even if created elsewhere."""
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Activity Diagram", name="GovX")
+    diag.tags.append("safety-management")
+    toolbox = SafetyManagementToolbox()
+    names = toolbox.list_diagrams()
+    assert "GovX" in names
+


### PR DESCRIPTION
## Summary
- rescan repository for safety-management tagged diagrams on each toolbox listing
- include governance diagrams created elsewhere in the safety management view
- test coverage for repository synchronization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bd51626088325916049614d4f4e0f