### PR TITLE
Use cylinder icons for data nodes and rename AI database

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -10914,9 +10914,10 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         if hasattr(self.toolbox, "tk"):
             self.ai_tools_frame = ttk.Frame(self.toolbox)
             for name in ai_nodes:
+                display = "AI Database" if name == "Database" else name
                 ttk.Button(
                     self.ai_tools_frame,
-                    text=name,
+                    text=display,
                     image=self._icon_for(name),
                     compound=tk.LEFT,
                     command=lambda t=name: self.select_tool(t),
@@ -12127,7 +12128,8 @@ class ArchitectureManagerDialog(tk.Frame):
             "ANN": self._create_icon("neural", style.get_color("ANN")),
             "Data acquisition": self._create_icon("arrow", style.get_color("Data acquisition")),
             "Business Unit": self._create_icon("department", style.get_color("Business Unit")),
-            "Data": self._create_icon("circle", style.get_color("Data")),
+            "Data": self._create_icon("cylinder", style.get_color("Data")),
+            "Field Data": self._create_icon("cylinder", style.get_color("Field Data")),
             "Document": self._create_icon("document", style.get_color("Document")),
             "Guideline": self._create_icon("compass", style.get_color("Guideline")),
             "Metric": self._create_icon("chart", style.get_color("Metric")),

--- a/tests/test_ai_database_label.py
+++ b/tests/test_ai_database_label.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+def test_ai_database_and_cylinder_icons():
+    arch_path = Path(__file__).resolve().parents[1] / "gui" / "architecture.py"
+    content = arch_path.read_text()
+    assert '"Data": self._create_icon("cylinder"' in content
+    assert '"Field Data": self._create_icon("cylinder"' in content
+    assert '"AI Database" if name == "Database" else name' in content


### PR DESCRIPTION
## Summary
- Display "AI Database" label in Safety & AI toolbox
- Render Data and Field Data nodes with matching cylinder icons
- Add regression test for AI Database label and cylinder icons

## Testing
- `pytest tests/test_ai_database_label.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a35a140a348327908975720d59f97e