### PR TITLE
Allow Safety & AI links with governance elements

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -56,6 +56,22 @@ ARCH_DIAGRAM_TYPES = {
     "Internal Block Diagram",
 }
 
+# Elements available in the Safety & AI Lifecycle toolbox
+SAFETY_AI_NODE_TYPES = {"Database", "ANN", "Data acquisition"}
+
+# Elements from the governance toolbox that may participate in
+# Safety & AI relationships
+GOVERNANCE_NODE_TYPES = {
+    "Action",
+    "Initial",
+    "Final",
+    "Decision",
+    "Merge",
+    "System Boundary",
+    "Work Product",
+    "Lifecycle Phase",
+}
+
 
 def _work_product_name(diag_type: str) -> str:
     """Return work product name for a given diagram type."""
@@ -3310,10 +3326,17 @@ class SysMLDiagramWindow(tk.Frame):
                 "Ingestion",
                 "Model evaluation",
             ):
-                allowed_types = {"Database", "ANN", "Data acquisition"}
-                if src.obj_type not in allowed_types or dst.obj_type not in allowed_types:
+                allowed = SAFETY_AI_NODE_TYPES | GOVERNANCE_NODE_TYPES
+                if not (
+                    src.obj_type in allowed
+                    and dst.obj_type in allowed
+                    and (
+                        src.obj_type in SAFETY_AI_NODE_TYPES
+                        or dst.obj_type in SAFETY_AI_NODE_TYPES
+                    )
+                ):
                     return False, (
-                        "Safety & AI relationships must connect Safety & AI elements"
+                        "Safety & AI relationships must connect Safety & AI and/or Governance elements"
                     )
             elif conn_type in (
                 "Used By",
@@ -3365,29 +3388,12 @@ class SysMLDiagramWindow(tk.Frame):
                             "already exists in this phase",
                         )
             else:
+                ai_targets = SAFETY_AI_NODE_TYPES
                 allowed = {
-                    "Initial": {
-                        "Action",
-                        "Decision",
-                        "Merge",
-                    },
-                    "Action": {
-                        "Action",
-                        "Decision",
-                        "Merge",
-                        "Final",
-                    },
-                    "Decision": {
-                        "Action",
-                        "Decision",
-                        "Merge",
-                        "Final",
-                    },
-                    "Merge": {
-                        "Action",
-                        "Decision",
-                        "Merge",
-                    },
+                    "Initial": {"Action", "Decision", "Merge", *ai_targets},
+                    "Action": {"Action", "Decision", "Merge", "Final", *ai_targets},
+                    "Decision": {"Action", "Decision", "Merge", "Final", *ai_targets},
+                    "Merge": {"Action", "Decision", "Merge", *ai_targets},
                     "Final": set(),
                 }
                 if src.obj_type == "Final":

--- a/tests/test_governance_safety_ai_connections.py
+++ b/tests/test_governance_safety_ai_connections.py
@@ -1,0 +1,47 @@
+import unittest
+import types
+
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+class GovernanceSafetyAIConnectionTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+
+    def tearDown(self):
+        SysMLRepository.reset_instance()
+
+    def _window(self, diag):
+        return types.SimpleNamespace(repo=self.repo, diagram_id=diag.diag_id)
+
+    def _make_nodes(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        gobj = SysMLObject(1, "Action", 0, 0, element_id=e1.elem_id)
+        aiobj = SysMLObject(2, "Database", 0, 100, element_id=e2.elem_id)
+        diag.objects = [gobj.__dict__, aiobj.__dict__]
+        return diag, gobj, aiobj
+
+    def test_safety_ai_relationship_between_governance_and_ai(self):
+        diag, gobj, aiobj = self._make_nodes()
+        win = self._window(diag)
+        valid, _ = GovernanceDiagramWindow.validate_connection(win, gobj, aiobj, "Annotation")
+        self.assertTrue(valid)
+        valid, _ = GovernanceDiagramWindow.validate_connection(win, aiobj, gobj, "Annotation")
+        self.assertTrue(valid)
+
+    def test_flow_from_governance_to_ai_allowed(self):
+        diag, gobj, aiobj = self._make_nodes()
+        win = self._window(diag)
+        valid, _ = GovernanceDiagramWindow.validate_connection(win, gobj, aiobj, "Flow")
+        self.assertTrue(valid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- permit Safety & AI relationships between governance and Safety & AI nodes
- allow flow connections from governance elements to Safety & AI elements
- add tests for cross-toolbox connections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f35bdc0bc8327a77d508f56ad2d3a