### PR TITLE
Add lifecycle phase filtering to safety management

### DIFF
--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -20,7 +20,11 @@ sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
 
 from AutoML import FaultTreeApp
 import AutoML
-from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from analysis.safety_management import (
+    SafetyManagementToolbox,
+    GovernanceModule,
+    SafetyWorkProduct,
+)
 from gui.architecture import BPMNDiagramWindow, SysMLObject, ArchitectureManagerDialog
 from gui.safety_management_explorer import SafetyManagementExplorer
 from gui.review_toolbox import ReviewData
@@ -1126,3 +1130,29 @@ def test_propagation_type_uses_stereotype_when_conn_type_missing():
     ]
     diag.connections = [{"src": 1, "dst": 2, "stereotype": "propagate by review"}]
     assert toolbox.propagation_type("Risk Assessment", "FTA") == "Propagate by Review"
+
+
+def test_list_modules_includes_submodules():
+    toolbox = SafetyManagementToolbox()
+    child = GovernanceModule("Child")
+    parent = GovernanceModule("Parent", modules=[child])
+    toolbox.modules = [parent]
+    assert set(toolbox.list_modules()) == {"Parent", "Child"}
+
+
+def test_active_module_filters_enabled_products():
+    toolbox = SafetyManagementToolbox()
+    toolbox.work_products = [
+        SafetyWorkProduct("D1", "HAZOP", ""),
+        SafetyWorkProduct("D2", "FMEA", ""),
+    ]
+    toolbox.modules = [
+        GovernanceModule("Phase1", diagrams=["D1"]),
+        GovernanceModule("Phase2", diagrams=["D2"]),
+    ]
+
+    assert toolbox.enabled_products() == {"HAZOP", "FMEA"}
+    toolbox.set_active_module("Phase1")
+    assert toolbox.enabled_products() == {"HAZOP"}
+    toolbox.set_active_module(None)
+    assert toolbox.enabled_products() == {"HAZOP", "FMEA"}


### PR DESCRIPTION
## Summary
- add lifecycle phase selection and filtering to safety management toolbox
- expose governance folders and activate rules by selected phase
- test module listing and phase-based activation

## Testing
- `pytest tests/test_safety_management.py::test_list_modules_includes_submodules tests/test_safety_management.py::test_active_module_filters_enabled_products -q`

------
https://chatgpt.com/codex/tasks/task_b_689ce3674a188325aeac9e4f8a285c92