### PR TITLE
Open requirements explorer inside workspace tab

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -16574,10 +16574,12 @@ class FaultTreeApp:
         self._haz_exp_window = HazardExplorerWindow(self)
 
     def show_requirements_explorer(self):
-        if hasattr(self, "_req_exp_window") and self._req_exp_window.winfo_exists():
-            self._req_exp_window.lift()
-            return
-        self._req_exp_window = RequirementsExplorerWindow(self)
+        if hasattr(self, "_req_exp_tab") and self._req_exp_tab.winfo_exists():
+            self.doc_nb.select(self._req_exp_tab)
+        else:
+            self._req_exp_tab = self._new_tab("Requirements Explorer")
+            self._req_exp_window = RequirementsExplorerWindow(self._req_exp_tab, self)
+            self._req_exp_window.pack(fill=tk.BOTH, expand=True)
 
     def _register_close(self, win, collection):
         def _close():

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -3898,15 +3898,20 @@ class DiagramElementDialog(simpledialog.Dialog):  # pragma: no cover - requires 
         self.selection = [self._options[i] for i in sels]
 
 
-class RequirementsExplorerWindow(tk.Toplevel):
+class RequirementsExplorerWindow(tk.Frame):
     """Read-only list of global requirements with filter options."""
 
     STATUSES = ["", "draft", "in review", "peer reviewed", "pending approval", "approved"]
 
-    def __init__(self, app):
-        super().__init__(app.root)
+    def __init__(self, master, app=None):
+        if app is None and hasattr(master, "root"):
+            app = master
+            master = tk.Toplevel(app.root)
+        super().__init__(master)
         self.app = app
-        self.title("Requirements Explorer")
+        if isinstance(master, tk.Toplevel):
+            master.title("Requirements Explorer")
+            self.pack(fill=tk.BOTH, expand=True)
 
         filter_frame = ttk.Frame(self)
         filter_frame.pack(fill=tk.X, padx=5, pady=2)


### PR DESCRIPTION
## Summary
- Refactor Requirements Explorer into a reusable frame that can embed in notebooks or standalone windows
- Add requirements explorer as a tab within the workspace instead of a separate window

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689df085e1a08325878d89a184d82bd6