### PR TITLE
Unify validation and audit report elements

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -83,8 +83,7 @@
     "Security Plan",
     "Mitigation Plan",
     "Security Threat",
-    "Validation Report",
-    "Audit Report",
+    "Report",
     "Safety Case",
     "Deployment Plan",
     "Maintenance Plan",
@@ -182,8 +181,7 @@
     "Security Plan",
     "Mitigation Plan",
     "Security Threat",
-    "Validation Report",
-    "Audit Report",
+    "Report",
     "Safety Case",
     "Deployment Plan",
     "Maintenance Plan",
@@ -434,8 +432,7 @@
     "Security Plan": "object",
     "Mitigation Plan": "object",
     "Security Threat": "object",
-    "Validation Report": "object",
-    "Audit Report": "object",
+    "Report": "object",
     "Safety Case": "object",
     "Deployment Plan": "object",
     "Maintenance Plan": "object",
@@ -472,14 +469,13 @@
       "Process": ["Document"],
       "Test Suite": ["Document"],
       "Verification Plan": ["Document"],
-      "Validation Report": ["Document"],
-      "Audit Report": ["Document"],
+      "Report": ["Document"],
       "Safety Case": ["Document"]
     },
     "Validate": {
       "Model": ["Test Suite"],
-      "Test Suite": ["Validation Report"],
-      "Mitigation Plan": ["Validation Report"]
+      "Test Suite": ["Report"],
+      "Mitigation Plan": ["Report"]
     },
     "Assesses": {
       "Hazard": ["Risk Assessment"],
@@ -498,8 +494,8 @@
       "Decommission Plan": ["Process"]
     },
     "Verify": {"Test Suite": ["Verification Plan"]},
-    "Audits": {"Process": ["Audit Report"]},
-    "Reviews": {"Audit Report": ["Safety Case"]}
+    "Audits": {"Process": ["Report"]},
+    "Reviews": {"Report": ["Safety Case"]}
   },
 
   // Connection validation rules per diagram type and connection kind

--- a/config/requirement_patterns.json
+++ b/config/requirement_patterns.json
@@ -4856,8 +4856,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-audits-Process-Audit_Report",
-    "Trigger": "Safety&AI: Process --[Audits]--> Audit Report",
+    "Pattern ID": "SA-audits-Process-Report",
+    "Trigger": "Safety&AI: Process --[Audits]--> Report",
     "Template": "Engineering team shall audit the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -4869,8 +4869,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-audits-Process-Audit_Report-COND",
-    "Trigger": "Safety&AI: Process --[Audits]--> Audit Report",
+    "Pattern ID": "SA-audits-Process-Report-COND",
+    "Trigger": "Safety&AI: Process --[Audits]--> Report",
     "Template": "When <condition>, Engineering team shall audit the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -4883,8 +4883,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-audits-Process-Audit_Report-COND-CONST",
-    "Trigger": "Safety&AI: Process --[Audits]--> Audit Report",
+    "Pattern ID": "SA-audits-Process-Report-COND-CONST",
+    "Trigger": "Safety&AI: Process --[Audits]--> Report",
     "Template": "When <condition>, Engineering team shall audit the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -4898,8 +4898,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-audits-Process-Audit_Report-CONST",
-    "Trigger": "Safety&AI: Process --[Audits]--> Audit Report",
+    "Pattern ID": "SA-audits-Process-Report-CONST",
+    "Trigger": "Safety&AI: Process --[Audits]--> Report",
     "Template": "Engineering team shall audit the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -6368,62 +6368,6 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-produces-Audit_Report-Document",
