### PR TITLE
Preserve connections when move canceled

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -609,8 +609,19 @@ class GSNDiagramWindow(tk.Frame):
         return None
 
     def _move_connection(
-        self, parent: GSNNode, old_child: GSNNode, new_child: GSNNode
+        self, parent: GSNNode, old_child: GSNNode, new_child: Optional[GSNNode]
     ) -> None:
+        """Reattach an existing relationship to a new child node.
+
+        If *new_child* is ``None`` the move is cancelled and the original
+        connection is left intact.  This ensures accidental drops on empty
+        space do not delete the relationship.
+        """
+
+        # Abort when the connection was not dropped on a valid node.
+        if new_child is None:
+            return
+
         app = getattr(self, "app", None)
         undo = getattr(app, "push_undo_state", None)
         if undo:

--- a/tests/test_gsn_connection_edit.py
+++ b/tests/test_gsn_connection_edit.py
@@ -82,6 +82,21 @@ def test_move_connection_updates_links():
     assert p in c2.parents
 
 
+def test_move_connection_cancelled_on_empty_drop():
+    p = GSNNode("p", "Goal")
+    c1 = GSNNode("c1", "Goal")
+    p.add_child(c1)
+    diag = GSNDiagram(p)
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.diagram = diag
+    win.refresh = lambda: None
+    # Attempt to move the connection without specifying a new child node.
+    win._move_connection(p, c1, None)
+    # The original relationship should remain intact.
+    assert c1 in p.children
+    assert p in c1.parents
+
+
 def test_delete_connection_removes_links():
     p = GSNNode("p", "Goal")
     c = GSNNode("c", "Context")


### PR DESCRIPTION
## Summary
- keep original connection when a move is dropped on empty space
- add regression test for cancelling connection moves

## Testing
- `pytest tests/test_gsn_connection_edit.py`


------
https://chatgpt.com/codex/tasks/task_b_689f5eedf89c8327b140e6a58a7ced5f