### PR TITLE
Deduplicate governance requirements

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -38,7 +38,9 @@
     "Ingestion",
     "Model evaluation",
     "Tune",
-    "Hyperparameter Validation"
+    "Hyperparameter Validation",
+    "Monitoring",
+    "Complies with"
   ],
 
   // Types shown in the Governance Elements toolbox
@@ -54,7 +56,25 @@
     "Procedure",
     "Record",
     "Role",
-    "Standard"
+    "Standard",
+    "Process",
+    "Activity",
+    "Task",
+    "Operation",
+    "Driving Function",
+    "Software Component",
+    "Test Suite",
+    "System",
+    "Verification Plan",
+    "Component",
+    "Manufacturing Process",
+    "Vehicle",
+    "Fleet",
+    "Safety Compliance",
+    "Incident",
+    "Safety Issue",
+    "Field Data",
+    "Model"
   ],
 
   // Relation labels for the Governance Elements toolbox
@@ -74,7 +94,17 @@
     "Performs",
     "Produces",
     "Responsible for",
-    "Uses"
+    "Uses",
+    "Constrains",
+    "Establish",
+    "Implement",
+    "Validate",
+    "Verify",
+    "Manufacture",
+    "Operate",
+    "Inspect",
+    "Triage",
+    "Improve"
   ],
 
   // Diagram types considered part of the generic "Architecture Diagram" work product
@@ -109,7 +139,25 @@
     "Procedure",
     "Record",
     "Role",
-    "Standard"
+    "Standard",
+    "Process",
+    "Activity",
+    "Task",
+    "Operation",
+    "Driving Function",
+    "Software Component",
+    "Test Suite",
+    "System",
+    "Verification Plan",
+    "Component",
+    "Manufacturing Process",
+    "Vehicle",
+    "Fleet",
+    "Safety Compliance",
+    "Incident",
+    "Safety Issue",
+    "Field Data",
+    "Model"
   ],
 
   // FMEDA/Fault tree gate node types
@@ -177,7 +225,19 @@
     "trace": {"action": "trace to"},
     "used by": {"action": "be used by"},
     "used after review": {"action": "be used after review"},
-    "used after approval": {"action": "be used after approval"}
+    "used after approval": {"action": "be used after approval"},
+    "constrains": {"action": "constrain"},
+    "establish": {"action": "establish"},
+    "implement": {"action": "implement"},
+    "validate": {"action": "validate", "subject": "Validation team"},
+    "verify": {"action": "verify", "subject": "Verification team"},
+    "manufacture": {"action": "manufacture", "subject": "Manufacturing team"},
+    "operate": {"action": "operate", "subject": "Operations team"},
+    "inspect": {"action": "inspect", "subject": "Inspection team"},
+    "triage": {"action": "triage", "subject": "Support team"},
+    "improve": {"action": "improve", "subject": "Engineering team"},
+    "monitoring": {"action": "monitor", "subject": "Engineering team"},
+    "complies with": {"action": "comply with", "subject": "Engineering team", "constraint": true}
   },
 
   // Default requirement role per node type
@@ -203,7 +263,22 @@
     "Database": "object",
     "ANN": "object",
     "Data acquisition": "object",
-    "Metric": "constraint"
+    "Metric": "constraint",
+    "Operation": "object",
+    "Driving Function": "object",
+    "Software Component": "object",
+    "Test Suite": "object",
+    "System": "object",
+    "Verification Plan": "object",
+    "Component": "object",
+    "Manufacturing Process": "object",
+    "Vehicle": "object",
+    "Fleet": "object",
+    "Safety Compliance": "object",
+    "Incident": "object",
+    "Safety Issue": "object",
+    "Field Data": "object",
+    "Model": "object"
   },
 
   // Allowed Safety & AI relationships between node types
@@ -220,7 +295,9 @@
     "AI re-training": {"Database": ["ANN"]},
     "Model evaluation": {"ANN": ["Database"]},
     "Curation": {"Database": ["Database"]},
-    "Ingestion": {"Database": ["Database"]}
+    "Ingestion": {"Database": ["Database"]},
+    "Monitoring": {"ANN": ["Operation"]},
+    "Complies with": {"ANN": ["Policy"], "Database": ["Policy"]}
   },
 
   // Connection validation rules per diagram type and connection kind

--- a/config/requirement_patterns.json
+++ b/config/requirement_patterns.json
@@ -1024,5 +1024,116 @@
       "<record>"
     ],
     "Notes": "Compliance requirement with auditable trail."
