### PR TITLE
Avoid default work product selection

### DIFF
--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -154,18 +154,9 @@ class GSNElementConfig(tk.Toplevel):
             # ``values`` to the constructor can result in an empty list on
             # some systems.
             wp_cb.configure(values=work_products)
-            # Pre-select the first available work product only when the
-            # diagram lacks existing work products.  This keeps the field
-            # blank if other solution nodes already define entries, forcing
-            # users to consciously pick a product while still presenting a
-            # sensible default for empty diagrams populated from the toolbox.
-            existing_products = [
-                getattr(n, "work_product", "")
-                for n in getattr(diagram, "nodes", [])
-                if n.node_type == "Solution" and getattr(n, "work_product", "")
-            ]
-            if not self.work_var.get() and not existing_products and work_products:
-                self.work_var.set(work_products[0])
+            # Leave the selection blank until the user picks a work product.
+            # ``state='readonly'`` prevents arbitrary text input while still
+            # allowing an empty initial value.
             row += 1
             tk.Label(self, text="Evidence Link:").grid(
                 row=row, column=0, sticky="e", padx=4, pady=4

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -578,5 +578,7 @@ def test_config_dialog_lists_toolbox_diagrams(monkeypatch):
 
     wp_cb = combo_holder[0]
     assert wp_cb.configured["values"] == ["DiagA", "DiagB"]
-    assert cfg.work_var.get() == "DiagA"
+    # The combobox should start without a selected value so the user must
+    # explicitly choose a work product.
+    assert cfg.work_var.get() == ""
 


### PR DESCRIPTION
## Summary
- prevent auto-selecting the first work product in the solution configuration dialog
- update tests for new selection behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c8b3a7df08325a3f1970d44105233