### PR TITLE
Add utility to truncate table height

### DIFF
--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -1,7 +1,7 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 """Utility helpers for analysis package."""
 
-from typing import List
+from typing import Any, List, Sequence
 
 
 # Mapping tables from risk assessment ratings to probabilities.
@@ -114,3 +114,33 @@ def derive_validation_target(acceptance_rate: float,
         )
 
     return acceptance_rate / denominator
+
+
+def truncate_to_height(table: Sequence[Sequence[Any]], height: int) -> List[List[Any]]:
+    """Return a copy of ``table`` limited to ``height`` rows.
+
+    The resulting list of lists preserves the column structure of ``table`` but
+    contains at most ``height`` rows.  This helper is handy when a lightweight
+    sample of a larger dataset is required—for example, to create test inputs
+    that mimic the shape of a database while being smaller in size.
+
+    Parameters
+    ----------
+    table:
+        Two-dimensional sequence representing the original dataset.
+    height:
+        Maximum number of rows in the returned dataset.  Values less than or
+        equal to zero yield an empty list.
+
+    Returns
+    -------
+    List[List[Any]]
+        ``table`` truncated to at most ``height`` rows.
+    """
+
+    if height <= 0 or not table:
+        return []
+
+    width = len(table[0])
+    rows = min(len(table), height)
+    return [list(row[:width]) for row in table[:rows]]

--- a/tests/test_truncate_to_height.py
+++ b/tests/test_truncate_to_height.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.utils import truncate_to_height
+
+def test_truncate_to_height_returns_shorter_table():
+    base = [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+    ]
+    result = truncate_to_height(base, 2)
+    assert result == [[1, 2, 3], [4, 5, 6]]
+    assert len(result) == 2
+    assert len(result[0]) == len(base[0])
+
+def test_truncate_to_height_handles_non_positive_height():
+    base = [[1, 2, 3]]
+    assert truncate_to_height(base, 0) == []
+    assert truncate_to_height(base, -5) == []
+
+
+def test_truncate_to_height_height_larger_than_source():
+    base = [[1, 2], [3, 4]]
+    result = truncate_to_height(base, 10)
+    assert result == base


### PR DESCRIPTION
## Summary
- add `truncate_to_height` helper in `analysis.utils` to create smaller datasets matching existing structure
- test truncation logic including edge cases

## Testing
- `pytest tests/test_truncate_to_height.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ff3cb51808327970ed7abab92375a