### PR TITLE
Fix escape warnings in causal Bayesian network docs

### DIFF
--- a/analysis/causal_bayesian_network.py
+++ b/analysis/causal_bayesian_network.py
@@ -181,7 +181,7 @@ class CausalBayesianNetwork:
 
     # ------------------------------------------------------------------
     def marginal_probabilities(self) -> Dict[str, float]:
-        """Return ``P(node=True)`` for every node.
+        r"""Return ``P(node=True)`` for every node.
 
         This implementation follows the standard marginalisation formula
 
@@ -242,7 +242,7 @@ class CausalBayesianNetwork:
 
     # ------------------------------------------------------------------
     def joint_probability(self, assignment: Mapping[str, bool]) -> float:
-        """Return ``P(assignment)`` for the provided variable/value mapping.
+        r"""Return ``P(assignment)`` for the provided variable/value mapping.
 
         The computation mirrors the classic factorisation of a Bayesian
         network, ``\prod_i P(X_i \mid Parents(X_i))``, while summing out all


### PR DESCRIPTION
## Summary
- mark probability docstrings as raw strings to avoid invalid escape warnings

## Testing
- `pytest -q` *(fails: IndexError, ValueError in causal Bayesian network tests)*

------
https://chatgpt.com/codex/tasks/task_b_689ed28454dc8327b911b6ca17369fcb