### PR TITLE
Fix governance explorer duplicate diagram names

### DIFF
--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -142,9 +142,11 @@ class SafetyManagementExplorer(tk.Frame):
         name = simpledialog.askstring("New Diagram", "Name:", parent=self)
         if not name:
             return
-        self.toolbox.create_diagram(name)
+        diag_id = self.toolbox.create_diagram(name)
+        repo = SysMLRepository.get_instance()
+        actual = repo.diagrams.get(diag_id).name
         if typ == "module" and obj is not None:
-            obj.diagrams.append(name)
+            obj.diagrams.append(actual)
         self.populate()
 
     # ------------------------------------------------------------------
@@ -159,8 +161,8 @@ class SafetyManagementExplorer(tk.Frame):
             )
             if not new or new == obj:
                 return
-            self.toolbox.rename_diagram(obj, new)
-            self._replace_name_in_modules(obj, new, self.toolbox.modules)
+            actual = self.toolbox.rename_diagram(obj, new)
+            self._replace_name_in_modules(obj, actual, self.toolbox.modules)
         elif typ == "module":
             new = simpledialog.askstring(
                 "Rename Folder", "Name:", initialvalue=obj.name, parent=self

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -123,10 +123,10 @@ class SafetyManagementWindow(tk.Frame):
         new = simpledialog.askstring("Rename Diagram", "Name:", initialvalue=old, parent=self)
         if not new or new == old:
             return
-        self.toolbox.rename_diagram(old, new)
+        actual = self.toolbox.rename_diagram(old, new)
         self.refresh_diagrams()
-        self.diag_var.set(new)
-        self.open_diagram(new)
+        self.diag_var.set(actual)
+        self.open_diagram(actual)
 
     def select_diagram(self, *_):
         name = self.diag_var.get()


### PR DESCRIPTION
## Summary
- Ensure SafetyManagementToolbox stores the repository-assigned name when creating governance diagrams and returns the final unique name when renaming
- Update SafetyManagement explorer and toolbox UI to use actual diagram names for creation and renaming
- Add regression test covering duplicate diagram names

## Testing
- `python -m pytest tests/test_safety_management.py::test_safety_management_explorer_creates_folders_and_diagrams tests/test_safety_management.py::test_explorer_renames_folders_and_diagrams tests/test_safety_management.py::test_explorer_allows_diagram_at_root tests/test_safety_management.py::test_explorer_handles_duplicate_names -q`


------
https://chatgpt.com/codex/tasks/task_b_689dc70ab0248325be2e760defd1f5df