### PR TITLE
Ensure governance diagrams disable removed work products

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6907,22 +6907,27 @@ class SysMLDiagramWindow(tk.Frame):
             if result is None:
                 return
             for obj in list(self.selected_objs):
+                if obj.obj_type == "Work Product":
+                    name = obj.properties.get("name", "")
+                    if getattr(self.app, "can_remove_work_product", None):
+                        if not self.app.can_remove_work_product(name):
+                            messagebox.showerror(
+                                "Delete",
+                                f"Cannot delete work product '{name}' with existing artifacts.",
+                            )
+                            continue
+                    getattr(self.app, "disable_work_product", lambda *_: None)(name)
+                    toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+                    if toolbox:
+                        diag = self.repo.diagrams.get(self.diagram_id)
+                        diagram_name = diag.name if diag else ""
+                        toolbox.remove_work_product(diagram_name, name)
                 if result:
                     if obj.obj_type == "Part":
                         self.remove_part_model(obj)
                     else:
                         self.remove_element_model(obj)
                 else:
-                    if obj.obj_type == "Work Product":
-                        name = obj.properties.get("name", "")
-                        if getattr(self.app, "can_remove_work_product", None):
-                            if not self.app.can_remove_work_product(name):
-                                messagebox.showerror(
-                                    "Delete",
-                                    f"Cannot delete work product '{name}' with existing artifacts.",
-                                )
-                                continue
-                            getattr(self.app, "disable_work_product", lambda *_: None)(name)
                     self.remove_object(obj)
             self.selected_objs = []
             self.selected_obj = None

--- a/tests/test_governance_work_product_removal.py
+++ b/tests/test_governance_work_product_removal.py
@@ -1,0 +1,53 @@
+from gui import messagebox
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
+from analysis import SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_delete_work_product_updates_toolbox(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_work_product("Gov1", "FI2TC", "")
+
+    disabled: list[str] = []
+
+    class DummyApp:
+        def can_remove_work_product(self, name):
+            return True
+
+        def disable_work_product(self, name):
+            disabled.append(name)
+
+        safety_mgmt_toolbox = toolbox
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.selected_conn = None
+    win.zoom = 1.0
+    win.remove_object = GovernanceDiagramWindow.remove_object.__get__(win, GovernanceDiagramWindow)
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    win.remove_part_model = GovernanceDiagramWindow.remove_part_model.__get__(win, GovernanceDiagramWindow)
+    win.remove_element_model = GovernanceDiagramWindow.remove_element_model.__get__(win, GovernanceDiagramWindow)
+
+    wp = SysMLObject(1, "Work Product", 0, 0, properties={"name": "FI2TC"})
+    win.objects.append(wp)
+    win.selected_objs = [wp]
+    win.selected_obj = wp
+    win.app = DummyApp()
+
+    monkeypatch.setattr(messagebox, "askyesnocancel", lambda *args, **kwargs: False)
+    monkeypatch.setattr(messagebox, "showerror", lambda *args, **kwargs: None)
+
+    win.delete_selected()
+
+    assert disabled == ["FI2TC"]
+    assert toolbox.work_products == []


### PR DESCRIPTION
## Summary
- disable menus and toolboxes when removing work products from governance diagrams
- cover governance work product removal with regression test

## Testing
- `PYTHONPATH=$PWD pytest tests/test_governance_actions.py tests/test_governance_work_product_removal.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689e19966aa483258cb93fd74f8b47a8