### PR TITLE
Fix governance bottom-label shapes to be non-resizable

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -255,6 +255,17 @@ _BOTTOM_LABEL_TYPES = {
 }
 
 
+# Object types that cannot be resized
+_FIXED_SIZE_TYPES = {
+    "Initial",
+    "Final",
+    "Actor",
+    "Decision",
+    "Merge",
+    "Work Product",
+} | _BOTTOM_LABEL_TYPES
+
+
 # Connection types excluding Safety & AI relations used for membership checks
 _BASE_CONN_TYPES = {
     "Association",
@@ -4556,14 +4567,7 @@ class SysMLDiagramWindow(tk.Frame):
         y = self.canvas.canvasy(event.y)
         if self.resizing_obj:
             obj = self.resizing_obj
-            if obj.obj_type in (
-                "Initial",
-                "Final",
-                "Actor",
-                "Decision",
-                "Merge",
-                "Work Product",
-            ):
+            if obj.obj_type in _FIXED_SIZE_TYPES:
                 return
             min_w, min_h = (10.0, 10.0)
             if obj.obj_type == "Block":
@@ -5276,14 +5280,7 @@ class SysMLDiagramWindow(tk.Frame):
         return None
 
     def hit_resize_handle(self, obj: SysMLObject, x: float, y: float) -> str | None:
-        if obj.obj_type in (
-            "Initial",
-            "Final",
-            "Actor",
-            "Decision",
-            "Merge",
-            "Work Product",
-        ):
+        if obj.obj_type in _FIXED_SIZE_TYPES:
             return None
         margin = 5
         ox = obj.x * self.zoom

--- a/tests/test_governance_label_positions.py
+++ b/tests/test_governance_label_positions.py
@@ -1,11 +1,62 @@
 import sys
+import types
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from gui.architecture import _BOTTOM_LABEL_TYPES
+from gui.architecture import (
+    _BOTTOM_LABEL_TYPES,
+    GovernanceDiagramWindow,
+    SysMLRepository,
+    SysMLObject,
+)
+
+
+class DummyCanvas:
+    def canvasx(self, x):
+        return x
+
+    def canvasy(self, y):
+        return y
 
 
 def test_governance_names_after_shape():
     for obj_type in ("Organization", "Model", "Business Unit"):
         assert obj_type in _BOTTOM_LABEL_TYPES
+
+
+def test_bottom_label_shapes_fixed_size():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.zoom = 1.0
+    win.canvas = DummyCanvas()
+    win.start = None
+    win.current_tool = "Select"
+    win.select_rect_start = None
+    win.dragging_endpoint = None
+    win.selected_conn = None
+    win.dragging_point_index = None
+    win.conn_drag_offset = None
+    for obj_type in ("Organization", "Model", "Business Unit"):
+        obj = SysMLObject(
+            1,
+            obj_type,
+            0.0,
+            0.0,
+            width=80.0,
+            height=40.0,
+            properties={"name": obj_type},
+        )
+        win.objects = [obj]
+        win.selected_obj = obj
+        assert win.hit_resize_handle(obj, 0.0, 0.0) is None
+        win.resizing_obj = obj
+        win.resize_edge = "se"
+        event = types.SimpleNamespace(x=100, y=100)
+        win.on_left_drag(event)
+        assert obj.width == 80.0
+        assert obj.height == 40.0


### PR DESCRIPTION
## Summary
- ensure governance diagram shapes with bottom labels keep fixed dimensions
- prevent resizing of bottom-label objects and other fixed shapes
- test that bottom-label objects cannot be resized

## Testing
- `pytest tests/test_governance_label_positions.py tests/test_safety_management.py::test_work_product_shapes_fixed_size -q`


------
https://chatgpt.com/codex/tasks/task_b_68a35f58737883278c0b7a92c5b379d8