### PR TITLE
Implement structured requirement generation

### DIFF
--- a/tests/test_governance_decision_guard.py
+++ b/tests/test_governance_decision_guard.py
@@ -31,7 +31,8 @@ class GovernanceDecisionGuardTests(unittest.TestCase):
         self.assertIn(("A", "B"), gdiag.flows())
         self.assertEqual(gdiag.edge_data[("A", "B")]["condition"], "g1")
         reqs = gdiag.generate_requirements()
-        self.assertIn("When g1, task 'A' shall precede task 'B'.", reqs)
+        texts = [t for t, _ in reqs]
+        self.assertIn("When g1, task 'A' shall precede task 'B'.", texts)
 
 
 if __name__ == "__main__":

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -10,19 +10,44 @@ from analysis.governance import GovernanceDiagram
 
 def test_generate_requirements_from_governance_diagram():
     diagram = GovernanceDiagram()
-    diagram.add_task("Start")
-    diagram.add_task("Approve")
-    diagram.add_task("Finish")
-    diagram.add_flow("Start", "Approve")
-    diagram.add_flow("Approve", "Finish", condition="approval granted")
-    diagram.add_relationship("Start", "Finish", condition="risk identified")
+    diagram.add_task("Data Steward", node_type="Role")
+    diagram.add_task("Review Data", node_type="Activity")
+    diagram.add_task("Report", node_type="Document")
+    diagram.add_task("Policy DP-001", node_type="Policy")
+    diagram.add_relationship("Data Steward", "Review Data", label="performs")
+    diagram.add_relationship("Review Data", "Report", label="produces")
+    diagram.add_relationship(
+        "Data Steward", "Report", label="approves", condition="data validated"
+    )
+    diagram.add_relationship("Review Data", "Policy DP-001", label="governed by")
 
     reqs = diagram.generate_requirements()
     texts = [t for t, _ in reqs]
 
-    assert "The system shall perform task 'Start'." in texts
-    assert "Task 'Start' shall precede task 'Approve'." in texts
-    assert "When approval granted, task 'Approve' shall precede task 'Finish'." in texts
-    assert (
-        "Task 'Start' shall be related to task 'Finish' when risk identified." in texts
+    assert "Data Steward shall perform 'Review Data'." in texts
+    assert "Review Data shall produce 'Report'." in texts
+    assert "If data validated, Data Steward shall approve 'Report'." in texts
+    assert "Review Data shall comply with 'Policy DP-001'." in texts
+
+
+def test_ai_training_and_curation_requirements():
+    diagram = GovernanceDiagram()
+    diagram.add_task("Decision1", node_type="Decision")
+    diagram.add_task("ANN1", node_type="ANN")
+    diagram.add_task("Database1", node_type="Database")
+    diagram.add_relationship(
+        "Decision1",
+        "ANN1",
+        condition="completion >= 0.98",
+        conn_type="AI training",
     )
+    diagram.add_relationship(
+        "Decision1",
+        "Database1",
+        condition="completion < 0.98",
+        conn_type="Curation",
+    )
+    reqs = diagram.generate_requirements()
+    texts = [t for t, _ in reqs]
+    assert "If completion >= 0.98, Engineering team shall train 'ANN1'." in texts
+    assert "If completion < 0.98, Engineering team shall curate 'Database1'." in texts


### PR DESCRIPTION
## Summary
- Map AI training and curation relations to engineering team actions
- Look up relationship templates by label or connection type when generating requirements
- Test AI training and data curation requirement generation

## Testing
- `pytest -q tests/test_governance_requirements_generator.py tests/test_governance_relationship_label.py tests/test_governance_requirements_button.py tests/test_governance_phase_requirements_menu.py tests/test_governance_decision_guard.py`
- `pytest -q` *(fails: AttributeError: type object 'SysMLDiagramWindow' has no attribute '_assign_decision_corner')*


------
https://chatgpt.com/codex/tasks/task_b_689f59d3161883279b8af9a914afda14