+  },
+  {
+    "Pattern ID": "ORG-establish-Organization-Process",
+    "Trigger": "Organization: Organization --[Establish]--> Process",
+    "Template": "<organization> shall establish the <process> and record evidence in <record>.",
+    "Variables": [
+      "<organization>",
+      "<process>",
+      "<record>",
+      "<due_date>"
+    ],
+    "Notes": "Organizational process definition requirement."
+  },
+  {
+    "Pattern ID": "SA-monitoring-ANN-Operation",
+    "Trigger": "Safety&AI: ANN --[Monitoring]--> Operation",
+    "Template": "Engineering team shall monitor the <Operation> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "AVD-implement-Driving_Function-Software_Component",
+    "Trigger": "AV Dev: Driving Function --[Implement]--> Software Component",
+    "Template": "Engineering team shall implement the <Software Component> for the <Driving Function>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "For autonomous vehicle functionality development."
+  },
+  {
+    "Pattern ID": "VAL-validate-Test_Suite-System",
+    "Trigger": "Validation: Test Suite --[Validate]--> System",
+    "Template": "Validation team shall validate the <System> using the <Test Suite>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Validation coverage requirement."
+  },
+  {
+    "Pattern ID": "VER-verify-Verification_Plan-Component",
+    "Trigger": "Verification: Verification Plan --[Verify]--> Component",
+    "Template": "Verification team shall verify the <Component> according to the <Verification Plan>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Verification requirement."
+  },
+  {
+    "Pattern ID": "PROD-manufacture-Manufacturing_Process-Vehicle",
+    "Trigger": "Production: Manufacturing Process --[Manufacture]--> Vehicle",
+    "Template": "Manufacturing team shall manufacture the <Vehicle> using the <Manufacturing Process>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Production requirement."
+  },
+  {
+    "Pattern ID": "OP-operate-Fleet-Vehicle",
+    "Trigger": "Operation: Fleet --[Operate]--> Vehicle",
+    "Template": "Operations team shall operate the <Vehicle> within the <Fleet>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Operational requirement."
+  },
+  {
+    "Pattern ID": "INSP-inspect-Vehicle-Safety_Compliance",
+    "Trigger": "Inspection: Vehicle --[Inspect]--> Safety Compliance",
+    "Template": "Inspection team shall inspect the <Vehicle> for <Safety Compliance>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Periodic inspection requirement."
+  },
+  {
+    "Pattern ID": "TRI-triage-Incident-Safety_Issue",
+    "Trigger": "Triage: Incident --[Triage]--> Safety Issue",
+    "Template": "Support team shall triage the <Safety Issue> from the <Incident>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Incident triage requirement."
+  },
+  {
+    "Pattern ID": "IMP-improve-Field_Data-Model",
+    "Trigger": "Improvement: Field Data --[Improve]--> Model",
+    "Template": "Engineering team shall improve the <Model> using the <Field Data>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Post-deployment improvement requirement."
   }
 ]

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -69,20 +69,38 @@ SAFETY_AI_RELATION_SET = set(SAFETY_AI_RELATIONS)
 GOV_ELEMENT_NODES = _CONFIG.get("governance_element_nodes", [])
 GOV_ELEMENT_RELATIONS = _CONFIG.get("governance_element_relations", [])
 
-# Group governance elements into meaningful classes for toolbox organisation
-GOV_ELEMENT_CLASSES = {
-    "Entities": [
-        n
-        for n in ["Organization", "Business Unit", "Role"]
-        if n in GOV_ELEMENT_NODES
-    ],
-    "Artifacts": [n for n in ["Data", "Document", "Record"] if n in GOV_ELEMENT_NODES],
-    "Governance": [
-        n
-        for n in ["Policy", "Principle", "Procedure", "Guideline", "Standard", "Metric"]
-        if n in GOV_ELEMENT_NODES
-    ],
-}
+
+def _make_gov_element_classes(nodes: list[str]) -> dict[str, list[str]]:
+    base = {
+        "Entities": [n for n in ["Organization", "Business Unit", "Role"] if n in nodes],
+        "Artifacts": [n for n in ["Data", "Document", "Record"] if n in nodes],
+        "Governance": [
+            n
+            for n in ["Policy", "Principle", "Procedure", "Guideline", "Standard", "Metric"]
+            if n in nodes
+        ],
+    }
+    known = {
+        "Organization",
+        "Business Unit",
+        "Role",
+        "Data",
+        "Document",
+        "Record",
+        "Policy",
+        "Principle",
+        "Procedure",
+        "Guideline",
+        "Standard",
+        "Metric",
+    }
+    other = [n for n in nodes if n not in known]
+    if other:
+        base["Other"] = other
+    return base
+
+
+GOV_ELEMENT_CLASSES = _make_gov_element_classes(GOV_ELEMENT_NODES)
 
 # Elements from the governance toolbox that may participate in
 # Safety & AI relationships
