### PR TITLE
Add label support for governance diagram relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ coordinating reviews and communicating how safety, cybersecurity and AI
 assurance fit together across the item’s lifecycle.
 
 Governance diagrams can also produce **derived requirements**.  Each task,
-flow and relationship—including any optional conditions—is converted into a
-natural language statement so governance models can be exported as concise
-requirements lists.
+flow and relationship—including any optional conditions or labels—is
+converted into a natural language statement so governance models can be
+exported as concise requirements lists.
 
 When editing a governance diagram in the Safety & Security Management tool,
 use the **Requirements** button to generate these statements and view them in
@@ -91,7 +91,9 @@ diagram = GovernanceDiagram()
 diagram.add_task("Draft Plan")
 diagram.add_task("Review Plan")
 diagram.add_flow("Draft Plan", "Review Plan", condition="plan complete")
-diagram.add_relationship("Review Plan", "Draft Plan", "changes requested")
+diagram.add_relationship(
+    "Review Plan", "Draft Plan", condition="changes requested", label="rework"
+)
 
 for req in diagram.generate_requirements():
     print(req)
@@ -103,7 +105,7 @@ Running this script produces:
 The system shall perform task 'Draft Plan'.
 The system shall perform task 'Review Plan'.
 When plan complete, task 'Draft Plan' shall precede task 'Review Plan'.
-Task 'Review Plan' shall be related to task 'Draft Plan' when changes requested.
+Task 'Review Plan' shall rework task 'Draft Plan' when changes requested.
 ```
 
 ## Workflow Overview

--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -43,15 +43,31 @@ class GovernanceDiagram:
         self.edge_data[(src, dst)] = {"kind": "flow", "condition": condition}
 
     def add_relationship(
-        self, src: str, dst: str, condition: str | None = None
+        self,
+        src: str,
+        dst: str,
+        condition: str | None = None,
+        label: str | None = None,
     ) -> None:
-        """Add a non-flow relationship between two existing tasks."""
+        """Add a non-flow relationship between two existing tasks.
+
+        Parameters
+        ----------
+        src, dst:
+            Names of the existing source and destination tasks.
+        condition:
+            Optional textual condition that must hold for the relationship.
+        label:
+            Optional label describing the relationship between the tasks.
+        """
+
         if not self.graph.has_node(src) or not self.graph.has_node(dst):
             raise ValueError("Both tasks must exist before creating a relationship")
         self.graph.add_edge(src, dst)
         self.edge_data[(src, dst)] = {
             "kind": "relationship",
             "condition": condition,
+            "label": label,
         }
 
     def tasks(self) -> List[str]:
@@ -78,9 +94,9 @@ class GovernanceDiagram:
     def generate_requirements(self) -> List[str]:
         """Generate textual requirements from the diagram.
 
-        Tasks, flows, relationships and any optional conditions are converted
-        into simple natural language statements for downstream processing or
-        documentation.
+        Tasks, flows, relationships and any optional conditions or labels are
+        converted into simple natural language statements for downstream
+        processing or documentation.
         """
 
         requirements: List[str] = []
@@ -89,19 +105,32 @@ class GovernanceDiagram:
             requirements.append(f"The system shall perform task '{task}'.")
 
         for src, dst in self.graph.edges():
-            data = self.edge_data.get((src, dst), {"kind": "flow", "condition": None})
+            data = self.edge_data.get(
+                (src, dst), {"kind": "flow", "condition": None, "label": None}
+            )
             cond = data.get("condition")
             kind = data.get("kind")
+            label = data.get("label")
             if kind == "flow":
                 if cond:
                     req = f"When {cond}, task '{src}' shall precede task '{dst}'."
                 else:
                     req = f"Task '{src}' shall precede task '{dst}'."
             else:  # relationship
-                if cond:
-                    req = f"Task '{src}' shall be related to task '{dst}' when {cond}."
+                if label:
+                    if cond:
+                        req = (
+                            f"Task '{src}' shall {label} task '{dst}' when {cond}."
+                        )
+                    else:
+                        req = f"Task '{src}' shall {label} task '{dst}'."
                 else:
-                    req = f"Task '{src}' shall be related to task '{dst}'."
+                    if cond:
+                        req = (
+                            f"Task '{src}' shall be related to task '{dst}' when {cond}."
+                        )
+                    else:
+                        req = f"Task '{src}' shall be related to task '{dst}'."
             requirements.append(req)
 
         return requirements
@@ -156,11 +185,16 @@ class GovernanceDiagram:
             dst = id_to_name.get(cdict.get("dst"))
             if not src or not dst:
                 continue
-            cond = cdict.get("name") or cdict.get("properties", {}).get("condition")
+            name = cdict.get("name")
+            cond = cdict.get("properties", {}).get("condition")
             if cdict.get("conn_type") == "Flow":
-                diagram.add_flow(src, dst, cond)
+                diagram.add_flow(src, dst, cond or name)
             else:
-                diagram.add_relationship(src, dst, cond)
+                if cond is None and name is not None:
+                    # Backwards compatibility: older diagrams used the name as the condition
+                    diagram.add_relationship(src, dst, condition=name)
+                else:
+                    diagram.add_relationship(src, dst, condition=cond, label=name)
 
         return diagram
 
@@ -169,6 +203,8 @@ if __name__ == "__main__":  # pragma: no cover - example usage for docs
     demo.add_task("Draft Plan")
     demo.add_task("Review Plan")
     demo.add_flow("Draft Plan", "Review Plan")
-    demo.add_relationship("Review Plan", "Draft Plan", "changes requested")
+    demo.add_relationship(
+        "Review Plan", "Draft Plan", condition="changes requested", label="rework"
+    )
     for requirement in demo.generate_requirements():
         print(requirement)

--- a/tests/test_governance_relationship_label.py
+++ b/tests/test_governance_relationship_label.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram
+
+
+def test_label_relationship_between_database_nodes():
+    diagram = GovernanceDiagram()
+    diagram.add_task("User DB")
+    diagram.add_task("Analytics DB")
+    diagram.add_relationship("User DB", "Analytics DB", label="sync with")
+
+    assert diagram.edge_data[("User DB", "Analytics DB")]["label"] == "sync with"
+
+    reqs = diagram.generate_requirements()
+    assert "Task 'User DB' shall sync with task 'Analytics DB'." in reqs


### PR DESCRIPTION
## Summary
- allow specifying optional labels on governance diagram relationships
- include relationship labels when converting diagrams from repositories
- document and test labeled relationships

## Testing
- `pytest tests/test_governance_requirements_generator.py tests/test_governance_relationship_label.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689f424862448327868a1b983f9b5cf3