### PR TITLE
Streamline Bayesian network editor selection handling

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -36,7 +36,6 @@ class CausalBayesianNetworkWindow(tk.Frame):
         toolbox = ttk.Frame(body)
         toolbox.pack(side=tk.LEFT, fill=tk.Y)
         for name in (
-            "Select",
             "Triggering Condition",
             "Existing Triggering Condition",
             "Functional Insufficiency",
@@ -162,6 +161,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
             prompt = self.current_tool
             name = simpledialog.askstring(prompt, "Name:", parent=self)
             if not name or name in doc.network.nodes:
+                self.select_tool("Select")
                 return
             x, y = event.x, event.y
             doc.network.add_node(name, cpd=0.5)
@@ -175,9 +175,11 @@ class CausalBayesianNetworkWindow(tk.Frame):
                 self.app, "update_functional_insufficiency_list"
             ):
                 self.app.update_functional_insufficiency_list()
+            self.select_tool("Select")
         elif self.current_tool == "Existing Triggering Condition":
             names = self._select_triggering_conditions()
             if not names:
+                self.select_tool("Select")
                 return
             x, y = event.x, event.y
             for idx, name in enumerate(names):
@@ -190,9 +192,11 @@ class CausalBayesianNetworkWindow(tk.Frame):
                 self._draw_node(name, nx, y, "trigger")
             if hasattr(self.app, "update_triggering_condition_list"):
                 self.app.update_triggering_condition_list()
+            self.select_tool("Select")
         elif self.current_tool == "Existing Functional Insufficiency":
             names = self._select_functional_insufficiencies()
             if not names:
+                self.select_tool("Select")
                 return
             x, y = event.x, event.y
             for idx, name in enumerate(names):
@@ -205,9 +209,11 @@ class CausalBayesianNetworkWindow(tk.Frame):
                 self._draw_node(name, nx, y, "insufficiency")
             if hasattr(self.app, "update_functional_insufficiency_list"):
                 self.app.update_functional_insufficiency_list()
+            self.select_tool("Select")
         elif self.current_tool == "Relationship":
             name = self._find_node(event.x, event.y)
             if not name:
+                self.select_tool("Select")
                 return
             self.edge_start = name
             self._highlight_node(None)
@@ -284,6 +290,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
             if self.temp_edge_anim:
                 self.after_cancel(self.temp_edge_anim)
                 self.temp_edge_anim = None
+            self.select_tool("Select")
 
     # ------------------------------------------------------------------
     def _animate_temp_edge(self):

--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -311,6 +311,22 @@ def test_drag_relationship_creates_edge():
     win.on_release(types.SimpleNamespace(x=100, y=0))
     assert len(win.edges) == 1
     assert "A" in doc.network.parents.get("B", [])
+    assert win.current_tool == "Select"
+
+
+def test_add_node_returns_to_select():
+    from gui import causal_bayesian_network_window as cbn_mod
+
+    win, doc = _setup_window()
+    win.current_tool = "Triggering Condition"
+    orig = cbn_mod.simpledialog.askstring
+    cbn_mod.simpledialog.askstring = lambda *a, **k: "N1"
+    try:
+        win.on_click(types.SimpleNamespace(x=10, y=20))
+    finally:
+        cbn_mod.simpledialog.askstring = orig
+    assert "N1" in doc.network.nodes
+    assert win.current_tool == "Select"
 
 
 def test_joint_probabilities_refresh_on_parent_change():


### PR DESCRIPTION
## Summary
- Remove explicit Select button from Bayesian network toolbox
- Automatically revert to Select mode after adding nodes or relationships
- Expand UI tests to cover mode reset behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ed559b40483279927f13cd7d71f7e