### PR TITLE
style: enhance governance work product visuals

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5498,24 +5498,31 @@ class SysMLDiagramWindow(tk.Frame):
                 "FMEDA",
             }
             if label in diagram_products:
-                color = "lightblue"
+                color = "#cfe2f3"
             elif label in analysis_products:
-                color = "lightgreen"
-            self.canvas.create_rectangle(
+                color = "#d5e8d4"
+            else:
+                color = "#ffffff"
+            self._create_round_rect(
                 x - w,
                 y - h,
                 x + w,
                 y + h,
+                radius=8 * self.zoom,
                 outline=outline,
                 fill=color,
             )
             fold = 10 * self.zoom
-            self.canvas.create_line(
+            fold_color = "#fdfdfd"
+            self.canvas.create_polygon(
                 x + w - fold,
                 y - h,
                 x + w,
+                y - h,
+                x + w,
                 y - h + fold,
-                fill=outline,
+                fill=fold_color,
+                outline=outline,
             )
             self.canvas.create_line(
                 x + w - fold,

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -53,6 +53,7 @@ class DummyCanvas:
     def __init__(self):
         self.text_calls = []
         self.rect_calls = []
+        self.polygon_calls = []
 
     def create_text(self, x, y, **kw):
         self.text_calls.append((x, y, kw))
@@ -64,7 +65,7 @@ class DummyCanvas:
         pass
 
     def create_polygon(self, *args, **kwargs):
-        pass
+        self.polygon_calls.append((args, kwargs))
 
 
 def test_activity_boundary_label_rotated_left():
@@ -1062,16 +1063,16 @@ def test_work_product_color_and_text_wrapping():
         properties={"name": "Architecture Diagram"},
     )
     win.draw_object(obj)
-    _, rect_kwargs = win.canvas.rect_calls[0]
-    assert rect_kwargs["fill"] == "lightblue"
+    _, poly_kwargs = win.canvas.polygon_calls[0]
+    assert poly_kwargs["fill"] == "#cfe2f3"
     assert win.canvas.text_calls[0][2]["width"] == 60.0
 
-    win.canvas.rect_calls.clear()
+    win.canvas.polygon_calls.clear()
     win.canvas.text_calls.clear()
     obj.properties["name"] = "HAZOP"
     win.draw_object(obj)
-    _, rect_kwargs = win.canvas.rect_calls[0]
-    assert rect_kwargs["fill"] == "lightgreen"
+    _, poly_kwargs = win.canvas.polygon_calls[0]
+    assert poly_kwargs["fill"] == "#d5e8d4"
 
 
 def test_propagation_connection_validation():


### PR DESCRIPTION
## Summary
- Give work products rounded document shapes with a filled corner fold
- Use pastel blue and green colors for diagram and analysis work products
- Update tests to check new work product rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cd78c5c60832593dee667ddd22de5