### PR TITLE
Add safety case explorer for GSN-based safety cases

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -244,6 +244,7 @@ from gui.review_toolbox import (
 from gui.safety_management_toolbox import SafetyManagementToolbox
 from gui.gsn_explorer import GSNExplorer
 from gui.safety_management_explorer import SafetyManagementExplorer
+from gui.safety_case_explorer import SafetyCaseExplorer
 from gui.gsn_diagram_window import GSNDiagramWindow
 from gui.gsn_config_window import GSNElementConfig
 from gsn import GSNDiagram, GSNModule
@@ -1942,8 +1943,8 @@ class FaultTreeApp:
         ),
         "Safety & Security Concept": (
             "System Design (Item Definition)",
-            "Safety & Security Case",
-            "show_safety_case",
+            "Safety & Security Case Explorer",
+            "manage_safety_cases",
         ),
         "Requirement Specification": (
             "System Design (Item Definition)",
@@ -2386,6 +2387,9 @@ class FaultTreeApp:
 
         gsn_menu = tk.Menu(menubar, tearoff=0)
         gsn_menu.add_command(label="GSN Explorer", command=self.manage_gsn)
+        gsn_menu.add_command(
+            label="Safety & Security Case Explorer", command=self.manage_safety_cases
+        )
 
         # Add menus to the bar in the desired order
         menubar.add_cascade(label="File", menu=file_menu)
@@ -2503,13 +2507,15 @@ class FaultTreeApp:
         self.tool_actions = {
             "Safety & Security Management": self.open_safety_management_toolbox,
             "Safety & Security Management Explorer": self.manage_safety_management,
+            "Safety & Security Case Explorer": self.manage_safety_cases,
         }
 
         self.tool_categories: dict[str, list[str]] = {
             "Safety & Security Management": [
                 "Safety & Security Management",
-                "Safety & Security Management Explorer",
-            ]
+            "Safety & Security Management Explorer",
+            "Safety & Security Case Explorer",
+        ]
         }
         self.tool_to_work_product = {
             info[1]: name for name, info in self.WORK_PRODUCT_INFO.items()
@@ -8545,7 +8551,7 @@ class FaultTreeApp:
                 self.doc_nb.select(self.canvas_tab)
                 self.open_page_diagram(te)
         elif kind == "safetycase":
-            self.show_safety_case()
+            self.manage_safety_cases()
         elif kind == "safetyconcept":
             self.show_safety_concept_editor()
         elif kind == "itemdef":
@@ -9852,7 +9858,12 @@ class FaultTreeApp:
             ):
                 add_gsn_diagram(diag, gsn_root)
 
-            tree.insert(mgmt_root, "end", text="Safety & Security Case", tags=("safetycase", "0"))
+            tree.insert(
+                mgmt_root,
+                "end",
+                text="Safety & Security Case Explorer",
+                tags=("safetycase", "0"),
+            )
 
             # --- Verification Reviews Section ---
             self.joint_reviews = [r for r in getattr(self, "reviews", []) if getattr(r, "mode", "") == "joint"]
@@ -16434,6 +16445,21 @@ class FaultTreeApp:
                 self._safety_exp_tab, self, self.safety_mgmt_toolbox
             )
             self._safety_exp_window.pack(fill=tk.BOTH, expand=True)
+        self.refresh_all()
+
+    def manage_safety_cases(self):
+        if not hasattr(self, "safety_case_library"):
+            from analysis import SafetyCaseLibrary as _SCL
+
+            self.safety_case_library = _SCL()
+        if hasattr(self, "_safety_case_exp_tab") and self._safety_case_exp_tab.winfo_exists():
+            self.doc_nb.select(self._safety_case_exp_tab)
+        else:
+            self._safety_case_exp_tab = self._new_tab("Safety & Security Case Explorer")
+            self._safety_case_window = SafetyCaseExplorer(
+                self._safety_case_exp_tab, self, self.safety_case_library
+            )
+            self._safety_case_window.pack(fill=tk.BOTH, expand=True)
         self.refresh_all()
 
     def open_gsn_diagram(self, diagram):

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -2,11 +2,15 @@
 
 from .sotif_validation import acceptance_rate, hazardous_behavior_rate, validation_time
 from .confusion_matrix import compute_metrics, compute_metrics_from_target
