### PR TITLE
Display ISO/IEEE/IEC label for Standard shape

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -7069,6 +7069,15 @@ class SysMLDiagramWindow(tk.Frame):
                 x + r, cy + r * 0.2, x + r * 0.2, y + h, x, cy + r * 0.2,
                 fill=color, outline=outline
             )
+            label_font = tkFont.Font(font=self.font)
+            label_font.configure(weight="bold")
+            self.canvas.create_text(
+                x,
+                cy - r - 5 * self.zoom,
+                text="ISO/IEEE/IEC",
+                font=label_font,
+                anchor="s",
+            )
         elif obj.obj_type == "Process" or obj.obj_type == "Manufacturing Process":
             r = min(w, h)
             pts = []

--- a/tests/test_standard_shape_label.py
+++ b/tests/test_standard_shape_label.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+import tkinter.font as tkFont
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import SysMLDiagramWindow
+from gui.style_manager import StyleManager
+
+
+class DummyFont:
+    def configure(self, **kwargs):
+        pass
+
+
+class DummyCanvas:
+    def __init__(self):
+        self.text_calls = []
+
+    def create_oval(self, *args, **kwargs):
+        pass
+
+    def create_polygon(self, *args, **kwargs):
+        pass
+
+    def create_text(self, x, y, text="", font=None, **kwargs):
+        self.text_calls.append(text)
+
+
+@pytest.fixture
+def dummy_window(monkeypatch):
+    monkeypatch.setattr(tkFont, "Font", lambda *a, **k: DummyFont())
+    StyleManager._instance = None
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.zoom = 1
+    win.canvas = DummyCanvas()
+    win.drawing_helper = SimpleNamespace(_fill_gradient_circle=lambda *a, **k: None)
+    win.font = DummyFont()
+    win.selected_objs = set()
+    win.repo = SimpleNamespace(elements={}, diagrams={}, element_diagrams={}, relationships=[], get_linked_diagram=lambda _id: None)
+    win.diagram_id = "D1"
+    return win
+
+
+def test_standard_shape_has_iso_label(dummy_window):
+    class DummyObj(SimpleNamespace):
+        __hash__ = object.__hash__
+
+    obj = DummyObj(
+        obj_type="Standard",
+        x=0,
+        y=0,
+        width=100,
+        height=100,
+        obj_id=1,
+        properties={},
+        element_id=None,
+        phase="",
+        requirements=[],
+    )
+    dummy_window.draw_object(obj)
+    assert "ISO/IEEE/IEC" in dummy_window.canvas.text_calls


### PR DESCRIPTION
## Summary
- show bold "ISO/IEEE/IEC" text above the Standard (ribbon) shape
- add regression test checking the label is rendered

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3576bf3808327b876300ed93d9add