### PR TITLE
Allow multiline requirement pattern table cells

### DIFF
--- a/gui/requirement_patterns_toolbox.py
+++ b/gui/requirement_patterns_toolbox.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk
 from pathlib import Path
 import json
+import textwrap
 from config import (
     load_diagram_rules,
     validate_diagram_rules,
@@ -498,9 +499,25 @@ class RequirementPatternsEditor(tk.Frame):
     # ------------------------------------------------------------------
     def _populate_pattern_tree(self):
         self.tree.delete(*self.tree.get_children(""))
+        wrapped: list[tuple[int, str, str]] = []
+        max_lines = 1
         for idx, pat in enumerate(self.data):
-            trig = pat.get("Trigger", "")
-            tmpl = pat.get("Template", "")
+            trig = textwrap.fill(pat.get("Trigger", ""), 40)
+            tmpl = textwrap.fill(pat.get("Template", ""), 40)
+            lines = max(trig.count("\n") + 1, tmpl.count("\n") + 1)
+            max_lines = max(max_lines, lines)
+            wrapped.append((idx, trig, tmpl))
+
+        style = ttk.Style(self.tree)
+        base = style.lookup("Treeview", "rowheight") or 20
+        try:
+            base_h = int(base)
+        except Exception:
+            base_h = 20
+        style.configure("PatternTree", rowheight=base_h * max_lines)
+        self.tree.configure(style="PatternTree")
+
+        for idx, trig, tmpl in wrapped:
             self.tree.insert("", "end", iid=str(idx), values=(trig, tmpl))
 
     def _edit_item(self, _event=None):

--- a/tests/test_requirement_patterns_toolbox.py
+++ b/tests/test_requirement_patterns_toolbox.py
@@ -1,5 +1,4 @@
 import sys
-import sys
 from pathlib import Path
 import types
 
@@ -17,6 +16,9 @@ sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
 sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
 
 from AutoML import FaultTreeApp
+import tkinter as tk
+import pytest
+from gui.requirement_patterns_toolbox import RequirementPatternsEditor
 
 
 def test_requirement_patterns_toolbox_single_instance():
@@ -62,3 +64,21 @@ def test_requirement_patterns_toolbox_single_instance():
     app.open_requirement_patterns_toolbox()
     app.open_requirement_patterns_toolbox()
     assert DummyEditor.created == 1
+
+
+def test_pattern_tree_wraps_text(tmp_path):
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+
+    cfg = tmp_path / "patterns.json"
+    cfg.write_text("[]")
+
+    editor = RequirementPatternsEditor(root, object(), cfg)
+    editor.data = [{"Trigger": "A " * 30, "Template": "B " * 30}]
+    editor._populate_pattern_tree()
+    vals = editor.tree.item(editor.tree.get_children()[0], "values")
+    assert "\n" in vals[0]
+    assert "\n" in vals[1]
+    root.destroy()


### PR DESCRIPTION
## Summary
- wrap long trigger and template text in requirement pattern table
- adjust tree row height to accommodate multi-line cells
- test requirement pattern tree text wrapping

## Testing
- `pytest tests/test_requirement_patterns_toolbox.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a28b0d6c048327bd5fc847122840c0