### PR TITLE
Align data nodes with database shape in governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3606,7 +3606,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Database": "cylinder",
             "System Boundary": "rect",
             "Business Unit": "rect",
-            "Data": "circle",
+            "Data": "cylinder",
             "Document": "document",
             "Guideline": "document",
             "Metric": "diamond",

--- a/tests/test_governance_icons.py
+++ b/tests/test_governance_icons.py
@@ -18,6 +18,8 @@ def test_governance_shapes_and_relations():
     assert shape(None, "Safety Goal") == "pentagon"
     assert shape(None, "Security Threat") == "cross"
     assert shape(None, "Plan") == "document"
+    assert shape(None, "Data") == "cylinder"
+    assert shape(None, "Field Data") == "cylinder"
 
     style = StyleManager.get_instance()
     for element in [
@@ -26,5 +28,7 @@ def test_governance_shapes_and_relations():
         "Safety Goal",
         "Security Threat",
         "Plan",
+        "Data",
+        "Field Data",
     ]:
         assert style.get_color(element) != "#FFFFFF"


### PR DESCRIPTION
## Summary
- Render `Data` nodes with a cylinder so they match `Database` and `Field Data` elements
- Test that Data-related elements use cylinder shapes and have defined colors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a342aa04c0832784597885222a977f