### PR TITLE
Use distinct arrowheads for GSN connections

### DIFF
--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -928,6 +928,43 @@ class GSNDrawingHelper(FTADrawingHelper):
             tags=(obj_id,),
         )
 
+    def _draw_arrow(
+        self,
+        canvas,
+        start_pt,
+        end_pt,
+        *,
+        fill="black",
+        outline="black",
+    ) -> None:
+        """Draw a triangular arrow head from *start_pt* to *end_pt*."""
+        x1, y1 = start_pt
+        x2, y2 = end_pt
+        dx = x2 - x1
+        dy = y2 - y1
+        length = math.hypot(dx, dy)
+        if length == 0:
+            return
+        ux, uy = dx / length, dy / length
+        arrow_length = 10
+        arrow_width = 6
+        base_x = x2 - arrow_length * ux
+        base_y = y2 - arrow_length * uy
+        perp_x = -uy
+        perp_y = ux
+        points = [
+            (x2, y2),
+            (
+                base_x + (arrow_width / 2) * perp_x,
+                base_y + (arrow_width / 2) * perp_y,
+            ),
+            (
+                base_x - (arrow_width / 2) * perp_x,
+                base_y - (arrow_width / 2) * perp_y,
+            ),
+        ]
+        canvas.create_polygon(points, fill=fill, outline=outline)
+
     def draw_solved_by_connection(
         self,
         canvas,
@@ -941,36 +978,43 @@ class GSNDrawingHelper(FTADrawingHelper):
         cx, cy = child_pt
         if parent_pt == child_pt:
             size = 20
+            path = [
+                px,
+                py,
+                px,
+                py - size,
+                px + size,
+                py - size,
+                px + size,
+                py,
+                px,
+                py,
+            ]
+            canvas.create_line(*path, fill=outline_color, width=line_width)
+        else:
+            offset = (cy - py) / 2
+            path = [
+                px,
+                py,
+                px,
+                py + offset,
+                cx,
+                cy - offset,
+                cx,
+                cy,
+            ]
             canvas.create_line(
-                px,
-                py,
-                px,
-                py - size,
-                px + size,
-                py - size,
-                px + size,
-                py,
-                px,
-                py,
+                *path,
+                smooth=True,
                 fill=outline_color,
                 width=line_width,
-                arrow=tk.LAST,
             )
-            return
-        offset = (cy - py) / 2
-        canvas.create_line(
-            px,
-            py,
-            px,
-            py + offset,
-            cx,
-            cy - offset,
-            cx,
-            cy,
-            smooth=True,
-            fill=outline_color,
-            width=line_width,
-            arrow=tk.LAST,
+        self._draw_arrow(
+            canvas,
+            (path[-4], path[-3]),
+            (path[-2], path[-1]),
+            fill="black",
+            outline="black",
         )
 
     def draw_in_context_connection(
@@ -988,37 +1032,48 @@ class GSNDrawingHelper(FTADrawingHelper):
         dash = (4, 2)
         if parent_pt == child_pt:
             size = 20
+            path = [
+                px,
+                py,
+                px,
+                py - size,
+                px + size,
+                py - size,
+                px + size,
+                py,
+                px,
+                py,
+            ]
             canvas.create_line(
-                px,
-                py,
-                px,
-                py - size,
-                px + size,
-                py - size,
-                px + size,
-                py,
-                px,
-                py,
+                *path,
                 fill=outline_color,
                 width=line_width,
                 dash=dash,
-                arrow=tk.LAST,
             )
-            return
-        canvas.create_line(
-            px,
-            py,
-            px,
-            py + offset,
-            cx,
-            cy - offset,
-            cx,
-            cy,
-            smooth=True,
-            fill=outline_color,
-            width=line_width,
-            dash=dash,
-            arrow=tk.LAST,
+        else:
+            path = [
+                px,
+                py,
+                px,
+                py + offset,
+                cx,
+                cy - offset,
+                cx,
+                cy,
+            ]
+            canvas.create_line(
+                *path,
+                smooth=True,
+                fill=outline_color,
+                width=line_width,
+                dash=dash,
+            )
+        self._draw_arrow(
+            canvas,
+            (path[-4], path[-3]),
+            (path[-2], path[-1]),
+            fill="white",
+            outline=outline_color,
         )
 
     def draw_strategy_shape(


### PR DESCRIPTION
## Summary
- draw a filled black arrow for solved-by relationships
- draw a white arrow with outline for in-context-of links

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689be42bc9308325ba4995f6f8ba16d5