### PR TITLE
Add propagation relationships and governance rules

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -3813,6 +3813,7 @@ class FaultTreeApp:
         """Propagate risk assessment values to top events, inheriting ASILs from assessment rows."""
         sg_data = {}
         sg_asil = {}
+        toolbox = getattr(self, "safety_toolbox", None)
         for doc in getattr(self, "hara_docs", []):
             approved = getattr(doc, "approved", False) or getattr(doc, "status", "") == "closed"
             for e in doc.entries:
@@ -3834,7 +3835,15 @@ class FaultTreeApp:
                     data["exp"] = e.exposure
                 if approved:
                     data["approved"] = True
-                if e.safety_goal:
+                if e.safety_goal and (
+                    not toolbox
+                    or toolbox.can_propagate(
+                        "Risk Assessment",
+                        "Product Goal Specification",
+                        reviewed=approved,
+                        joint_review=approved,
+                    )
+                ):
                     best = sg_asil.get(e.safety_goal, "QM")
                     if ASIL_ORDER.get(e.asil, 0) > ASIL_ORDER.get(best, 0):
                         sg_asil[e.safety_goal] = e.asil
@@ -3844,12 +3853,21 @@ class FaultTreeApp:
             data = sg_data.get(mal)
             if data:
                 propagate = False
-                if getattr(te, "status", "draft") != "closed":
-                    propagate = True
-                elif data.get("approved"):
-                    propagate = True
-                    te.status = "draft"
-                    self.invalidate_reviews_for_fta(te.unique_id)
+                if (
+                    not toolbox
+                    or toolbox.can_propagate(
+                        "Risk Assessment",
+                        "FTA",
+                        reviewed=data.get("approved", False),
+                        joint_review=data.get("approved", False),
+                    )
+                ):
+                    if getattr(te, "status", "draft") != "closed":
+                        propagate = True
+                    elif data.get("approved"):
+                        propagate = True
+                        te.status = "draft"
+                        self.invalidate_reviews_for_fta(te.unique_id)
                 if propagate:
                     te.safety_goal_description = data["sg"]
                     te.severity = data["severity"]
@@ -3858,6 +3876,11 @@ class FaultTreeApp:
                     te.update_validation_target()
             sg_name = te.safety_goal_description
             asil = sg_asil.get(sg_name)
+            flag = data.get("approved", False) if data else False
+            if toolbox and not toolbox.can_propagate(
+                "FTA", "Product Goal Specification", reviewed=flag, joint_review=flag
+            ):
+                asil = None
             if asil and ASIL_ORDER.get(asil, 0) > ASIL_ORDER.get(te.safety_goal_asil or "QM", 0):
                 te.safety_goal_asil = asil
 

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -15,6 +15,7 @@ from gui.style_manager import StyleManager
 
 from sysml.sysml_spec import SYSML_PROPERTIES
 from analysis.models import global_requirements, ASIL_ORDER, StpaDoc
+from analysis.safety_management import ALLOWED_PROPAGATIONS
 
 # ---------------------------------------------------------------------------
 # Appearance customization
@@ -2904,41 +2905,53 @@ class SysMLDiagramWindow(tk.Frame):
                     f"Flow from {src.obj_type} to {dst.obj_type} is not allowed",
                 )
         elif diag_type == "BPMN Diagram":
-            allowed = {
-                "Initial": {
-                    "Action",
-                    "Decision",
-                    "Merge",
-                },
-                "Action": {
-                    "Action",
-                    "Decision",
-                    "Merge",
-                    "Final",
-                },
-                "Decision": {
-                    "Action",
-                    "Decision",
-                    "Merge",
-                    "Final",
-                },
-                "Merge": {
-                    "Action",
-                    "Decision",
-                    "Merge",
-                },
-                "Final": set(),
-            }
-            if src.obj_type == "Final":
-                return False, "Flows cannot originate from Final nodes"
-            if dst.obj_type == "Initial":
-                return False, "Flows cannot terminate at an Initial node"
-            valid_targets = allowed.get(src.obj_type)
-            if valid_targets and dst.obj_type not in valid_targets:
-                return (
-                    False,
-                    f"Flow from {src.obj_type} to {dst.obj_type} is not allowed",
-                )
+            if conn_type in (
+                "Propagate",
+                "Propagate by Review",
+                "Propagate by Approval",
+            ):
+                if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
+                    return False, "Propagation links must connect Work Products"
+                src_name = src.properties.get("name")
+                dst_name = dst.properties.get("name")
+                if (src_name, dst_name) not in ALLOWED_PROPAGATIONS:
+                    return False, f"Propagation from {src_name} to {dst_name} is not allowed"
+            else:
+                allowed = {
+                    "Initial": {
+                        "Action",
+                        "Decision",
+                        "Merge",
+                    },
+                    "Action": {
+                        "Action",
+                        "Decision",
+                        "Merge",
+                        "Final",
+                    },
+                    "Decision": {
+                        "Action",
+                        "Decision",
+                        "Merge",
+                        "Final",
+                    },
+                    "Merge": {
+                        "Action",
+                        "Decision",
+                        "Merge",
+                    },
+                    "Final": set(),
+                }
+                if src.obj_type == "Final":
+                    return False, "Flows cannot originate from Final nodes"
+                if dst.obj_type == "Initial":
+                    return False, "Flows cannot terminate at an Initial node"
+                valid_targets = allowed.get(src.obj_type)
+                if valid_targets and dst.obj_type not in valid_targets:
+                    return (
+                        False,
+                        f"Flow from {src.obj_type} to {dst.obj_type} is not allowed",
+                    )
 
         return True, ""
 
