### PR TITLE
Add CSV export for Safety Case table

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12907,11 +12907,26 @@ class FaultTreeApp:
 
         self._edit_safety_case_item = edit_selected
 
+        def export_csv():
+            path = filedialog.asksaveasfilename(
+                defaultextension=".csv", filetypes=[("CSV", "*.csv")]
+            )
+            if not path:
+                return
+            with open(path, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(columns)
+                for iid in tree.get_children():
+                    writer.writerow(tree.item(iid, "values"))
+            messagebox.showinfo("Export", "Safety case exported.")
+
         btn = ttk.Button(win, text="Edit", command=edit_selected)
         btn.pack(pady=4)
+        ttk.Button(win, text="Export CSV", command=export_csv).pack(pady=4)
 
         menu = tk.Menu(win, tearoff=0)
         menu.add_command(label="Edit", command=edit_selected)
+        menu.add_command(label="Export CSV", command=export_csv)
 
         def on_right_click(event):
             row = tree.identify_row(event.y)


### PR DESCRIPTION
## Summary
- Add Export CSV button and context menu item to Safety Case view
- Implement CSV export for Safety Case table values

## Testing
- `pytest tests/test_safety_case.py`

------
https://chatgpt.com/codex/tasks/task_b_689c1d3e8d788325914809e713696279