### PR TITLE
Move Plan element to Other toolbox

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -140,7 +140,7 @@ def _make_gov_element_classes(nodes: list[str]) -> dict[str, list[str]]:
             ]
             if n in nodes
         ],
-        "Verification": [n for n in ["Test Suite", "Plan"] if n in nodes],
+        "Verification": [n for n in ["Test Suite"] if n in nodes],
         "Events": [n for n in ["Incident", "Safety Issue"] if n in nodes],
     }
     known = {n for vals in base.values() for n in vals}


### PR DESCRIPTION
## Summary
- Move Plan element from Verification to Other sub-toolbox in governance elements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a3319064288327a5cc4b37e5b3838b