@@ -2992,6 +3005,9 @@ class SysMLDiagramWindow(tk.Frame):
             "Include",
             "Extend",
             "Flow",
+            "Propagate",
+            "Propagate by Review",
+            "Propagate by Approval",
             "Connector",
             "Generalize",
             "Generalization",
@@ -3395,6 +3411,9 @@ class SysMLDiagramWindow(tk.Frame):
             "Include",
             "Extend",
             "Flow",
+            "Propagate",
+            "Propagate by Review",
+            "Propagate by Approval",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3623,6 +3642,9 @@ class SysMLDiagramWindow(tk.Frame):
                         "Generalization",
                         "Include",
                         "Extend",
+                        "Propagate",
+                        "Propagate by Review",
+                        "Propagate by Approval",
                     ):
                         arrow_default = "forward"
                     else:
@@ -8035,6 +8057,9 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
             "Decision",
             "Merge",
             "Flow",
+            "Propagate",
+            "Propagate by Review",
+            "Propagate by Approval",
             "System Boundary",
         ]
         super().__init__(master, "BPMN Diagram", tools, diagram_id, app=app, history=history)

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -1001,3 +1001,41 @@ def test_work_product_color_and_text_wrapping():
     _, rect_kwargs = win.canvas.rect_calls[0]
     assert rect_kwargs["fill"] == "lightgreen"
 
+
+def test_propagation_connection_validation():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("BPMN Diagram")
+    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    wp1 = SysMLObject(1, "Work Product", 0.0, 0.0, properties={"name": "Risk Assessment"})
+    wp2 = SysMLObject(2, "Work Product", 0.0, 0.0, properties={"name": "FTA"})
+    win.objects = [wp1, wp2]
+    valid, _ = BPMNDiagramWindow.validate_connection(win, wp1, wp2, "Propagate")
+    assert valid
+    wp3 = SysMLObject(3, "Work Product", 0.0, 0.0, properties={"name": "STPA"})
+    win.objects.append(wp3)
+    valid, _ = BPMNDiagramWindow.validate_connection(win, wp1, wp3, "Propagate")
+    assert not valid
+
+
+def test_can_propagate_respects_review_states():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    diag = repo.create_diagram("BPMN Diagram", name="Gov")
+    toolbox.diagrams["Gov"] = diag.diag_id
+    diag.objects = [
+        {"obj_id": 1, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "Risk Assessment"}},
+        {"obj_id": 2, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "FTA"}},
+    ]
+    diag.connections = [{"src": 1, "dst": 2, "conn_type": "Propagate by Review"}]
+    assert not toolbox.can_propagate("Risk Assessment", "FTA", reviewed=False)
+    assert toolbox.can_propagate("Risk Assessment", "FTA", reviewed=True)
+    diag.connections = [{"src": 1, "dst": 2, "conn_type": "Propagate by Approval"}]
+    assert not toolbox.can_propagate("Risk Assessment", "FTA", joint_review=False)
+    assert toolbox.can_propagate("Risk Assessment", "FTA", joint_review=True)
+    diag.connections = [{"src": 1, "dst": 2, "conn_type": "Propagate"}]
+    assert toolbox.can_propagate("Risk Assessment", "FTA", reviewed=False)
+


### PR DESCRIPTION
## Summary
- add Propagate/Propagate by Review/Propagate by Approval relationships to BPMN governance diagrams
- validate propagation links against allowed work product pairs
- gate ASIL propagation by review status per relationship type

## Testing
- `pytest tests/test_safety_management.py::test_propagation_connection_validation tests/test_safety_management.py::test_can_propagate_respects_review_states -q`


------
https://chatgpt.com/codex/tasks/task_b_689ccc69e60c8325bfa2af98b1579383