### PR TITLE
Enable fault prioritization and SPI tools

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2470,7 +2470,6 @@ class FaultTreeApp:
         qualitative_menu.add_command(
             label="Fault Prioritization",
             command=self.open_fault_prioritization_window,
-            state=tk.DISABLED,
         )
         # --- Quantitative Analysis Menu ---
         quantitative_menu = tk.Menu(menubar, tearoff=0)
@@ -2658,14 +2657,20 @@ class FaultTreeApp:
             "Safety & Security Management": self.open_safety_management_toolbox,
             "Safety & Security Management Explorer": self.manage_safety_management,
             "Safety & Security Case Explorer": self.manage_safety_cases,
+            "Safety Performance Indicators": self.show_safety_performance_indicators,
+            "Fault Prioritization": self.open_fault_prioritization_window,
         }
 
         self.tool_categories: dict[str, list[str]] = {
             "Safety & Security Management": [
                 "Safety & Security Management",
-            "Safety & Security Management Explorer",
-            "Safety & Security Case Explorer",
-        ]
+                "Safety & Security Management Explorer",
+                "Safety & Security Case Explorer",
+                "Safety Performance Indicators",
+            ],
+            "Safety Analysis": [
+                "Fault Prioritization",
+            ],
         }
         self.tool_to_work_product = {}
         for name, info in self.WORK_PRODUCT_INFO.items():


### PR DESCRIPTION
## Summary
- expose Fault Prioritization toolbox and include it in Safety Analysis tools
- register Safety Performance Indicators in tool list for quick access

## Testing
- `pytest` (fails: tests/test_governance_relationship_stereotype.py::GovernanceRelationshipStereotypeTests::test_used_relations_reject_non_analysis_targets, tests/test_governance_trace_relationship.py::GovernanceTraceRelationshipTests::test_trace_between_safety_analyses_disallowed, tests/test_governance_trace_relationship.py::GovernanceTraceRelationshipTests::test_used_by_between_safety_analyses_disallowed, tests/test_governance_work_product_enablement.py::test_governance_work_product_enablement[ODD Library-Scenario])
- `pytest tests/test_safety_management.py::test_tools_include_safety_management_explorer -q`


------
https://chatgpt.com/codex/tasks/task_b_689e53871c70832585f14b05832c0d82