### PR TITLE
Add icons and shapes for governance elements toolbox

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3557,6 +3557,19 @@ class SysMLDiagramWindow(tk.Frame):
             "Field Data": "cylinder",
             "Model": "document",
             "Lifecycle Phase": "folder",
+            "Hazard": "triangle",
+            "Risk Assessment": "diamond",
+            "Safety Goal": "pentagon",
+            "Safety Plan": "document",
+            "Security Plan": "document",
+            "Mitigation Plan": "document",
+            "Security Threat": "cross",
+            "Validation Report": "document",
+            "Audit Report": "document",
+            "Safety Case": "document",
+            "Deployment Plan": "document",
+            "Maintenance Plan": "document",
+            "Decommission Plan": "document",
             "Work Product": "rect",
         }
         if name in mapping:
@@ -7115,6 +7128,54 @@ class SysMLDiagramWindow(tk.Frame):
             self.canvas.create_line(x + w, y - h, x + w + off, y - h + off, fill=outline)
             self.canvas.create_line(x + w, y + h, x + w + off, y + h + off, fill=outline)
             self.canvas.create_line(x - w, y + h, x - w + off, y + h + off, fill=outline)
+        elif obj.obj_type == "Hazard":
+            points = [x, y - h, x + w, y + h, x - w, y + h]
+            self.canvas.create_polygon(points, outline=outline, fill=color)
+        elif obj.obj_type == "Risk Assessment":
+            points = [x, y - h, x + w, y, x, y + h, x - w, y]
+            self.canvas.create_polygon(points, outline=outline, fill=color)
+        elif obj.obj_type == "Safety Goal":
+            r = min(obj.width, obj.height) * self.zoom / 2
+            pts = []
+            for i in range(5):
+                angle = math.radians(72 * i - 90)
+                px = x + r * math.cos(angle)
+                py = y + r * math.sin(angle)
+                pts.extend([px, py])
+            self.canvas.create_polygon(pts, outline=outline, fill=color)
+        elif obj.obj_type in (
+            "Safety Plan",
+            "Security Plan",
+            "Mitigation Plan",
+            "Validation Report",
+            "Audit Report",
+            "Safety Case",
+            "Deployment Plan",
+            "Maintenance Plan",
+            "Decommission Plan",
+        ):
+            self.canvas.create_rectangle(
+                x - w,
+                y - h,
+                x + w,
+                y + h,
+                outline=outline,
+                fill=color,
+            )
+            fold = 10 * self.zoom
+            self.canvas.create_polygon(
+                x + w - fold,
+                y - h,
+                x + w,
+                y - h,
+                x + w,
+                y - h + fold,
+                fill=StyleManager.get_instance().get_canvas_color(),
+                outline=outline,
+            )
+        elif obj.obj_type == "Security Threat":
+            self.canvas.create_line(x - w, y - h, x + w, y + h, fill=outline, width=2)
+            self.canvas.create_line(x - w, y + h, x + w, y - h, fill=outline, width=2)
         elif obj.obj_type == "Use Case":
             self.canvas.create_oval(
                 x - w,

--- a/tests/test_governance_icons.py
+++ b/tests/test_governance_icons.py
@@ -12,4 +12,9 @@ def test_governance_shapes_and_relations():
     assert shape(None, "Task") == "trapezoid"
     assert shape(None, "Vehicle") == "vehicle"
     assert shape(None, "Approves") == "relation"
+    assert shape(None, "Hazard") == "triangle"
+    assert shape(None, "Risk Assessment") == "diamond"
+    assert shape(None, "Safety Goal") == "pentagon"
+    assert shape(None, "Security Threat") == "cross"
+    assert shape(None, "Safety Plan") == "document"
 


### PR DESCRIPTION
## Summary
- add icon/shape mapping for Hazard, Risk Assessment, Safety Goal and other governance elements
- render new governance elements and plans with appropriate shapes on diagram canvas
- expand governance icon tests to cover new element types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a29e8d5ca08327aeea373c46a7274e