### PR TITLE
Fix GSN context connection anchoring

### DIFF
--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -1358,6 +1358,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             fill=fill,
             outline="",
             width=0,
+            tags=(obj_id,),
         )
         canvas.create_oval(
             left,
@@ -1367,6 +1368,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             fill=fill,
             outline="",
             width=0,
+            tags=(obj_id,),
         )
         canvas.create_oval(
             right - h,
@@ -1376,6 +1378,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             fill=fill,
             outline="",
             width=0,
+            tags=(obj_id,),
         )
         canvas.create_line(
             left + radius,

--- a/tests/test_gsn_connection_surface.py
+++ b/tests/test_gsn_connection_surface.py
@@ -11,16 +11,32 @@ class OffsetCanvas:
     def __init__(self):
         self.rects = {}
 
-    def create_rectangle(self, left, top, right, bottom, tags=()):
-        # Record rectangles so bbox() can return their extents.
+    def _update_rect(self, tag, left, top, right, bottom):
+        if tag in self.rects:
+            l, t, r, b = self.rects[tag]
+            self.rects[tag] = (min(l, left), min(t, top), max(r, right), max(b, bottom))
+        else:
+            self.rects[tag] = (left, top, right, bottom)
+
+    def create_rectangle(self, left, top, right, bottom, tags=(), **kwargs):
         if tags:
-            self.rects[tags[0]] = (left, top, right, bottom)
+            self._update_rect(tags[0], left, top, right, bottom)
+
+    def create_oval(self, left, top, right, bottom, tags=(), **kwargs):
+        if tags:
+            self._update_rect(tags[0], left, top, right, bottom)
 
     # The diagram calls these no-op methods during rendering.
     def create_line(self, *a, **k):
         pass
 
+    def create_arc(self, *a, **k):
+        pass
+
     def create_text(self, *a, **k):
+        pass
+
+    def create_polygon(self, *a, **k):
         pass
 
     def bbox(self, tag):
@@ -42,6 +58,16 @@ class TrackingHelper(GSNDrawingHelper):
         self.calls = []
         self.connection = None
 
+    def _scaled_font(self, scale):
+        class DummyFont:
+            def measure(self, text):
+                return len(text) * 5
+
+            def metrics(self, key):
+                return 10
+
+        return DummyFont()
+
     def draw_goal_shape(self, canvas, x, y, scale, text="", font_obj=None, obj_id=""):
         offset = self.offsets.get(obj_id, 0)
         half = scale / 2
@@ -57,14 +83,21 @@ class TrackingHelper(GSNDrawingHelper):
     draw_away_goal_shape = draw_goal_shape
     draw_assumption_shape = draw_goal_shape
     draw_justification_shape = draw_goal_shape
-    draw_context_shape = draw_goal_shape
     draw_away_module_shape = draw_goal_shape
+
+    def draw_context_shape(self, canvas, x, y, scale=60.0, **kwargs):
+        obj_id = kwargs.get("obj_id", "")
+        offset = self.offsets.get(obj_id, 0)
+        super().draw_context_shape(canvas, x + offset, y, scale=scale, **kwargs)
 
     def point_on_shape(self, shape, target_pt):
         self.calls.append((shape["center"], target_pt))
         return super().point_on_shape(shape, target_pt)
 
     def draw_solved_by_connection(self, canvas, parent_pt, child_pt, obj_id=""):
+        self.connection = (parent_pt, child_pt)
+
+    def draw_in_context_connection(self, canvas, parent_pt, child_pt, obj_id=""):
         self.connection = (parent_pt, child_pt)
 
 
@@ -90,6 +123,28 @@ def test_connections_touch_shape_surface():
 
     # The connection points returned to draw_solved_by_connection should lie on
     # the surfaces of both rectangles regardless of the offset.
+    assert helper.connection[0] == (30.0, 0.0)
+    assert helper.connection[1] == (80.0, 0.0)
+
+
+def test_context_connections_touch_shape_surface():
+    parent = GSNNode("p", "Goal", x=0, y=0)
+    child = GSNNode("c", "Context", x=100, y=0)
+    parent.add_child(child, relation="context")
+
+    offsets = {parent.unique_id: 0, child.unique_id: 10}
+    helper = TrackingHelper(offsets)
+    diag = GSNDiagram(parent, drawing_helper=helper)
+    diag.add_node(child)
+
+    canvas = OffsetCanvas()
+    diag.draw(canvas)
+
+    expected_child_center = (child.x + offsets[child.unique_id], child.y)
+    expected_parent_center = (parent.x + offsets[parent.unique_id], parent.y)
+    assert helper.calls[0][1] == expected_child_center
+    assert helper.calls[1][1] == expected_parent_center
+
     assert helper.connection[0] == (30.0, 0.0)
     assert helper.connection[1] == (80.0, 0.0)
 


### PR DESCRIPTION
## Summary
- tag context pill shapes with node IDs so `bbox` captures their full extents
- add regression test ensuring context connections start and end on node surfaces

## Testing
- `pytest tests/test_gsn_connection_surface.py tests/test_gsn_diagram_draw.py tests/test_gsn_horizontal_connection.py tests/test_gsn_connection_edit.py tests/test_gsn_connection_tags.py tests/test_gsn_diagram_window.py tests/test_gsn_explorer.py tests/test_gsn_persistence.py tests/test_gsn_solution_link.py tests/test_gsn_solution_work_product_clone.py tests/test_gsn_text_dragging.py`


------
https://chatgpt.com/codex/tasks/task_b_689bf3a291748325a15c090d59452b83