### PR TITLE
Remove specific nodes from governance toolbox

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -75,10 +75,7 @@
     "Field Data",
     "Model",
     "Lifecycle Phase",
-    "Hazard",
     "Risk Assessment",
-    "Safety Goal",
-    "Security Threat",
     "Report"
   ],
 


### PR DESCRIPTION
## Summary
- remove Security Threat, Hazard and Safety Goal from governance element toolbox configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3402846c0832784a6d206d1dd9f26