@@ -150,6 +168,16 @@ _BASE_CONN_TYPES = {
     "Produces",
     "Responsible for",
     "Uses",
+    "Constrains",
+    "Establish",
+    "Implement",
+    "Validate",
+    "Verify",
+    "Manufacture",
+    "Operate",
+    "Inspect",
+    "Triage",
+    "Improve",
 }
 
 # Ordered list of base connection tools for toolbox composition
@@ -189,6 +217,16 @@ _BASE_CONN_TOOLS = [
     "Produces",
     "Responsible for",
     "Uses",
+    "Constrains",
+    "Establish",
+    "Implement",
+    "Validate",
+    "Verify",
+    "Manufacture",
+    "Operate",
+    "Inspect",
+    "Triage",
+    "Improve",
 ]
 
 # Connection types that default to forward arrows
@@ -220,6 +258,16 @@ _ARROW_FORWARD_BASE.update(
         "Produces",
         "Responsible for",
         "Uses",
+        "Constrains",
+        "Establish",
+        "Implement",
+        "Validate",
+        "Verify",
+        "Manufacture",
+        "Operate",
+        "Inspect",
+        "Triage",
+        "Improve",
     }
 )
 
@@ -238,7 +286,7 @@ def reload_config() -> None:
     """Reload diagram rule configuration at runtime."""
     global _CONFIG, ARCH_DIAGRAM_TYPES, SAFETY_AI_NODES, SAFETY_AI_NODE_TYPES
     global SAFETY_AI_RELATIONS, SAFETY_AI_RELATION_SET, GOVERNANCE_NODE_TYPES
-    global GOV_ELEMENT_NODES, GOV_ELEMENT_RELATIONS
+    global GOV_ELEMENT_NODES, GOV_ELEMENT_RELATIONS, GOV_ELEMENT_CLASSES
     global SAFETY_AI_RELATION_RULES, CONNECTION_RULES, NODE_CONNECTION_LIMITS, GUARD_NODES
     _CONFIG = load_diagram_rules(_CONFIG_PATH)
     ARCH_DIAGRAM_TYPES = set(_CONFIG.get("arch_diagram_types", []))
@@ -248,6 +296,7 @@ def reload_config() -> None:
     SAFETY_AI_RELATION_SET = set(SAFETY_AI_RELATIONS)
     GOV_ELEMENT_NODES = _CONFIG.get("governance_element_nodes", [])
     GOV_ELEMENT_RELATIONS = _CONFIG.get("governance_element_relations", [])
+    GOV_ELEMENT_CLASSES = _make_gov_element_classes(GOV_ELEMENT_NODES)
     GOVERNANCE_NODE_TYPES = set(_CONFIG.get("governance_node_types", []))
     SAFETY_AI_RELATION_RULES = {
         conn: {src: set(dests) for src, dests in srcs.items()}

--- a/tests/test_governance_requirement_dedup.py
+++ b/tests/test_governance_requirement_dedup.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram
+
+
+def test_data_acquisition_default_requirement_removed_when_sources_present():
+    diagram = GovernanceDiagram()
+    diagram.add_task(
+        "Acquire Data",
+        node_type="Data acquisition",
+        compartments=["Sensor A"],
+    )
+
+    reqs = diagram.generate_requirements()
+    texts = [r.text if hasattr(r, "text") else r[0] for r in reqs]
+
+    assert "Engineering team shall acquire data from 'Sensor A'." in texts
+    assert "Engineering team shall acquire data." not in texts
+    assert sum("acquire data" in t for t in texts) == 1

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -128,8 +128,8 @@ def test_data_acquisition_node_name_normalized():
     texts = [r.text for r in reqs]
 
     assert "Engineering team shall acquire data from 'Sensor X'." in texts
-    # Ensure the task-level requirement uses the normalized verb
-    assert "Engineering team shall acquire data." in texts
+    # Ensure the raw node name does not appear in generated text
+    assert not any("shall Data acquisition" in t for t in texts)
 
 
 def test_tasks_create_requirement_actions():


### PR DESCRIPTION
## Summary
- extend Safety & AI relations and governance element/connection catalogs with previously unmapped pattern types
- group additional governance elements under an "Other" toolbox section and expose new domain-specific connection verbs

## Testing
- `pytest tests/test_governance_requirement_dedup.py tests/test_governance_requirements_generator.py tests/test_requirement_patterns_toolbox.py`


------
https://chatgpt.com/codex/tasks/task_b_68a00882b6e88327a1befa41ad2a06c2