### PR TITLE
feat: gate work products via governance

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6256,6 +6256,16 @@ class SysMLDiagramWindow(tk.Frame):
                     else:
                         self.remove_element_model(obj)
                 else:
+                    if obj.obj_type == "Work Product":
+                        name = obj.properties.get("name", "")
+                        if getattr(self.app, "can_remove_work_product", None):
+                            if not self.app.can_remove_work_product(name):
+                                messagebox.showerror(
+                                    "Delete",
+                                    f"Cannot delete work product '{name}' with existing artifacts.",
+                                )
+                                continue
+                            getattr(self.app, "disable_work_product", lambda *_: None)(name)
                     self.remove_object(obj)
             self.selected_objs = []
             self.selected_obj = None

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -4,6 +4,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import types
 import sys
+import tkinter as tk
 
 # Stub out Pillow dependencies so importing the main app doesn't require Pillow
 PIL_stub = types.ModuleType("PIL")
@@ -103,6 +104,31 @@ def test_toolbox_manages_diagram_lifecycle():
     toolbox.delete_diagram("Gov2")
     assert diag_id not in repo.diagrams
     assert not toolbox.diagrams
+
+
+def test_disable_work_product_rejects_existing_docs():
+    """Work product types with existing documents cannot be removed."""
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.enabled_work_products = {"HAZOP"}
+    app.work_product_menus = {}
+    app.tool_listboxes = {}
+    app.tool_actions = {}
+    app.hazop_docs = [object()]
+    assert not app.disable_work_product("HAZOP")
+
+    # When no documents exist the work product can be disabled
+    class DummyMenu:
+        def __init__(self):
+            self.state = None
+
+        def entryconfig(self, idx, state=tk.DISABLED):
+            self.state = state
+
+    menu = DummyMenu()
+    app.hazop_docs = []
+    app.work_product_menus["HAZOP"] = (menu, 0)
+    assert app.disable_work_product("HAZOP")
+    assert menu.state == tk.DISABLED
 
 
 def test_open_safety_management_toolbox_uses_browser():


### PR DESCRIPTION
## Summary
- disable analysis menu items until matching work products are registered
- prevent removing work product types when project contains their documents
- test disabling work products with existing docs

## Testing
- `pytest tests/test_safety_management.py::test_work_product_registration tests/test_safety_management.py::test_toolbox_manages_diagram_lifecycle tests/test_safety_management.py::test_disable_work_product_rejects_existing_docs tests/test_safety_management.py::test_open_safety_management_toolbox_uses_browser tests/test_safety_management.py::test_safety_diagrams_hidden_and_immutable_in_explorer -q`


------
https://chatgpt.com/codex/tasks/task_b_689cc0255664832584ef0e7990ffd4cf