### PR TITLE
Fix overlapping work product titles in governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4789,6 +4789,8 @@ class SysMLDiagramWindow(tk.Frame):
                 lines.extend(wrapped)
             else:
                 lines.append(name)
+        elif obj.obj_type == "Work Product" and name:
+            lines.extend(name.split())
         else:
             lines.append(name)
 
@@ -5837,7 +5839,13 @@ class SysMLDiagramWindow(tk.Frame):
                 outline=outline,
             )
 
-        if obj.obj_type not in ("Block", "System Boundary", "Block Boundary", "Port"):
+        if obj.obj_type not in (
+            "Block",
+            "System Boundary",
+            "Block Boundary",
+            "Port",
+            "Work Product",
+        ):
             name = obj.properties.get("name", obj.obj_type)
             label = name
             if obj.obj_type == "Part":


### PR DESCRIPTION
## Summary
- avoid drawing default labels for work product nodes, preventing duplicate titles
- split work product names into separate words so sizing matches the rendered text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cd97009bc8325b2df8b9dc72ac816