### PR TITLE
Allow ODD to feed Scenario Library in governance diagrams

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -50,6 +50,7 @@ ALLOWED_ANALYSIS_USAGE: set[tuple[str, str]] = {
     # in connection validation so it is omitted here.
     ("Reliability Analysis", "FMEA"),
     ("Reliability Analysis", "FMEDA"),
+    ("ODD", "Scenario Library"),
 }
 
 # Work products that support governed inputs from other work products
@@ -88,6 +89,8 @@ ALLOWED_USAGE.update(
         ("Mission Profile", "FTA"),
         ("Requirement Specification", "HAZOP"),
         ("ODD", "Scenario Library"),
+        ("Reliability Analysis", "FMEA"),
+        ("Reliability Analysis", "FMEDA"),
     }
 )
 

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3219,6 +3219,12 @@ class SysMLDiagramWindow(tk.Frame):
                     return False, f"{conn_type} links must connect Work Products"
                 sname = src.properties.get("name")
                 dname = dst.properties.get("name")
+                if sname not in UNRESTRICTED_USAGE_SOURCES and (
+                    sname, dname
+                ) not in ALLOWED_USAGE:
+                    return False, (
+                        "No metamodel dependency between these work products"
+                    )
                 if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS and not (
                     sname == "ODD" and dname == "Scenario Library"
                 ):

--- a/tests/test_analysis_input_visibility.py
+++ b/tests/test_analysis_input_visibility.py
@@ -161,3 +161,59 @@ def test_analysis_inputs_respect_phase(analysis):
     assert toolbox.analysis_inputs(analysis) == set()
     toolbox.set_active_module("P1")
     assert toolbox.analysis_inputs(analysis) == {"Architecture Diagram"}
+
+
+def test_scenario_library_inputs_require_relationship():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    # Without any governance relationship the Scenario Library has no inputs
+    toolbox.work_products = [
+        SafetyWorkProduct("Gov", "ODD", ""),
+        SafetyWorkProduct("Gov", "Scenario Library", ""),
+    ]
+    assert toolbox.analysis_inputs("Scenario Library") == set()
+
+    # Create a Used By relationship from ODD to Scenario Library
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams = {"Gov": diag.diag_id}
+    e1 = repo.create_element("Block", name="E1")
+    e2 = repo.create_element("Block", name="E2")
+    repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+    repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+    o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "ODD"})
+    o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "Scenario Library"})
+    diag.objects = [o1.__dict__, o2.__dict__]
+    win = _create_window(repo, "Used By", o1, o2, diag)
+    GovernanceDiagramWindow.on_left_press(win, types.SimpleNamespace(x=0, y=0, state=0))
+    GovernanceDiagramWindow.on_left_press(win, types.SimpleNamespace(x=0, y=100, state=0))
+    diag.connections = [c.__dict__ for c in win.connections]
+    assert toolbox.analysis_inputs("Scenario Library") == {"ODD"}
+
+
+def test_scenario_library_inputs_respect_phase():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams = {"Gov": diag.diag_id}
+    toolbox.modules = [GovernanceModule("P1", diagrams=["Gov"]), GovernanceModule("P2")]
+    e1 = repo.create_element("Block", name="E1")
+    e2 = repo.create_element("Block", name="E2")
+    repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+    repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+    o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "ODD"})
+    o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "Scenario Library"})
+    diag.objects = [o1.__dict__, o2.__dict__]
+    win = _create_window(repo, "Used By", o1, o2, diag)
+    GovernanceDiagramWindow.on_left_press(win, types.SimpleNamespace(x=0, y=0, state=0))
+    GovernanceDiagramWindow.on_left_press(win, types.SimpleNamespace(x=0, y=100, state=0))
+    diag.connections = [c.__dict__ for c in win.connections]
+    toolbox.work_products = [
+        SafetyWorkProduct("Gov", "ODD", ""),
+        SafetyWorkProduct("Gov", "Scenario Library", ""),
+    ]
+    toolbox.set_active_module("P2")
+    assert toolbox.analysis_inputs("Scenario Library") == set()
+    toolbox.set_active_module("P1")
+    assert toolbox.analysis_inputs("Scenario Library") == {"ODD"}

--- a/tests/test_governance_trace_relationship.py
+++ b/tests/test_governance_trace_relationship.py
@@ -274,7 +274,7 @@ class GovernanceTraceRelationshipTests(unittest.TestCase):
                 win, scenario_lib, odd, rel
             )
             self.assertFalse(valid)
-            self.assertIn("safety analysis work product", msg)
+            self.assertIn("metamodel dependency", msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow ODD work products to connect to Scenario Library using "Used" relationships
- block Scenario Library -> ODD "Used" links and enforce dependency checks for work product usage
- hide ODD libraries when editing Scenario Library unless a governed ODD->Scenario Library link exists in the active lifecycle phase
- extend tests for ODD/Scenario Library governance connections and input visibility

## Testing
- `PYTHONPATH=. pytest tests/test_analysis_input_visibility.py::test_scenario_library_inputs_require_relationship -q`
- `PYTHONPATH=. pytest tests/test_analysis_input_visibility.py::test_scenario_library_inputs_respect_phase -q`
- `PYTHONPATH=. pytest tests/test_governance_trace_relationship.py -k used_allows_odd_to_scenario_library -q`
- `PYTHONPATH=. pytest tests/test_governance_trace_relationship.py -k used_disallows_scenario_library_to_odd -q`
- `PYTHONPATH=. pytest tests/test_governance_relationship_stereotype.py::GovernanceRelationshipStereotypeTests::test_used_relationship_requires_dependency -q`
- `PYTHONPATH=. pytest tests/test_governance_relationship_stereotype.py::GovernanceRelationshipStereotypeTests::test_odd_scenario_library_used_relationships -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e8805ed9c8327bc66982277da5871