-    "Trigger": "Safety&AI: Audit Report --[Produces]--> Document",
-    "Template": "Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>).",
-    "Variables": [
-      "<source_id>",
-      "<source_class>",
-      "<target_id>",
-      "<target_class>",
-      "<acceptance_criteria>"
-    ],
-    "Notes": "Auto-generated from diagram rules (Safety&AI)."
-  },
-  {
-    "Pattern ID": "SA-produces-Audit_Report-Document-COND",
-    "Trigger": "Safety&AI: Audit Report --[Produces]--> Document",
-    "Template": "When <condition>, Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>).",
-    "Variables": [
-      "<source_id>",
-      "<source_class>",
-      "<target_id>",
-      "<target_class>",
-      "<acceptance_criteria>",
-      "<condition>"
-    ],
-    "Notes": "Auto-generated from diagram rules (Safety&AI)."
-  },
-  {
-    "Pattern ID": "SA-produces-Audit_Report-Document-COND-CONST",
-    "Trigger": "Safety&AI: Audit Report --[Produces]--> Document",
-    "Template": "When <condition>, Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
-    "Variables": [
-      "<source_id>",
-      "<source_class>",
-      "<target_id>",
-      "<target_class>",
-      "<acceptance_criteria>",
-      "<condition>",
-      "<constraint>"
-    ],
-    "Notes": "Auto-generated from diagram rules (Safety&AI)."
-  },
-  {
-    "Pattern ID": "SA-produces-Audit_Report-Document-CONST",
-    "Trigger": "Safety&AI: Audit Report --[Produces]--> Document",
-    "Template": "Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
-    "Variables": [
-      "<source_id>",
-      "<source_class>",
-      "<target_id>",
-      "<target_class>",
-      "<acceptance_criteria>",
-      "<constraint>"
-    ],
-    "Notes": "Auto-generated from diagram rules (Safety&AI)."
-  },
-  {
     "Pattern ID": "SA-produces-Process-Document",
     "Trigger": "Safety&AI: Process --[Produces]--> Document",
     "Template": "Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>).",
@@ -6468,6 +6412,62 @@
   {
     "Pattern ID": "SA-produces-Process-Document-CONST",
     "Trigger": "Safety&AI: Process --[Produces]--> Document",
+    "Template": "Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
+    "Variables": [
+      "<source_id>",
+      "<source_class>",
+      "<target_id>",
+      "<target_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Report-Document",
+    "Trigger": "Safety&AI: Report --[Produces]--> Document",
+    "Template": "Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>).",
+    "Variables": [
+      "<source_id>",
+      "<source_class>",
+      "<target_id>",
+      "<target_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Report-Document-COND",
+    "Trigger": "Safety&AI: Report --[Produces]--> Document",
+    "Template": "When <condition>, Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>).",
+    "Variables": [
+      "<source_id>",
+      "<source_class>",
+      "<target_id>",
+      "<target_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Report-Document-COND-CONST",
+    "Trigger": "Safety&AI: Report --[Produces]--> Document",
+    "Template": "When <condition>, Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
+    "Variables": [
+      "<source_id>",
+      "<source_class>",
+      "<target_id>",
+      "<target_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Report-Document-CONST",
+    "Trigger": "Safety&AI: Report --[Produces]--> Document",
     "Template": "Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -6592,62 +6592,6 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-produces-Validation_Report-Document",
-    "Trigger": "Safety&AI: Validation Report --[Produces]--> Document",
-    "Template": "Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>).",
-    "Variables": [
-      "<source_id>",
-      "<source_class>",
-      "<target_id>",
-      "<target_class>",
-      "<acceptance_criteria>"
-    ],
-    "Notes": "Auto-generated from diagram rules (Safety&AI)."
-  },
-  {
-    "Pattern ID": "SA-produces-Validation_Report-Document-COND",
-    "Trigger": "Safety&AI: Validation Report --[Produces]--> Document",
-    "Template": "When <condition>, Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>).",
-    "Variables": [
-      "<source_id>",
-      "<source_class>",
-      "<target_id>",
-      "<target_class>",
-      "<acceptance_criteria>",
-      "<condition>"
-    ],
-    "Notes": "Auto-generated from diagram rules (Safety&AI)."
-  },
-  {
-    "Pattern ID": "SA-produces-Validation_Report-Document-COND-CONST",
-    "Trigger": "Safety&AI: Validation Report --[Produces]--> Document",
-    "Template": "When <condition>, Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
-    "Variables": [
-      "<source_id>",
-      "<source_class>",
-      "<target_id>",
-      "<target_class>",
-      "<acceptance_criteria>",
-      "<condition>",
-      "<constraint>"
-    ],
-    "Notes": "Auto-generated from diagram rules (Safety&AI)."
-  },
-  {
-    "Pattern ID": "SA-produces-Validation_Report-Document-CONST",
-    "Trigger": "Safety&AI: Validation Report --[Produces]--> Document",
-    "Template": "Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
-    "Variables": [
-      "<source_id>",
-      "<source_class>",
-      "<target_id>",
-      "<target_class>",
-      "<acceptance_criteria>",
-      "<constraint>"
-    ],
-    "Notes": "Auto-generated from diagram rules (Safety&AI)."
-  },
-  {
     "Pattern ID": "SA-produces-Verification_Plan-Document",
     "Trigger": "Safety&AI: Verification Plan --[Produces]--> Document",
     "Template": "Engineering team shall produce the <target_id> (<target_class>) using the <source_id> (<source_class>).",
@@ -6704,8 +6648,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-reviews-Audit_Report-Safety_Case",
-    "Trigger": "Safety&AI: Audit Report --[Reviews]--> Safety Case",
+    "Pattern ID": "SA-reviews-Report-Safety_Case",
+    "Trigger": "Safety&AI: Report --[Reviews]--> Safety Case",
     "Template": "Engineering team shall reviews the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -6717,8 +6661,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-reviews-Audit_Report-Safety_Case-COND",
-    "Trigger": "Safety&AI: Audit Report --[Reviews]--> Safety Case",
+    "Pattern ID": "SA-reviews-Report-Safety_Case-COND",
+    "Trigger": "Safety&AI: Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Engineering team shall reviews the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -6731,8 +6675,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-reviews-Audit_Report-Safety_Case-COND-CONST",
-    "Trigger": "Safety&AI: Audit Report --[Reviews]--> Safety Case",
+    "Pattern ID": "SA-reviews-Report-Safety_Case-COND-CONST",
+    "Trigger": "Safety&AI: Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Engineering team shall reviews the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -6746,8 +6690,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-reviews-Audit_Report-Safety_Case-CONST",
-    "Trigger": "Safety&AI: Audit Report --[Reviews]--> Safety Case",
+    "Pattern ID": "SA-reviews-Report-Safety_Case-CONST",
+    "Trigger": "Safety&AI: Report --[Reviews]--> Safety Case",
     "Template": "Engineering team shall reviews the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -6872,8 +6816,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-validate-Mitigation_Plan-Validation_Report",
-    "Trigger": "Safety&AI: Mitigation Plan --[Validate]--> Validation Report",
+    "Pattern ID": "SA-validate-Mitigation_Plan-Report",
+    "Trigger": "Safety&AI: Mitigation Plan --[Validate]--> Report",
     "Template": "Validation team shall validate the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -6885,8 +6829,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-validate-Mitigation_Plan-Validation_Report-COND",
-    "Trigger": "Safety&AI: Mitigation Plan --[Validate]--> Validation Report",
+    "Pattern ID": "SA-validate-Mitigation_Plan-Report-COND",
+    "Trigger": "Safety&AI: Mitigation Plan --[Validate]--> Report",
     "Template": "When <condition>, Validation team shall validate the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -6899,8 +6843,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-validate-Mitigation_Plan-Validation_Report-COND-CONST",
-    "Trigger": "Safety&AI: Mitigation Plan --[Validate]--> Validation Report",
+    "Pattern ID": "SA-validate-Mitigation_Plan-Report-COND-CONST",
+    "Trigger": "Safety&AI: Mitigation Plan --[Validate]--> Report",
     "Template": "When <condition>, Validation team shall validate the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -6914,8 +6858,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-validate-Mitigation_Plan-Validation_Report-CONST",
-    "Trigger": "Safety&AI: Mitigation Plan --[Validate]--> Validation Report",
+    "Pattern ID": "SA-validate-Mitigation_Plan-Report-CONST",
+    "Trigger": "Safety&AI: Mitigation Plan --[Validate]--> Report",
     "Template": "Validation team shall validate the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -6984,8 +6928,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-validate-Test_Suite-Validation_Report",
-    "Trigger": "Safety&AI: Test Suite --[Validate]--> Validation Report",
+    "Pattern ID": "SA-validate-Test_Suite-Report",
+    "Trigger": "Safety&AI: Test Suite --[Validate]--> Report",
     "Template": "Validation team shall validate the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -6997,8 +6941,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-validate-Test_Suite-Validation_Report-COND",
-    "Trigger": "Safety&AI: Test Suite --[Validate]--> Validation Report",
+    "Pattern ID": "SA-validate-Test_Suite-Report-COND",
+    "Trigger": "Safety&AI: Test Suite --[Validate]--> Report",
     "Template": "When <condition>, Validation team shall validate the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -7011,8 +6955,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-validate-Test_Suite-Validation_Report-COND-CONST",
-    "Trigger": "Safety&AI: Test Suite --[Validate]--> Validation Report",
+    "Pattern ID": "SA-validate-Test_Suite-Report-COND-CONST",
+    "Trigger": "Safety&AI: Test Suite --[Validate]--> Report",
     "Template": "When <condition>, Validation team shall validate the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -7026,8 +6970,8 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
-    "Pattern ID": "SA-validate-Test_Suite-Validation_Report-CONST",
-    "Trigger": "Safety&AI: Test Suite --[Validate]--> Validation Report",
+    "Pattern ID": "SA-validate-Test_Suite-Report-CONST",
+    "Trigger": "Safety&AI: Test Suite --[Validate]--> Report",
     "Template": "Validation team shall validate the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8081,7 +8025,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Decommission_Plan-Document",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8100,7 +8044,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Decommission_Plan-Document-COND",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8120,7 +8064,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Decommission_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8141,7 +8085,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Decommission_Plan-Document-CONST",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8161,7 +8105,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Deployment_Plan-Document",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8180,7 +8124,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Deployment_Plan-Document-COND",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8200,7 +8144,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Deployment_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8221,7 +8165,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Deployment_Plan-Document-CONST",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8241,7 +8185,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Maintenance_Plan-Document",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8260,7 +8204,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Maintenance_Plan-Document-COND",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8280,7 +8224,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Maintenance_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8301,7 +8245,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Maintenance_Plan-Document-CONST",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8321,7 +8265,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Mitigation_Plan-Document",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8340,7 +8284,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Mitigation_Plan-Document-COND",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8360,7 +8304,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Mitigation_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8381,7 +8325,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Mitigation_Plan-Document-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8401,7 +8345,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Safety_Plan-Document",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8420,7 +8364,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Safety_Plan-Document-COND",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8440,7 +8384,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Safety_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8461,7 +8405,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Safety_Plan-Document-CONST",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8481,7 +8425,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Security_Plan-Document",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8500,7 +8444,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Security_Plan-Document-COND",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -8520,7 +8464,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Security_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -8541,7 +8485,7 @@
   },
   {
     "Pattern ID": "SEQ-decommissioning_validation-Security_Plan-Document-CONST",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate decommissioning the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10089,7 +10033,7 @@
   },
   {
     "Pattern ID": "SEQ-incident_validation-Safety_Issue-Document",
-    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate incident resolution the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10108,7 +10052,7 @@
   },
   {
     "Pattern ID": "SEQ-incident_validation-Safety_Issue-Document-COND",
-    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate incident resolution the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10128,7 +10072,7 @@
   },
   {
     "Pattern ID": "SEQ-incident_validation-Safety_Issue-Document-COND-CONST",
-    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Safety manager shall validate incident resolution the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10149,7 +10093,7 @@
   },
   {
     "Pattern ID": "SEQ-incident_validation-Safety_Issue-Document-CONST",
-    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall validate incident resolution the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10169,7 +10113,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Decommission_Plan-Document",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10188,7 +10132,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Decommission_Plan-Document-COND",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10208,7 +10152,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Decommission_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10229,7 +10173,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Decommission_Plan-Document-CONST",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10249,7 +10193,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Deployment_Plan-Document",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10268,7 +10212,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Deployment_Plan-Document-COND",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10288,7 +10232,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Deployment_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10309,7 +10253,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Deployment_Plan-Document-CONST",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10329,7 +10273,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Maintenance_Plan-Document",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10348,7 +10292,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Maintenance_Plan-Document-COND",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10368,7 +10312,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Maintenance_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10389,7 +10333,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Maintenance_Plan-Document-CONST",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10409,7 +10353,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Mitigation_Plan-Document",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10428,7 +10372,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Mitigation_Plan-Document-COND",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10448,7 +10392,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Mitigation_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10469,7 +10413,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Mitigation_Plan-Document-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10489,7 +10433,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Safety_Plan-Document",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10508,7 +10452,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Safety_Plan-Document-COND",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10528,7 +10472,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Safety_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10549,7 +10493,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Safety_Plan-Document-CONST",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10569,7 +10513,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Security_Plan-Document",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10588,7 +10532,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Security_Plan-Document-COND",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10608,7 +10552,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Security_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10629,7 +10573,7 @@
   },
   {
     "Pattern ID": "SEQ-maintenance_validation-Security_Plan-Document-CONST",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall validate maintenance the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10649,7 +10593,7 @@
   },
   {
     "Pattern ID": "SEQ-model_validation-Mitigation_Plan-Document",
-    "Trigger": "Sequence: Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "Validation team shall validate models the <target_id> (<target_class>) and the <target2_id> (<target2_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10664,7 +10608,7 @@
   },
   {
     "Pattern ID": "SEQ-model_validation-Mitigation_Plan-Document-COND",
-    "Trigger": "Sequence: Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Validation team shall validate models the <target_id> (<target_class>) and the <target2_id> (<target2_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10680,7 +10624,7 @@
   },
   {
     "Pattern ID": "SEQ-model_validation-Mitigation_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Validation team shall validate models the <target_id> (<target_class>) and the <target2_id> (<target2_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10697,7 +10641,7 @@
   },
   {
     "Pattern ID": "SEQ-model_validation-Mitigation_Plan-Document-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "Validation team shall validate models the <target_id> (<target_class>) and the <target2_id> (<target2_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10777,7 +10721,7 @@
   },
   {
     "Pattern ID": "SEQ-model_validation-Test_Suite-Document",
-    "Trigger": "Sequence: Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Validation team shall validate models the <target_id> (<target_class>) and the <target2_id> (<target2_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10792,7 +10736,7 @@
   },
   {
     "Pattern ID": "SEQ-model_validation-Test_Suite-Document-COND",
-    "Trigger": "Sequence: Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Validation team shall validate models the <target_id> (<target_class>) and the <target2_id> (<target2_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -10808,7 +10752,7 @@
   },
   {
     "Pattern ID": "SEQ-model_validation-Test_Suite-Document-COND-CONST",
-    "Trigger": "Sequence: Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Validation team shall validate models the <target_id> (<target_class>) and the <target2_id> (<target2_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -10825,7 +10769,7 @@
   },
   {
     "Pattern ID": "SEQ-model_validation-Test_Suite-Document-CONST",
-    "Trigger": "Sequence: Test Suite --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Validation team shall validate models the <target_id> (<target_class>) and the <target2_id> (<target2_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12009,7 +11953,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Decommission_Plan-Document",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12026,7 +11970,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Decommission_Plan-Document-COND",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12044,7 +11988,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Decommission_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12063,7 +12007,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Decommission_Plan-Document-CONST",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12081,7 +12025,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Deployment_Plan-Document",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12098,7 +12042,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Deployment_Plan-Document-COND",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12116,7 +12060,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Deployment_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12135,7 +12079,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Deployment_Plan-Document-CONST",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12153,7 +12097,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Maintenance_Plan-Document",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12170,7 +12114,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Maintenance_Plan-Document-COND",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12188,7 +12132,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Maintenance_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12207,7 +12151,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Maintenance_Plan-Document-CONST",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12225,7 +12169,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Mitigation_Plan-Document",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12242,7 +12186,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Mitigation_Plan-Document-COND",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12260,7 +12204,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Mitigation_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12279,7 +12223,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Mitigation_Plan-Document-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12297,7 +12241,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Safety_Plan-Document",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12314,7 +12258,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Safety_Plan-Document-COND",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12332,7 +12276,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Safety_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12351,7 +12295,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Safety_Plan-Document-CONST",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12369,7 +12313,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Security_Plan-Document",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12386,7 +12330,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Security_Plan-Document-COND",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12404,7 +12348,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Security_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12423,7 +12367,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_audit-Security_Plan-Document-CONST",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall audit safety processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12441,7 +12385,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Decommission_Plan-Safety_Case",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12458,7 +12402,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Decommission_Plan-Safety_Case-COND",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12476,7 +12420,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Decommission_Plan-Safety_Case-COND-CONST",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12495,7 +12439,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Decommission_Plan-Safety_Case-CONST",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12513,7 +12457,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Deployment_Plan-Safety_Case",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12530,7 +12474,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Deployment_Plan-Safety_Case-COND",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12548,7 +12492,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Deployment_Plan-Safety_Case-COND-CONST",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12567,7 +12511,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Deployment_Plan-Safety_Case-CONST",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12585,7 +12529,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Maintenance_Plan-Safety_Case",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12602,7 +12546,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Maintenance_Plan-Safety_Case-COND",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12620,7 +12564,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Maintenance_Plan-Safety_Case-COND-CONST",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12639,7 +12583,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Maintenance_Plan-Safety_Case-CONST",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12657,7 +12601,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Mitigation_Plan-Safety_Case",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12674,7 +12618,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Mitigation_Plan-Safety_Case-COND",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12692,7 +12636,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Mitigation_Plan-Safety_Case-COND-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12711,7 +12655,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Mitigation_Plan-Safety_Case-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12729,7 +12673,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Safety_Plan-Safety_Case",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12746,7 +12690,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Safety_Plan-Safety_Case-COND",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12764,7 +12708,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Safety_Plan-Safety_Case-COND-CONST",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12783,7 +12727,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Safety_Plan-Safety_Case-CONST",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12801,7 +12745,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Security_Plan-Safety_Case",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12818,7 +12762,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Security_Plan-Safety_Case-COND",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12836,7 +12780,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Security_Plan-Safety_Case-COND-CONST",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "When <condition>, Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12855,7 +12799,7 @@
   },
   {
     "Pattern ID": "SEQ-safety_case_review-Security_Plan-Safety_Case-CONST",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Reviews]--> Safety Case",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Reviews]--> Safety Case",
     "Template": "Safety manager shall review safety case the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -12953,7 +12897,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Decommission_Plan-Document",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12970,7 +12914,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Decommission_Plan-Document-COND",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -12988,7 +12932,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Decommission_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13007,7 +12951,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Decommission_Plan-Document-CONST",
-    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Decommission Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13025,7 +12969,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Deployment_Plan-Document",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13042,7 +12986,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Deployment_Plan-Document-COND",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13060,7 +13004,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Deployment_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13079,7 +13023,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Deployment_Plan-Document-CONST",
-    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Deployment Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13097,7 +13041,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Maintenance_Plan-Document",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13114,7 +13058,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Maintenance_Plan-Document-COND",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13132,7 +13076,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Maintenance_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13151,7 +13095,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Maintenance_Plan-Document-CONST",
-    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Maintenance Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13169,7 +13113,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Mitigation_Plan-Document",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13186,7 +13130,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Mitigation_Plan-Document-COND",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13204,7 +13148,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Mitigation_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13223,7 +13167,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Mitigation_Plan-Document-CONST",
-    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Mitigation Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13241,7 +13185,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Safety_Plan-Document",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13258,7 +13202,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Safety_Plan-Document-COND",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13276,7 +13220,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Safety_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13295,7 +13239,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Safety_Plan-Document-CONST",
-    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Safety Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13313,7 +13257,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Security_Plan-Document",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13330,7 +13274,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Security_Plan-Document-COND",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13348,7 +13292,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Security_Plan-Document-COND-CONST",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13367,7 +13311,7 @@
   },
   {
     "Pattern ID": "SEQ-security_audit-Security_Plan-Document-CONST",
-    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Audit Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall audit security processes the <target_id> (<target_class>), the <target2_id> (<target2_class>), and the <target3_id> (<target3_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13841,7 +13785,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Field_Data-Document",
-    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13860,7 +13804,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Field_Data-Document-COND",
-    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13880,7 +13824,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Field_Data-Document-COND-CONST",
-    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13901,7 +13845,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Field_Data-Document-CONST",
-    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13921,7 +13865,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Hazard-Document",
-    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13940,7 +13884,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Hazard-Document-COND",
-    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -13960,7 +13904,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Hazard-Document-COND-CONST",
-    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -13981,7 +13925,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Hazard-Document-CONST",
-    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -14001,7 +13945,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Security_Threat-Document",
-    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -14020,7 +13964,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Security_Threat-Document-COND",
-    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
@@ -14040,7 +13984,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Security_Threat-Document-COND-CONST",
-    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "When <condition>, Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
@@ -14061,7 +14005,7 @@
   },
   {
     "Pattern ID": "SEQ-threat_analysis_validation-Security_Threat-Document-CONST",
-    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Validation Report --[Produces]--> Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Mitigation Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "Cybersecurity team shall validate threat mitigations the <target_id> (<target_class>), the <target2_id> (<target2_class>), the <target3_id> (<target3_class>), and the <target4_id> (<target4_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -504,8 +504,13 @@ def _format_label(
     label = name or ""
     if obj is not None:
         repo = getattr(_win, "repo", None)
-        diag = repo.diagrams.get(_win.diagram_id) if repo else None
-        if diag and diag.diag_type == "Governance Diagram":
+        diagram_id = getattr(_win, "diagram_id", None)
+        diag = repo.diagrams.get(diagram_id) if repo and diagram_id else None
+        if (
+            diag
+            and diag.diag_type == "Governance Diagram"
+            and obj.obj_type != "Work Product"
+        ):
             elem_type = obj.obj_type
             if repo and obj.element_id in repo.elements:
                 elem_type = repo.elements[obj.element_id].elem_type
@@ -3584,8 +3589,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Security Plan": "document",
             "Mitigation Plan": "document",
             "Security Threat": "cross",
-            "Validation Report": "document",
-            "Audit Report": "document",
+            "Report": "document",
             "Safety Case": "document",
             "Deployment Plan": "document",
             "Maintenance Plan": "document",
@@ -7167,8 +7171,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Safety Plan",
             "Security Plan",
             "Mitigation Plan",
-            "Validation Report",
-            "Audit Report",
+            "Report",
             "Safety Case",
             "Deployment Plan",
             "Maintenance Plan",

--- a/styles/pastel.xml
+++ b/styles/pastel.xml
@@ -70,8 +70,7 @@
   <object type="Security Plan" color="#c9daf8" />
   <object type="Mitigation Plan" color="#d9d2e9" />
   <object type="Security Threat" color="#ead1dc" />
-  <object type="Validation Report" color="#cfe2f3" />
-  <object type="Audit Report" color="#b4a7d6" />
+  <object type="Report" color="#cfe2f3" />
   <object type="Safety Case" color="#d9ead3" />
   <object type="Deployment Plan" color="#fff2cc" />
   <object type="Maintenance Plan" color="#e2f0d9" />

--- a/tests/test_requirement_rule_generator.py
+++ b/tests/test_requirement_rule_generator.py
@@ -134,13 +134,13 @@ def test_complex_sequences() -> None:
             "Produces": {
                 "Process": ["Document"],
                 "Test Suite": ["Document"],
-                "Validation Report": ["Document"],
+                "Report": ["Document"],
                 "Verification Plan": ["Document"],
             },
             "Validate": {
                 "Model": ["Test Suite"],
-                "Mitigation Plan": ["Validation Report"],
-                "Test Suite": ["Validation Report"],
+                "Mitigation Plan": ["Report"],
+                "Test Suite": ["Report"],
             },
             "Assesses": {
                 "Hazard": ["Risk Assessment"],


### PR DESCRIPTION
## Summary
- Replace separate Validation Report and Audit Report toolbox entries with a single Report element
- Update patterns, diagram rules and GUI mapping to reference the new Report node
- Ensure label formatting skips stereotypes for Work Product objects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a323e86de88327809b8e37c040f44b