### PR TITLE
Add scrollbars to GSN diagram canvas

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -49,9 +49,18 @@ class GSNDiagramWindow(tk.Frame):
         for name, cmd in btn_cmds:
             ttk.Button(self.toolbox, text=name, command=cmd).pack(side=tk.LEFT)
 
-        # drawing canvas
-        self.canvas = tk.Canvas(self, width=800, height=600, bg="white")
-        self.canvas.pack(fill=tk.BOTH, expand=True)
+        # drawing canvas with scrollbars so large diagrams remain accessible
+        canvas_frame = ttk.Frame(self)
+        canvas_frame.pack(fill=tk.BOTH, expand=True)
+        self.canvas = tk.Canvas(canvas_frame, width=800, height=600, bg="white")
+        self.canvas.grid(row=0, column=0, sticky="nsew")
+        hbar = ttk.Scrollbar(canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
+        vbar = ttk.Scrollbar(canvas_frame, orient=tk.VERTICAL, command=self.canvas.yview)
+        self.canvas.configure(xscrollcommand=hbar.set, yscrollcommand=vbar.set)
+        hbar.grid(row=1, column=0, sticky="ew")
+        vbar.grid(row=0, column=1, sticky="ns")
+        canvas_frame.rowconfigure(0, weight=1)
+        canvas_frame.columnconfigure(0, weight=1)
         self.pack(fill=tk.BOTH, expand=True)
 
         self.id_to_node = {}
@@ -76,6 +85,9 @@ class GSNDiagramWindow(tk.Frame):
             bbox = self.canvas.bbox(self.selected_node.unique_id)
             if bbox:
                 self.canvas.create_rectangle(*bbox, outline="red", width=2)
+        # update scroll region to encompass all drawn items
+        bbox = self.canvas.bbox("all") or (0, 0, 0, 0)
+        self.canvas.configure(scrollregion=bbox)
 
     # The following methods simply extend the diagram with new nodes.
     # Placement is very rudimentary but sufficient for tests.

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -82,3 +82,40 @@ def test_on_release_creates_context_link():
     win._on_release(event)
     assert child in parent.children
     assert child in parent.context_children
+
+
+def test_refresh_updates_scrollregion():
+    """Refresh should configure the canvas scrollregion."""
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.selected_node = None
+    win.zoom = 1.0
+
+    class DiagramStub:
+        def _traverse(self):
+            return []
+
+        def draw(self, canvas, zoom):
+            pass
+
+    win.diagram = DiagramStub()
+
+    class CanvasStub:
+        def __init__(self):
+            self.config = {}
+
+        def delete(self, *a, **k):
+            pass
+
+        def bbox(self, tag):
+            return (0, 0, 100, 100)
+
+        def configure(self, **kwargs):
+            self.config.update(kwargs)
+
+        def create_rectangle(self, *args, **kwargs):
+            pass
+
+    win.canvas = CanvasStub()
+    win.id_to_node = {}
+    win.refresh()
+    assert win.canvas.config.get("scrollregion") == (0, 0, 100, 100)


### PR DESCRIPTION
## Summary
- Make GSN diagram windows scrollable by wrapping the canvas with horizontal and vertical scrollbars and updating the scroll region on refresh
- Test that refreshing a GSN diagram window configures the canvas scroll region

## Testing
- `PYTHONPATH=. pytest tests/test_gsn_*`


------
https://chatgpt.com/codex/tasks/task_b_689be059f5708325b2a3883dd33fdd20