### PR TITLE
Ensure explorers refresh on focus

### DIFF
--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -105,6 +105,11 @@ class SafetyCaseExplorer(tk.Frame):
                 self.item_map[sid] = ("solution", sol)
 
     # ------------------------------------------------------------------
+    def refresh(self):
+        """Refresh the explorer view to reflect the current model state."""
+        self.populate()
+
+    # ------------------------------------------------------------------
     def _available_diagrams(self):
         """Return a list of all GSN diagrams available in the application."""
         if not self.app:

--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -108,6 +108,11 @@ class SafetyManagementExplorer(tk.Frame):
                 self.item_map[iid] = ("diagram", label)
 
     # ------------------------------------------------------------------
+    def refresh(self):
+        """Refresh the explorer view to reflect the current model state."""
+        self.populate()
+
+    # ------------------------------------------------------------------
     def new_folder(self):
         name = simpledialog.askstring("New Folder", "Name:", parent=self)
         if not name:

--- a/tests/test_safety_case_explorer.py
+++ b/tests/test_safety_case_explorer.py
@@ -115,6 +115,18 @@ def test_create_case_from_module(monkeypatch):
     assert explorer.library.cases and explorer.library.cases[0].diagram is diag
 
 
+def test_safety_case_explorer_refresh_calls_populate(monkeypatch):
+    called = {}
+
+    def fake_populate(self):
+        called["called"] = True
+
+    monkeypatch.setattr(safety_case_explorer.SafetyCaseExplorer, "populate", fake_populate)
+    explorer = safety_case_explorer.SafetyCaseExplorer.__new__(safety_case_explorer.SafetyCaseExplorer)
+    safety_case_explorer.SafetyCaseExplorer.refresh(explorer)
+    assert called.get("called")
+
+
 def test_safety_case_table_lists_solutions():
     root = GSNNode("G", "Goal")
     sol1 = GSNNode("S1", "Solution", description="d1")

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -1554,6 +1554,18 @@ def test_safety_management_explorer_creates_folders_and_diagrams(monkeypatch):
     assert "Diag" in toolbox.diagrams
 
 
+def test_safety_management_explorer_refresh_calls_populate(monkeypatch):
+    called = {}
+
+    def fake_populate(self):
+        called["called"] = True
+
+    monkeypatch.setattr(SafetyManagementExplorer, "populate", fake_populate)
+    explorer = SafetyManagementExplorer.__new__(SafetyManagementExplorer)
+    SafetyManagementExplorer.refresh(explorer)
+    assert called.get("called")
+
+
 def test_explorer_renames_folders_and_diagrams(monkeypatch):
     SysMLRepository._instance = None
     SysMLRepository.get_instance()


### PR DESCRIPTION
## Summary
- Refresh safety & security management explorer when the tab regains focus
- Refresh safety & security case explorer when the tab regains focus
- Test that both explorers trigger `populate()` when refreshed

## Testing
- `PYTHONPATH=$PWD pytest tests/test_safety_case_explorer.py tests/test_safety_management.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a29f4bc5cc83279be31afc7e58b65a