### PR TITLE
Show verification target in safety case

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12722,6 +12722,7 @@ class FaultTreeApp:
                 if getattr(node, "node_type", "").lower() == "solution":
                     self._solution_lookup[node.unique_id] = (node, diag)
                     prob = ""
+                    v_target = ""
                     target = getattr(node, "spi_target", "")
                     if target:
                         for te in getattr(self, "top_events", []):
@@ -12733,8 +12734,11 @@ class FaultTreeApp:
                             )
                             if label == target:
                                 p = getattr(te, "probability", "")
+                                vt = getattr(te, "validation_target", "")
                                 if p not in ("", None):
                                     prob = f"{p:.2e}"
+                                if vt not in ("", None):
+                                    v_target = f"{vt:.2e}"
                                 break
                     tree.insert(
                         "",
@@ -12744,7 +12748,7 @@ class FaultTreeApp:
                             node.description,
                             node.work_product,
                             node.evidence_link,
-                            node.spi_target,
+                            v_target,
                             prob,
                             CHECK_MARK if getattr(node, "evidence_sufficient", False) else "",
                             getattr(node, "manager_notes", ""),
@@ -12766,7 +12770,7 @@ class FaultTreeApp:
             "Description",
             "Work Product",
             "Evidence Link",
-            "SPI Target",
+            "Verification Target",
             "Achieved Probability",
             "Evidence OK",
             "Notes",

--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -164,7 +164,7 @@ class GSNElementConfig(tk.Toplevel):
                 row=row, column=1, padx=4, pady=4, sticky="ew"
             )
             row += 1
-            tk.Label(self, text="SPI Target:").grid(
+            tk.Label(self, text="Verification Target:").grid(
                 row=row, column=0, sticky="e", padx=4, pady=4
             )
             spi_targets = _collect_spi_targets(diagram, getattr(master, "app", None))

--- a/tests/test_safety_case.py
+++ b/tests/test_safety_case.py
@@ -162,6 +162,42 @@ def test_edit_probability_updates_spi(monkeypatch):
     assert spi_tree.data[iid]["values"][3] == f"{expected_spi:.2f}"
 
 
+def test_safety_case_shows_verification_target(monkeypatch):
+    root = GSNNode("G", "Goal")
+    sol = GSNNode("E", "Solution")
+    sol.spi_target = "SG1"
+    root.add_child(sol)
+    diag = GSNDiagram(root)
+    diag.add_node(sol)
+
+    te = types.SimpleNamespace(
+        user_name="SG1",
+        validation_target=1e-5,
+        probability=1e-4,
+        validation_desc="",
+        safety_goal_description="",
+        acceptance_criteria="AC",
+        unique_id=1,
+    )
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
+    app._new_tab = lambda title: DummyTab()
+    app.all_gsn_diagrams = [diag]
+    app.push_undo_state = lambda: None
+    app.top_events = [te]
+
+    monkeypatch.setattr("AutoML.ttk.Treeview", DummyTree)
+    monkeypatch.setattr("AutoML.ttk.Button", DummyButton)
+    monkeypatch.setattr("AutoML.tk.Menu", DummyMenu)
+
+    FaultTreeApp.show_safety_case(app)
+    tree = app._safety_case_tree
+    assert tree.columns[4] == "Verification Target"
+    iid = next(iter(tree.data))
+    assert tree.data[iid]["values"][4] == f"{1e-5:.2e}"
+
+
 def test_edit_probability_in_spi_explorer(monkeypatch):
     root = GSNNode("G", "Goal")
     sol = GSNNode("E", "Solution")


### PR DESCRIPTION
## Summary
- Rename safety case column from SPI Target to Verification Target
- Display top-event verification targets instead of product goals in safety case
- Update configuration dialog and add regression test for verification target

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c0f6ecddc8325a201f51e116afe14