### PR TITLE
Fix Safety Management toolbox activation

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -16669,94 +16669,6 @@ class FaultTreeApp:
         self.refresh_all()
 
     def open_safety_management_toolbox(self):
-        """Open a placeholder tab for the Safety & Security Management toolbox."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        msg = (
-            "Safety & Security Management toolbox initialized.\n"
-            "Future versions will provide a full graphical interface."
-        )
-        ttk.Label(self._safety_mgmt_tab, text=msg, justify=tk.CENTER).pack(
-            fill=tk.BOTH, expand=True, padx=10, pady=10
-        )
-
-    def open_safety_management_toolbox(self):
-        """Open a placeholder tab for the Safety & Security Management toolbox."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        msg = (
-            "Safety & Security Management toolbox initialized.\n"
-            "Future versions will provide a full graphical interface."
-        )
-        ttk.Label(self._safety_mgmt_tab, text=msg, justify=tk.CENTER).pack(
-            fill=tk.BOTH, expand=True, padx=10, pady=10
-        )
-
-    def open_safety_management_toolbox(self):
-        """Open the Safety & Security Management toolbox tab."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-        from gui.safety_management_toolbox import SafetyManagementToolbox as SMTGUI
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        gui = SMTGUI(self._safety_mgmt_tab, toolbox=self.safety_toolbox)
-        gui.pack(fill=tk.BOTH, expand=True)
-
-    def open_safety_management_toolbox(self):
-        """Open the Safety & Security Management toolbox tab."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-        from gui.safety_management_toolbox import SafetyManagementToolbox as SMTGUI
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        gui = SMTGUI(self._safety_mgmt_tab, toolbox=self.safety_toolbox)
-        gui.pack(fill=tk.BOTH, expand=True)
-
-    def open_safety_management_toolbox(self):
-        """Open a Safety & Security Management tab with an Activity Diagram."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from gui.architecture import ActivityDiagramWindow
-
-        ActivityDiagramWindow(self._safety_mgmt_tab, self)
-
-    def open_safety_management_toolbox(self):
         """Open the Safety & Security Management editor and browser."""
         if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
             self.doc_nb.select(self._safety_mgmt_tab)
@@ -16778,6 +16690,9 @@ class FaultTreeApp:
         # expected controls instead of appearing blank.
         if hasattr(self.safety_mgmt_window, "pack"):
             self.safety_mgmt_window.pack(fill=tk.BOTH, expand=True)
+
+        # Opening the toolbox can affect menu enablement, so refresh the UI.
+        self.refresh_all()
 
     def open_style_editor(self):
         """Open the diagram style editor window."""


### PR DESCRIPTION
## Summary
- ensure Safety & Security Management toolbox opens fully instead of placeholder
- refresh UI after activating toolbox

## Testing
- `pytest tests/test_safety_management.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689f49ebeb708327b296d9ab0c8515e1