### PR TITLE
Add requirement traceability and serialization support

### DIFF
--- a/analysis/models.py
+++ b/analysis/models.py
@@ -556,6 +556,31 @@ RELIABILITY_MODELS = {
 
 global_requirements = {}
 
+
+def ensure_requirement_defaults(req: dict) -> dict:
+    """Ensure a requirement dictionary has mandatory default fields.
+
+    Parameters
+    ----------
+    req:
+        Requirement dictionary to normalise.
+
+    Returns
+    -------
+    dict
+        The updated requirement dictionary with default fields present.
+
+    Notes
+    -----
+    Each requirement now carries a ``traces`` list capturing diagram or
+    element identifiers that reference the requirement.  When older
+    models are loaded the field may be missing; this helper guarantees the
+    key exists so callers can rely on it.
+    """
+
+    req.setdefault("traces", [])
+    return req
+
 # Requirement type options used throughout the GUI when creating or
 # editing safety requirements.  The list retains the original "vehicle"
 # and "operational" categories and adds new ones for functional,

--- a/tests/test_requirement_traces_persistence.py
+++ b/tests/test_requirement_traces_persistence.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import types
+
+# Stub out PIL modules to avoid dependency
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import FaultTreeApp
+from analysis.models import global_requirements
+
+
+def _minimal_app():
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.top_events = []
+    app.fmeas = []
+    app.fmedas = []
+    app.fmea_entries = []
+    app.fmeda_entries = []
+    app.mechanism_libraries = []
+    app.selected_mechanism_libraries = []
+    app.mission_profiles = []
+    app.reliability_analyses = []
+    app.hazop_docs = []
+    app.hara_docs = []
+    app.stpa_docs = []
+    app.threat_docs = []
+    app.fi2tc_docs = []
+    app.tc2fi_docs = []
+    app.hazop_entries = []
+    app.fi2tc_entries = []
+    app.tc2fi_entries = []
+    app.scenario_libraries = []
+    app.odd_libraries = []
+    app.faults = []
+    app.malfunctions = []
+    app.hazards = []
+    app.failures = []
+    app.project_properties = {}
+    app.reviews = []
+    app.review_data = None
+    app.versions = {}
+    app.update_odd_elements = lambda: None
+    app.update_failure_list = lambda: None
+    app.load_default_mechanisms = lambda: None
+    app.update_hazard_list = lambda: None
+    app.update_hara_statuses = lambda: None
+    app.update_fta_statuses = lambda: None
+    app.get_all_basic_events = lambda: []
+    app.get_all_nodes = lambda te: []
+    app.get_all_fmea_entries = lambda: []
+    app.update_global_requirements_from_nodes = lambda *args, **kwargs: None
+    app.sync_hara_to_safety_goals = lambda: None
+    app.close_page_diagram = lambda: None
+    app.update_views = lambda: None
+    return app
+
+
+def test_requirement_traces_roundtrip():
+    global_requirements.clear()
+    rid = "R1"
+    global_requirements[rid] = {"id": rid, "text": "Req1", "traces": ["D1", "E2"]}
+
+    app = _minimal_app()
+    data = app.export_model_data(include_versions=False)
+    assert data["global_requirements"][rid]["traces"] == ["D1", "E2"]
+
+    global_requirements.clear()
+    app2 = _minimal_app()
+    app2.apply_model_data(data, ensure_root=False)
+    assert global_requirements[rid]["traces"] == ["D1", "E2"]


### PR DESCRIPTION
## Summary
- add `traces` list to requirement dictionaries and helper to ensure field exists
- serialize/deserialize requirement traces with model export and load
- test persistence of requirement traces

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689dd1c6ca888325b23f0c9f45977ea8