### PR TITLE
Fix missing textwrap import in requirement patterns toolbox

### DIFF
--- a/gui/requirement_patterns_toolbox.py
+++ b/gui/requirement_patterns_toolbox.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk
 from pathlib import Path
 import json
+import textwrap
 from config import (
     load_diagram_rules,
     validate_diagram_rules,


### PR DESCRIPTION
## Summary
- Import `textwrap` in `requirement_patterns_toolbox` to prevent NameError when wrapping pattern text

## Testing
- `pytest tests/test_requirement_patterns_toolbox.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68a29964e3088327876d31ae5d9222e7