### PR TITLE
feat: enable movable governance relationships

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3377,6 +3377,22 @@ class SysMLDiagramWindow(tk.Frame):
                         if abs(mx - x) <= 4 and abs(my - y) <= 4:
                             self.dragging_point_index = 0
                             self.conn_drag_offset = (x - mx, 0)
+                elif (
+                    self.repo.diagrams.get(self.diagram_id).diag_type
+                    == "Governance Diagram"
+                    and conn.style == "Straight"
+                ):
+                    src_obj = self.get_object(conn.src)
+                    dst_obj = self.get_object(conn.dst)
+                    if src_obj and dst_obj:
+                        mx = ((src_obj.x + dst_obj.x) / 2) * self.zoom
+                        my = ((src_obj.y + dst_obj.y) / 2) * self.zoom
+                        if abs(mx - x) <= 4 and abs(my - y) <= 4:
+                            conn.style = "Custom"
+                            if not conn.points:
+                                conn.points.append((mx / self.zoom, my / self.zoom))
+                            self.dragging_point_index = 0
+                            self.conn_drag_offset = (x - mx, y - my)
                 # check for dragging endpoints
                 src_obj = self.get_object(conn.src)
                 dst_obj = self.get_object(conn.dst)
@@ -6603,6 +6619,18 @@ class SysMLDiagramWindow(tk.Frame):
                     hy - s,
                     mx + s,
                     hy + s,
+                    outline="red",
+                    fill="white",
+                    tags="connection",
+                )
+            elif diag and diag.diag_type == "Governance Diagram" and conn.style == "Straight":
+                mx, my = (ax + bx) / 2, (ay + by) / 2
+                s = 3
+                self.canvas.create_rectangle(
+                    mx - s,
+                    my - s,
+                    mx + s,
+                    my + s,
                     outline="red",
                     fill="white",
                     tags="connection",

--- a/tests/test_governance_relationship_move.py
+++ b/tests/test_governance_relationship_move.py
@@ -1,0 +1,81 @@
+import types
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sysml.sysml_repository import SysMLRepository
+from gui.architecture import SysMLDiagramWindow, SysMLObject, DiagramConnection
+
+
+class DummyCanvas:
+    def canvasx(self, x):
+        return x
+
+    def canvasy(self, y):
+        return y
+
+    def delete(self, *args, **kwargs):
+        pass
+
+    def configure(self, **kwargs):
+        pass
+
+
+class DummyEvent:
+    def __init__(self, x, y, state=0):
+        self.x = x
+        self.y = y
+        self.state = state
+
+
+class GovernanceConnectionDragTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def _create_window(self):
+        repo = self.repo
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
+        a = SysMLObject(1, "Work Product", 0.0, 0.0)
+        b = SysMLObject(2, "Work Product", 100.0, 0.0)
+        win.objects = [a, b]
+        conn = DiagramConnection(a.obj_id, b.obj_id, "Flow")
+        win.connections = [conn]
+        win.canvas = DummyCanvas()
+        win.zoom = 1.0
+        win.current_tool = "Select"
+        win.selected_obj = None
+        win.selected_objs = []
+        win.selected_conn = None
+        win.dragging_point_index = None
+        win.dragging_endpoint = None
+        win.conn_drag_offset = None
+        win.endpoint_drag_pos = None
+        win.start = None
+        win.temp_line_end = None
+        win.select_rect_start = None
+        win.resizing_obj = None
+        win.drag_offset = (0, 0)
+        win.find_connection = lambda *args, **kwargs: conn
+        win.get_object = SysMLDiagramWindow.get_object.__get__(win)
+        win.redraw = lambda: None
+        win._sync_to_repository = lambda: None
+        win.update_property_view = lambda: None
+        return win, conn
+
+    def test_connection_midpoint_drag_creates_custom_point(self):
+        win, conn = self._create_window()
+        win.on_left_press(DummyEvent(50, 0))
+        self.assertEqual(win.dragging_point_index, 0)
+        self.assertEqual(conn.style, "Custom")
+        win.on_left_drag(DummyEvent(60, 10))
+        self.assertEqual(conn.points[0], (60.0, 10.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow dragging governance diagram connections via midpoint handle
- test for draggable governance connections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689df7f6812c8325b094c8dc3c455cc2