+from .safety_case import SafetyCase, SafetyCaseLibrary
+
 __all__ = [
     "acceptance_rate",
     "hazardous_behavior_rate",
     "validation_time",
     "compute_metrics",
+    "SafetyCase",
+    "SafetyCaseLibrary",
     "SafetyManagementToolbox",
 ]
 

--- a/analysis/safety_case.py
+++ b/analysis/safety_case.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Data structures for safety & security cases."""
+
+from dataclasses import dataclass, field
+from typing import List
+
+from gsn import GSNDiagram, GSNNode
+
+
+@dataclass
+class SafetyCase:
+    """Representation of a safety & security case derived from a GSN diagram."""
+
+    name: str
+    diagram: GSNDiagram
+    solutions: List[GSNNode] = field(default_factory=list)
+
+    def collect_solutions(self) -> None:
+        """Populate :attr:`solutions` with all solution nodes from ``diagram``."""
+        self.solutions = [n for n in self.diagram.nodes if n.node_type == "Solution"]
+
+
+@dataclass
+class SafetyCaseLibrary:
+    """Container managing multiple :class:`SafetyCase` instances."""
+
+    cases: List[SafetyCase] = field(default_factory=list)
+
+    def create_case(self, name: str, diagram: GSNDiagram) -> SafetyCase:
+        case = SafetyCase(name, diagram)
+        case.collect_solutions()
+        self.cases.append(case)
+        return case
+
+    def delete_case(self, case: SafetyCase) -> None:
+        if case in self.cases:
+            self.cases.remove(case)
+
+    def rename_case(self, case: SafetyCase, new_name: str) -> None:
+        case.name = new_name
+
+    def list_cases(self) -> List[SafetyCase]:
+        return list(self.cases)

--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -1,0 +1,190 @@
+"""Explorer for safety & security cases derived from GSN diagrams."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk, simpledialog
+from typing import Dict, Tuple
+
+from analysis.safety_case import SafetyCaseLibrary, SafetyCase
+from gui import messagebox
+
+
+class SafetyCaseExplorer(tk.Frame):
+    """Manage and browse safety & security cases."""
+
+    def __init__(self, master, app=None, library: SafetyCaseLibrary | None = None):
+        if isinstance(master, tk.Toplevel):
+            container = master
+        else:
+            container = master
+        super().__init__(container)
+        self.app = app
+        self.library = library or SafetyCaseLibrary()
+        if isinstance(master, tk.Toplevel):
+            master.title("Safety & Security Case Explorer")
+            master.geometry("350x400")
+            self.pack(fill=tk.BOTH, expand=True)
+
+        btns = ttk.Frame(self)
+        btns.pack(side=tk.TOP, fill=tk.X, padx=4, pady=4)
+        ttk.Button(btns, text="Open", command=self.open_item).pack(side=tk.LEFT)
+        ttk.Button(btns, text="New Case", command=self.new_case).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="Edit", command=self.edit_case).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="Delete", command=self.delete_case).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="Refresh", command=self.populate).pack(side=tk.RIGHT)
+
+        tree_frame = ttk.Frame(self)
+        tree_frame.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=4, pady=4)
+        self.tree = ttk.Treeview(tree_frame)
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
+        hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.tree.xview)
+        self.tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+        tree_frame.rowconfigure(0, weight=1)
+        tree_frame.columnconfigure(0, weight=1)
+
+        self.case_icon = self._create_icon("folder", "#b8860b")
+        self.solution_icon = self._create_icon("circle", "#1e90ff")
+        self.item_map: Dict[str, Tuple[str, object]] = {}
+
+        self.tree.bind("<Double-1>", self._on_double_click)
+        self.populate()
+
+    # ------------------------------------------------------------------
+    def populate(self):
+        """Fill the tree with safety cases and their solutions."""
+        self.item_map.clear()
+        self.tree.delete(*self.tree.get_children(""))
+        for case in self.library.list_cases():
+            iid = self.tree.insert("", "end", text=case.name, image=self.case_icon)
+            self.item_map[iid] = ("case", case)
+            for sol in case.solutions:
+                sid = self.tree.insert(iid, "end", text=sol.user_name, image=self.solution_icon)
+                self.item_map[sid] = ("solution", sol)
+
+    # ------------------------------------------------------------------
+    def new_case(self):
+        """Create a new safety case derived from a GSN diagram."""
+        if not self.app or not getattr(self.app, "gsn_diagrams", []):
+            messagebox.showerror("New Case", "No GSN diagrams available")
+            return
+        name = simpledialog.askstring("New Safety Case", "Name:", parent=self)
+        if not name:
+            return
+        diagrams = getattr(self.app, "gsn_diagrams", [])
+        diag_names = [d.root.user_name for d in diagrams]
+        prompt = "Diagram name:\n" + "\n".join(diag_names)
+        diag_name = simpledialog.askstring("GSN Diagram", prompt, parent=self)
+        if not diag_name:
+            return
+        diag = next((d for d in diagrams if d.root.user_name == diag_name), None)
+        if not diag:
+            messagebox.showerror("New Case", "Diagram not found")
+            return
+        self.library.create_case(name, diag)
+        self.populate()
+
+    # ------------------------------------------------------------------
+    def edit_case(self):
+        """Rename the selected safety case or change its diagram."""
+        sel = self.tree.selection()
+        if not sel:
+            return
+        typ, obj = self.item_map.get(sel[0], (None, None))
+        if typ != "case":
+            return
+        new_name = simpledialog.askstring(
+            "Rename Safety Case", "Name:", initialvalue=obj.name, parent=self
+        )
+        if not new_name:
+            return
+        diagrams = getattr(self.app, "gsn_diagrams", [])
+        diag_names = [d.root.user_name for d in diagrams]
+        prompt = "Diagram name:\n" + "\n".join(diag_names)
+        new_diag_name = simpledialog.askstring(
+            "GSN Diagram", prompt, initialvalue=obj.diagram.root.user_name, parent=self
+        )
+        if not new_diag_name:
+            return
+        new_diag = next((d for d in diagrams if d.root.user_name == new_diag_name), None)
+        if not new_diag:
+            messagebox.showerror("Edit Case", "Diagram not found")
+            return
+        obj.name = new_name
+        obj.diagram = new_diag
+        obj.collect_solutions()
+        self.populate()
+
+    # ------------------------------------------------------------------
+    def delete_case(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        typ, obj = self.item_map.get(sel[0], (None, None))
+        if typ != "case":
+            return
+        if messagebox.askokcancel("Delete", f"Delete '{obj.name}'?"):
+            self.library.delete_case(obj)
+            self.populate()
+
+    # ------------------------------------------------------------------
+    def open_item(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        typ, obj = self.item_map.get(sel[0], (None, None))
+        if typ == "case" and self.app:
+            opener = getattr(self.app, "open_gsn_diagram", None)
+            if opener:
+                opener(obj.diagram)
+        elif typ == "solution" and self.app:
+            for case in self.library.cases:
+                if obj in case.solutions:
+                    opener = getattr(self.app, "open_gsn_diagram", None)
+                    if opener:
+                        opener(case.diagram)
+                    break
+
+    # ------------------------------------------------------------------
+    def _on_double_click(self, event):
+        self.open_item()
+
+    # ------------------------------------------------------------------
+    def _create_icon(self, shape: str, color: str = "black") -> tk.PhotoImage:
+        """Return a simple 16x16 icon for treeview items."""
+        size = 16
+        img = tk.PhotoImage(width=size, height=size)
+        img.put("white", to=(0, 0, size - 1, size - 1))
+        c = color
+        if shape == "circle":
+            r = size // 2 - 2
+            cx = cy = size // 2
+            for y in range(size):
+                for x in range(size):
+                    if (x - cx) ** 2 + (y - cy) ** 2 <= r * r:
+                        img.put(c, (x, y))
+        elif shape == "diamond":
+            mid = size // 2
+            for y in range(2, size - 2):
+                span = mid - abs(mid - y)
+                img.put(c, to=(mid - span, y, mid + span + 1, y + 1))
+        elif shape == "rect":
+            for x in range(3, size - 3):
+                img.put(c, (x, 3))
+                img.put(c, (x, size - 4))
+            for y in range(3, size - 3):
+                img.put(c, (3, y))
+                img.put(c, (size - 4, y))
+        elif shape == "folder":
+            for x in range(1, size - 1):
+                img.put(c, (x, 4))
+                img.put(c, (x, size - 2))
+            for y in range(4, size - 1):
+                img.put(c, (1, y))
+                img.put(c, (size - 2, y))
+            for x in range(3, size - 3):
+                img.put(c, (x, 2))
+            img.put(c, to=(1, 3, size - 2, 4))
+        return img

--- a/tests/test_safety_case_explorer.py
+++ b/tests/test_safety_case_explorer.py
@@ -1,0 +1,70 @@
+import types
+from tkinter import simpledialog
+
+from gsn import GSNNode, GSNDiagram
+from analysis.safety_case import SafetyCaseLibrary
+from gui.safety_case_explorer import SafetyCaseExplorer
+from gui import messagebox
+
+
+def test_create_edit_delete_case(monkeypatch):
+    root = GSNNode("G", "Goal")
+    sol = GSNNode("S", "Solution")
+    root.add_child(sol)
+    diag = GSNDiagram(root)
+    diag.add_node(sol)
+
+    explorer = SafetyCaseExplorer.__new__(SafetyCaseExplorer)
+
+    class DummyTree:
+        def __init__(self):
+            self.items = {}
+            self.counter = 0
+            self.selection_item = None
+
+        def delete(self, *items):
+            self.items = {}
+
+        def get_children(self, item=""):
+            return [iid for iid, meta in self.items.items() if meta["parent"] == item]
+
+        def insert(self, parent, index, text="", image=None):
+            iid = f"i{self.counter}"
+            self.counter += 1
+            self.items[iid] = {"parent": parent, "text": text}
+            return iid
+
+        def selection(self):
+            return (self.selection_item,) if self.selection_item else ()
+
+    explorer.tree = DummyTree()
+    explorer.app = types.SimpleNamespace(gsn_diagrams=[diag])
+    explorer.library = SafetyCaseLibrary()
+    explorer.item_map = {}
+    explorer.case_icon = explorer.solution_icon = None
+
+    SafetyCaseExplorer.populate(explorer)
+
+    inputs = iter(["Case1", root.user_name])
+    monkeypatch.setattr(simpledialog, "askstring", lambda *a, **k: next(inputs))
+    SafetyCaseExplorer.new_case(explorer)
+    assert len(explorer.library.cases) == 1
+    texts = [meta["text"] for meta in explorer.tree.items.values()]
+    assert "Case1" in texts
+    assert "S" in texts
+
+    for iid, (typ, obj) in explorer.item_map.items():
+        if typ == "case":
+            explorer.tree.selection_item = iid
+            break
+    inputs = iter(["Renamed", root.user_name])
+    monkeypatch.setattr(simpledialog, "askstring", lambda *a, **k: next(inputs))
+    SafetyCaseExplorer.edit_case(explorer)
+    assert explorer.library.cases[0].name == "Renamed"
+    for iid, (typ, obj) in explorer.item_map.items():
+        if typ == "case":
+            explorer.tree.selection_item = iid
+            break
+    monkeypatch.setattr(messagebox, "askokcancel", lambda *a, **k: True)
+    SafetyCaseExplorer.delete_case(explorer)
+    assert explorer.library.cases == []


### PR DESCRIPTION
## Summary
- add data structures for safety & security cases with solution collection
- introduce SafetyCaseExplorer GUI to create, edit, delete and browse cases derived from GSN diagrams
- integrate SafetyCaseExplorer into menus and analysis tree

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ced3916688325867dc2c37edffcdb