### PR TITLE
Remove report template editor option from configuration tab

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2746,7 +2746,6 @@ class FaultTreeApp:
             "Cause & Effect Diagram": self.show_cause_effect_chain,
             "Diagram Rule Editor": self.open_diagram_rules_toolbox,
             "Requirement Pattern Editor": self.open_requirement_patterns_toolbox,
-            "Report Template Editor": self.open_report_template_toolbox,
             "Report Template Manager": self.open_report_template_manager,
         }
 
@@ -2762,9 +2761,8 @@ class FaultTreeApp:
                 "Cause & Effect Diagram",
             ],
             "Configuration": [
-                "Diagram Rule Editor", 
+                "Diagram Rule Editor",
                 "Requirement Pattern Editor",
-                "Report Template Editor",
                 "Report Template Manager",
             ],
         }


### PR DESCRIPTION
## Summary
- Remove Report Template Editor entry from Tools configuration group
- Keep Report Template Manager as only report template tool

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a12e1477448327a2636d6c53a01b41