### PR TITLE
Ensure clone edits propagate to all instances

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -16008,6 +16008,47 @@ class FaultTreeApp:
         return _search_modules(getattr(self, "gsn_modules", []))
 
     def sync_nodes_by_id(self, updated_node):
+        # If a clone was edited, first copy its values back to the primary
+        # instance so the original reflects the change.  Afterwards, continue
+        # propagating from that primary node to all other clones.
+        if not getattr(updated_node, "is_primary_instance", True) and getattr(updated_node, "original", None):
+            original = updated_node.original
+            attrs = [
+                "node_type",
+                "user_name",
+                "description",
+                "rationale",
+                "quant_value",
+                "gate_type",
+                "severity",
+                "input_subtype",
+                "equation",
+                "detailed_equation",
+                "is_page",
+                "failure_prob",
+                "prob_formula",
+                "failure_mode_ref",
+                "fmea_effect",
+                "fmea_cause",
+                "fmea_severity",
+                "fmea_occurrence",
+                "fmea_detection",
+                "fmea_component",
+                "fmeda_malfunction",
+                "fmeda_safety_goal",
+                "fmeda_diag_cov",
+                "fmeda_fit",
+                "fmeda_spfm",
+                "fmeda_lpfm",
+                "fmeda_fault_type",
+                "fmeda_fault_fraction",
+            ]
+            for attr in attrs:
+                if hasattr(original, attr) and hasattr(updated_node, attr):
+                    setattr(original, attr, getattr(updated_node, attr))
+            if hasattr(original, "display_label") and hasattr(updated_node, "display_label"):
+                original.display_label = updated_node.display_label.replace(" (clone)", "")
+            updated_node = original
         # Always work with the primary instance.
         if not updated_node.is_primary_instance and updated_node.original:
             updated_node = updated_node.original

--- a/tests/test_clone_sync_nodes.py
+++ b/tests/test_clone_sync_nodes.py
@@ -1,0 +1,59 @@
+import unittest
+import types
+import os
+import sys
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from AutoML import FaultTreeApp, FaultTreeNode
+
+
+class CloneSyncTests(unittest.TestCase):
+    def setUp(self):
+        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app.fmea_entries = []
+        self.app.fmeas = []
+        self.app.fmedas = []
+
+        self.original = FaultTreeNode("orig", "Basic Event")
+        self.original.display_label = "OrigLabel"
+        self.clone1 = self.app.clone_node_preserving_id(self.original)
+        self.clone2 = self.app.clone_node_preserving_id(self.original)
+
+        # stub methods used by sync_nodes_by_id
+        def all_nodes(_self, node=None):
+            return [self.original, self.clone1, self.clone2]
+        self.app.get_all_nodes = types.MethodType(all_nodes, self.app)
+        self.app.get_all_fmea_entries = types.MethodType(lambda _self: [], self.app)
+        self.app.root_node = self.original
+
+        # initial sync to apply clone markers
+        self.app.sync_nodes_by_id(self.original)
+
+    def test_clone_and_original_propagation(self):
+        # modify a clone and sync
+        self.clone1.user_name = "Updated"
+        self.clone1.display_label = "UpdatedLabel (clone)"
+        self.app.sync_nodes_by_id(self.clone1)
+
+        # original and other clones should update
+        self.assertEqual(self.original.user_name, "Updated")
+        self.assertEqual(self.original.display_label, "UpdatedLabel")
+        self.assertEqual(self.clone2.user_name, "Updated")
+        self.assertEqual(self.clone2.display_label, "UpdatedLabel (clone)")
+
+        # modify the original and propagate to clones
+        self.original.description = "New description"
+        self.app.sync_nodes_by_id(self.original)
+        self.assertEqual(self.clone1.description, "New description")
+        self.assertEqual(self.clone2.description, "New description")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual test execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- sync attribute changes from a clone back to its original before updating other clones
- add regression test for clone/original synchronization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c3068629c832599a246d1e4efefef