### PR TITLE
Include decision transition origin in requirements

### DIFF
--- a/tests/test_governance_decision_transition_requirement.py
+++ b/tests/test_governance_decision_transition_requirement.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram
+
+
+def test_decision_transition_requirement_mentions_source():
+    diagram = GovernanceDiagram()
+    diagram.add_task("Collect Data", node_type="Activity")
+    diagram.add_task("Decision1", node_type="Decision")
+    diagram.add_task("ANN1", node_type="ANN")
+    diagram.add_flow("Collect Data", "Decision1")
+    diagram.add_relationship(
+        "Decision1",
+        "ANN1",
+        conn_type="AI training",
+        condition="completion >= 0.98",
+    )
+
+    reqs = diagram.generate_requirements()
+    texts = [r.text for r in reqs]
+    assert "If completion >= 0.98, after 'Collect Data', Engineering team shall train 'ANN1'." in texts
+    assert all("Decision1" not in t for t in texts)


### PR DESCRIPTION
## Summary
- track preceding elements for decision nodes and mention them when generating requirements
- add origin handling to `GeneratedRequirement`
- test decision node requirements include transition source

## Testing
- `pytest tests/test_governance_decision_guard.py::GovernanceDecisionGuardTests::test_decision_flow_guard_generation tests/test_governance_requirements_generator.py::test_generate_requirements_from_governance_diagram tests/test_governance_requirements_generator.py::test_ai_training_and_curation_requirements tests/test_governance_decision_transition_requirement.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689fae13c6208327bb6467d3f86ddcbe