### PR TITLE
Show stereotypes before element names in governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -560,7 +560,7 @@ def _format_label(
             if repo and obj.element_id in repo.elements:
                 elem_type = repo.elements[obj.element_id].elem_type
             stereo = _GOV_TYPE_ALIASES.get(elem_type, elem_type).lower()
-            label = f"{label}\n<<{stereo}>>".strip()
+            label = f"<<{stereo}>>\n{label}".strip()
     return label
 
 

--- a/tests/test_governance_element_stereotype_label.py
+++ b/tests/test_governance_element_stereotype_label.py
@@ -36,7 +36,8 @@ class GovernanceElementStereotypeTests(unittest.TestCase):
         obj = SysMLObject(1, "Action", 0.0, 0.0, element_id=elem.elem_id, properties={"name": "Draft Plan"})
         win = DummyWindow(diag.diag_id)
         lines = win._object_label_lines(obj)
-        self.assertIn("<<task>>", " ".join(lines))
+        self.assertEqual("<<task>>", lines[0])
+        self.assertEqual("Draft Plan", lines[1])
 
     def test_decision_label_includes_stereotype(self):
         repo = SysMLRepository.get_instance()
@@ -45,7 +46,8 @@ class GovernanceElementStereotypeTests(unittest.TestCase):
         obj = SysMLObject(2, "Decision", 0.0, 0.0, element_id=elem.elem_id, properties={"name": "Gate"})
         win = DummyWindow(diag.diag_id)
         lines = win._object_label_lines(obj)
-        self.assertIn("<<decision>>", " ".join(lines))
+        self.assertEqual("<<decision>>", lines[0])
+        self.assertEqual("Gate", lines[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Prefix element labels with stereotypes in governance diagrams
- Adjust tests to ensure stereotypes render before names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a33ba201e48327a59eaa2dec2bbd1c