### PR TITLE
feat(gui): dynamic governance toolboxes

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -11,6 +11,7 @@ except Exception:  # pragma: no cover - fallback for minimal installs
 import math
 import re
 import types
+import weakref
 from pathlib import Path
 from dataclasses import dataclass, field, asdict, replace
 from typing import Dict, List, Tuple
@@ -54,6 +55,9 @@ CONNECTION_SELECT_RADIUS = 15
 
 _CONFIG_PATH = Path(__file__).resolve().parents[1] / "config/diagram_rules.json"
 _CONFIG = load_diagram_rules(_CONFIG_PATH)
+
+# Track open Architecture windows so toolbox layouts can refresh when rules change
+ARCH_WINDOWS: set[weakref.ReferenceType] = set()
 
 # Diagram types that belong to the generic "Architecture Diagram" work product
 ARCH_DIAGRAM_TYPES = set(_CONFIG.get("arch_diagram_types", []))
@@ -144,52 +148,16 @@ def _make_gov_element_classes(nodes: list[str]) -> dict[str, list[str]]:
         "Events": [n for n in ["Incident", "Safety Issue"] if n in nodes],
     }
     known = {n for vals in base.values() for n in vals}
-    # Exclude lifecycle phases from the generic "Other" group since a dedicated
-    # toolbox command exists for adding them. Keeping them here would create a
-    # duplicate button in the governance elements toolbox.
+    # Exclude lifecycle phases from the generic management group since a
+    # dedicated toolbox command exists for adding them. Keeping them here would
+    # create a duplicate button in the governance elements toolbox.
     other = [n for n in nodes if n not in known and n != "Lifecycle Phase"]
     if other:
-        base["Other"] = other
-    return base
-
-
-def _make_gov_relation_groups(rels: list[str]) -> dict[str, list[str]]:
-    base = {
-        "Authority": [
-            n
-            for n in ["Approves", "Audits", "Authorizes", "Monitors", "Responsible for"]
-            if n in rels
-        ],
-        "Flow": [
-            n
-            for n in ["Communication Path", "Delivers", "Produces", "Consumes", "Uses"]
-            if n in rels
-        ],
-        "Execution": [
-            n
-            for n in ["Executes", "Performs", "Implement", "Operate", "Manufacture"]
-            if n in rels
-        ],
-        "Quality": [
-            n
-            for n in ["Validate", "Verify", "Inspect", "Triage", "Improve"]
-            if n in rels
-        ],
-        "Structure": [
-            n
-            for n in ["Constrained by", "Constrains", "Extend", "Generalize", "Establish"]
-            if n in rels
-        ],
-    }
-    known = {n for vals in base.values() for n in vals}
-    other = [n for n in rels if n not in known]
-    if other:
-        base["Other"] = other
+        base["Safety & Security Mgmt"] = other
     return base
 
 
 GOV_ELEMENT_CLASSES = _make_gov_element_classes(GOV_ELEMENT_NODES)
-GOV_ELEMENT_RELATION_GROUPS = _make_gov_relation_groups(GOV_ELEMENT_RELATIONS)
 
 # Elements from the governance toolbox that may participate in
 # Safety & AI relationships
@@ -220,6 +188,52 @@ NODE_CONNECTION_LIMITS: dict[str, int] = _CONFIG.get("node_connection_limits", {
 
 # Node types that require guards on outgoing flows
 GUARD_NODES = set(_CONFIG.get("guard_nodes", []))
+
+
+def _relations_for(nodes: list[str]) -> list[str]:
+    """Return connection labels relevant to ``nodes`` based on diagram rules."""
+
+    rels: set[str] = set()
+    node_set = set(nodes)
+
+    # Only consider relationships defined for Governance diagrams.  Iterating
+    # over all diagram rules caused every connection label to appear in each
+    # toolbox even when a node had no valid targets for that relation.
+    gov_rules = CONNECTION_RULES.get("Governance Diagram", {})
+    for rel, srcs in gov_rules.items():
+        for src, dests in srcs.items():
+            # A relation is relevant when a node in ``node_set`` can be the
+            # source with at least one allowed target, or when a node in
+            # ``node_set`` can be the target for some other source.
+            if src in node_set and dests:
+                rels.add(rel)
+            elif node_set.intersection(dests):
+                rels.add(rel)
+
+    # Apply the same filtering to Safety & AI specific rules.
+    for rel, srcs in SAFETY_AI_RELATION_RULES.items():
+        for src, dests in srcs.items():
+            if src in node_set and dests:
+                rels.add(rel)
+            elif node_set.intersection(dests):
+                rels.add(rel)
+
+    return sorted(rels)
+
+
+def _toolbox_defs() -> dict[str, dict[str, list[str]]]:
+    """Return mapping of toolbox name to node/relation lists."""
+    defs: dict[str, dict[str, list[str]]] = {}
+    for group, nodes in GOV_ELEMENT_CLASSES.items():
+        if not nodes:
+            continue
+        defs[group] = {"nodes": nodes, "relations": _relations_for(nodes)}
+    if SAFETY_AI_NODES:
+        defs["Safety & AI Lifecycle"] = {
+            "nodes": SAFETY_AI_NODES,
+            "relations": _relations_for(SAFETY_AI_NODES),
+        }
+    return defs
 
 # Node type aliases used when validating governance diagram connections.
 # Governance tasks are implemented using SysML ``Action`` elements but are
@@ -469,7 +483,7 @@ def reload_config() -> None:
     """Reload diagram rule configuration at runtime."""
     global _CONFIG, ARCH_DIAGRAM_TYPES, SAFETY_AI_NODES, SAFETY_AI_NODE_TYPES
     global SAFETY_AI_RELATIONS, SAFETY_AI_RELATION_SET, GOVERNANCE_NODE_TYPES
-    global GOV_ELEMENT_NODES, GOV_ELEMENT_RELATIONS, GOV_ELEMENT_CLASSES, GOV_ELEMENT_RELATION_GROUPS
+    global GOV_ELEMENT_NODES, GOV_ELEMENT_RELATIONS, GOV_ELEMENT_CLASSES
     global SAFETY_AI_RELATION_RULES, CONNECTION_RULES, NODE_CONNECTION_LIMITS, GUARD_NODES
     _CONFIG = load_diagram_rules(_CONFIG_PATH)
     ARCH_DIAGRAM_TYPES = set(_CONFIG.get("arch_diagram_types", []))
@@ -482,7 +496,6 @@ def reload_config() -> None:
     )
     GOV_ELEMENT_RELATIONS = _CONFIG.get("governance_element_relations", [])
     GOV_ELEMENT_CLASSES = _make_gov_element_classes(GOV_ELEMENT_NODES)
-    GOV_ELEMENT_RELATION_GROUPS = _make_gov_relation_groups(GOV_ELEMENT_RELATIONS)
     GOVERNANCE_NODE_TYPES = set(
         _normalize_plan_types(_CONFIG.get("governance_node_types", []))
     )
@@ -500,6 +513,12 @@ def reload_config() -> None:
     NODE_CONNECTION_LIMITS = _CONFIG.get("node_connection_limits", {})
     GUARD_NODES = set(_CONFIG.get("guard_nodes", []))
     _enforce_connection_rules()
+    for ref in list(ARCH_WINDOWS):
+        win = ref()
+        if win:
+            win._rebuild_toolboxes()
+        else:
+            ARCH_WINDOWS.discard(ref)
 
 
 def _work_product_name(diag_type: str) -> str:
@@ -10857,242 +10876,41 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                     pass
 
         # ------------------------------------------------------------------
-        # Toolbox toggle between Governance and Safety & AI Lifecycle
+        # Toolbox selector built from diagram rules
         # ------------------------------------------------------------------
+        self._toolbox_frames: dict[str, list] = {}
         try:
-            self.toolbox_var = tk.StringVar(value="Governance")
+            self.toolbox_var = tk.StringVar()
         except Exception:  # pragma: no cover - headless tests
             class _Var:
-                def __init__(self, value):
-                    self._value = value
+                def __init__(self):
+                    self._v = ""
 
                 def get(self):
-                    return self._value
+                    return self._v
 
                 def set(self, v):
-                    self._value = v
+                    self._v = v
 
-            self.toolbox_var = _Var("Governance")
+            self.toolbox_var = _Var()
         if hasattr(self.toolbox, "tk"):
-            selector = ttk.Combobox(
-                self.toolbox,
-                values=[
-                    "Governance",
-                    "Safety & AI Lifecycle",
-                ],
-                state="readonly",
-                textvariable=self.toolbox_var,
+            self.toolbox_selector = ttk.Combobox(
+                self.toolbox, state="readonly", textvariable=self.toolbox_var
             )
-            selector.pack(fill=tk.X, padx=2, pady=2)
-            selector.bind("<<ComboboxSelected>>", lambda e: self._switch_toolbox())
+            self.toolbox_selector.pack(fill=tk.X, padx=2, pady=2)
+            self.toolbox_selector.bind("<<ComboboxSelected>>", lambda e: self._switch_toolbox())
         else:  # pragma: no cover - headless tests
-            selector = types.SimpleNamespace(pack=lambda *a, **k: None, bind=lambda *a, **k: None, lift=lambda: None)
-
-        # Store original governance tool frame and relationship frame
-        self.gov_tools_frame = self.tools_frame
-        self.gov_rel_frame = getattr(self, "rel_frame", None)
-
-        # Create Safety & AI Lifecycle toolbox frame
-        ai_nodes = SAFETY_AI_NODES
-        ai_relations = SAFETY_AI_RELATIONS
-        if hasattr(self.toolbox, "tk"):
-            self.ai_tools_frame = ttk.Frame(self.toolbox)
-            for name in ai_nodes:
-                display = "AI Database" if name == "Database" else name
-                ttk.Button(
-                    self.ai_tools_frame,
-                    text=display,
-                    image=self._icon_for(name),
-                    compound=tk.LEFT,
-                    command=lambda t=name: self.select_tool(t),
-                ).pack(fill=tk.X, padx=2, pady=2)
-            rel_frame = ttk.LabelFrame(
-                self.ai_tools_frame, text="Relationships (relationships)"
-            )
-            rel_frame.pack(fill=tk.X, padx=2, pady=2)
-            for name in ai_relations:
-                ttk.Button(
-                    rel_frame,
-                    text=name,
-                    image=self._icon_for(name),
-                    compound=tk.LEFT,
-                    command=lambda t=name: self.select_tool(t),
-                ).pack(fill=tk.X, padx=2, pady=2)
-        else:  # pragma: no cover - headless tests
-            self.ai_tools_frame = types.SimpleNamespace(
+            self.toolbox_selector = types.SimpleNamespace(
                 pack=lambda *a, **k: None,
-                pack_forget=lambda *a, **k: None,
+                bind=lambda *a, **k: None,
+                configure=lambda *a, **k: None,
             )
 
-        # Create toolbox for additional governance elements grouped by class
-        # (merged into the main Governance toolbox)
-        ge_nodes = GOV_ELEMENT_CLASSES
-        if hasattr(self.toolbox, "tk"):
-            self.gov_elements_frame = ttk.Frame(self.toolbox)
-
-            # Migrate basic governance element commands from the right panel
-            node_cmds = [
-                ("Add Work Product", self.add_work_product),
-                ("Add Generic Work Product", self.add_generic_work_product),
-                ("Add Process Area", self.add_process_area),
-                ("Add Lifecycle Phase", self.add_lifecycle_phase),
-            ]
-            elem_group = ttk.LabelFrame(
-                self.gov_elements_frame, text="Elements (elements)"
-            )
-            elem_group.pack(fill=tk.X, padx=2, pady=2)
-            for name, cmd in node_cmds:
-                ttk.Button(
-                    elem_group,
-                    text=name,
-                    image=self._icon_for(name),
-                    compound=tk.LEFT,
-                    command=cmd,
-                ).pack(fill=tk.X, padx=2, pady=2)
-
-            for group, nodes in ge_nodes.items():
-                frame = ttk.LabelFrame(
-                    self.gov_elements_frame, text=f"{group} (elements)"
-                )
-                frame.pack(fill=tk.X, padx=2, pady=2)
-                for name in nodes:
-                    ttk.Button(
-                        frame,
-                        text=name,
-                        image=self._icon_for(name),
-                        compound=tk.LEFT,
-                        command=lambda t=name: self.select_tool(t),
-                    ).pack(fill=tk.X, padx=2, pady=2)
-        else:
-            self.gov_elements_frame = types.SimpleNamespace(
-                pack=lambda *a, **k: None,
-                pack_forget=lambda *a, **k: None,
-            )
-
-        # Repack toolbox to include selector and default to governance frame
-        if hasattr(self, "back_btn"):
-            self.back_btn.pack_forget()
-        if hasattr(self.gov_tools_frame, "pack_forget"):
-            self.gov_tools_frame.pack_forget()
-        if self.gov_rel_frame and hasattr(self.gov_rel_frame, "pack_forget"):
-            self.gov_rel_frame.pack_forget()
-        if getattr(self, "gov_elements_frame", None) and hasattr(
-            self.gov_elements_frame, "pack_forget"
-        ):
-            self.gov_elements_frame.pack_forget()
-        if hasattr(self, "prop_frame") and hasattr(self.prop_frame, "pack_forget"):
-            self.prop_frame.pack_forget()
-
-        if hasattr(self, "back_btn"):
-            self.back_btn.pack(fill=tk.X, padx=2, pady=2)
-        selector.lift()
-        if hasattr(self.gov_tools_frame, "pack"):
-            self.gov_tools_frame.pack(fill=tk.X, padx=2, pady=2)
-        if getattr(self, "gov_elements_frame", None) and hasattr(
-            self.gov_elements_frame, "pack"
-        ):
-            self.gov_elements_frame.pack(fill=tk.X, padx=2, pady=2)
-        if self.gov_rel_frame and hasattr(self.gov_rel_frame, "pack"):
-            self.gov_rel_frame.pack(fill=tk.X, padx=2, pady=2)
-        if hasattr(self, "prop_frame") and hasattr(self.prop_frame, "pack"):
-            self.prop_frame.pack(fill=tk.BOTH, expand=True, padx=2, pady=2)
+        self._rebuild_toolboxes()
+        ARCH_WINDOWS.add(weakref.ref(self))
 
         canvas_frame = self.canvas.master
         canvas_frame.pack_forget()
-
-        if hasattr(self, "tk"):
-            # Measure current toolbox widths so the governance toolbox matches
-            self.toolbox_canvas.update_idletasks()
-            self.toolbox_container.update_idletasks()
-            canvas_width = (
-                self.toolbox_canvas.winfo_width()
-                or self.toolbox_canvas.winfo_reqwidth()
-            )
-            container_width = (
-                self.toolbox_container.winfo_width()
-                or self.toolbox_container.winfo_reqwidth()
-            )
-
-            gov_container = ttk.Frame(self, width=container_width)
-            gov_container.pack(side=tk.RIGHT, fill=tk.Y, padx=2, pady=2)
-            gov_container.pack_propagate(False)
-
-            gov_canvas = tk.Canvas(
-                gov_container, highlightthickness=0, width=canvas_width
-            )
-            gov_canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-
-            gov_scroll = ttk.Scrollbar(
-                gov_container, orient=tk.VERTICAL, command=gov_canvas.yview
-            )
-            gov_scroll.pack(side=tk.RIGHT, fill=tk.Y)
-            gov_canvas.configure(yscrollcommand=gov_scroll.set)
-
-            governance_panel = ttk.LabelFrame(
-                gov_canvas, text="Governance relationships"
-            )
-            gov_window = gov_canvas.create_window(
-                (0, 0), window=governance_panel, anchor="nw"
-            )
-            governance_panel.bind(
-                "<Configure>",
-                lambda e: gov_canvas.configure(scrollregion=gov_canvas.bbox("all")),
-            )
-            gov_canvas.bind(
-                "<Configure>",
-                lambda e: gov_canvas.itemconfig(gov_window, width=e.width),
-            )
-
-            # Ensure the governance toolbox is visible immediately
-            self._fit_governance_toolbox(gov_container, gov_canvas, gov_window)
-            self.after_idle(
-                lambda: self._fit_governance_toolbox(
-                    gov_container, gov_canvas, gov_window
-                )
-            )
-
-            work_rel_names = [
-                "Propagate",
-                "Propagate by Review",
-                "Propagate by Approval",
-                "Used By",
-                "Used after Review",
-                "Used after Approval",
-                "Re-use",
-                "Trace",
-                "Satisfied by",
-                "Derived from",
-            ]
-            wp_rel = ttk.LabelFrame(
-                governance_panel, text="Work Product Links (relationships)"
-            )
-            wp_rel.pack(fill=tk.X, padx=2, pady=2)
-            for name in work_rel_names:
-                ttk.Button(
-                    wp_rel,
-                    text=name,
-                    image=self._icon_for(name),
-                    compound=tk.LEFT,
-                    command=lambda t=name: self.select_tool(t),
-                ).pack(fill=tk.X, padx=2, pady=2)
-
-            for group, names in GOV_ELEMENT_RELATION_GROUPS.items():
-                rel_frame = ttk.LabelFrame(
-                    governance_panel, text=f"{group} (relationships)"
-                )
-                rel_frame.pack(fill=tk.X, padx=2, pady=2)
-                for name in names:
-                    ttk.Button(
-                        rel_frame,
-                        text=name,
-                        image=self._icon_for(name),
-                        compound=tk.LEFT,
-                        command=lambda t=name: self.select_tool(t),
-                    ).pack(fill=tk.X, padx=2, pady=2)
-        else:  # pragma: no cover - headless tests
-            governance_panel = types.SimpleNamespace(
-                pack=lambda *a, **k: None
-            )
 
         canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
         self._activate_parent_phase()
@@ -11123,33 +10941,98 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         toolbox.activate_phase(phase, app)
 
     # ------------------------------------------------------------------
-    # Toolbox switching logic
+    # Dynamic toolbox construction
     # ------------------------------------------------------------------
+    def _rebuild_toolboxes(self) -> None:
+        defs = _toolbox_defs()
+        options = ["Governance Core"] + sorted(defs.keys())
+        if hasattr(self.tools_frame, "pack_forget"):
+            self.tools_frame.pack_forget()
+        if getattr(self, "rel_frame", None) and hasattr(self.rel_frame, "pack_forget"):
+            self.rel_frame.pack_forget()
+        for name, frames in list(getattr(self, "_toolbox_frames", {}).items()):
+            if name == "Governance Core":
+                continue
+            for fr in frames:
+                if hasattr(fr, "destroy"):
+                    fr.destroy()
+            del self._toolbox_frames[name]
+        if hasattr(self.toolbox, "tk"):
+            action_frame = ttk.Frame(self.toolbox)
+            cmds = [
+                ("Add Work Product", self.add_work_product),
+                ("Add Generic Work Product", self.add_generic_work_product),
+                ("Add Process Area", self.add_process_area),
+                ("Add Lifecycle Phase", self.add_lifecycle_phase),
+            ]
+            for name, cmd in cmds:
+                ttk.Button(
+                    action_frame,
+                    text=name,
+                    image=self._icon_for(name),
+                    compound=tk.LEFT,
+                    command=cmd,
+                ).pack(fill=tk.X, padx=2, pady=2)
+        else:  # pragma: no cover - headless tests
+            action_frame = types.SimpleNamespace(
+                pack=lambda *a, **k: None,
+                pack_forget=lambda *a, **k: None,
+                destroy=lambda *a, **k: None,
+            )
+        self._toolbox_frames["Governance Core"] = [
+            self.tools_frame,
+            action_frame,
+            getattr(self, "rel_frame", None),
+        ]
+        for name, data in defs.items():
+            if name == "Governance Core":
+                continue
+            if hasattr(self.toolbox, "tk"):
+                frame = ttk.Frame(self.toolbox)
+                if data["nodes"]:
+                    elem = ttk.LabelFrame(frame, text="Elements (elements)")
+                    elem.pack(fill=tk.X, padx=2, pady=2)
+                    for node in data["nodes"]:
+                        ttk.Button(
+                            elem,
+                            text=node,
+                            image=self._icon_for(node),
+                            compound=tk.LEFT,
+                            command=lambda t=node: self.select_tool(t),
+                        ).pack(fill=tk.X, padx=2, pady=2)
+                if data["relations"]:
+                    rel = ttk.LabelFrame(frame, text="Relationships (relationships)")
+                    rel.pack(fill=tk.X, padx=2, pady=2)
+                    for rel_name in data["relations"]:
+                        ttk.Button(
+                            rel,
+                            text=rel_name,
+                            image=self._icon_for(rel_name),
+                            compound=tk.LEFT,
+                            command=lambda t=rel_name: self.select_tool(t),
+                        ).pack(fill=tk.X, padx=2, pady=2)
+            else:  # pragma: no cover - headless tests
+                frame = types.SimpleNamespace(
+                    pack=lambda *a, **k: None,
+                    pack_forget=lambda *a, **k: None,
+                    destroy=lambda *a, **k: None,
+                )
+            self._toolbox_frames[name] = [frame]
+        self.toolbox_selector.configure(values=options)
+        current = self.toolbox_var.get()
+        if current not in options:
+            self.toolbox_var.set(options[0] if options else "")
+        self._switch_toolbox()
+
     def _switch_toolbox(self) -> None:
         choice = self.toolbox_var.get()
-        before = self.prop_frame if hasattr(self, "prop_frame") else None
-        frames = {
-            "Governance": [
-                self.gov_tools_frame,
-                getattr(self, "gov_elements_frame", None),
-                self.gov_rel_frame,
-            ],
-            "Safety & AI Lifecycle": [self.ai_tools_frame],
-        }
-        for frame in [
-            self.gov_tools_frame,
-            self.gov_rel_frame,
-            self.ai_tools_frame,
-            getattr(self, "gov_elements_frame", None),
-        ]:
-            if frame and hasattr(frame, "pack_forget"):
-                frame.pack_forget()
-        for frame in frames.get(choice, []):
+        for frames in self._toolbox_frames.values():
+            for frame in frames:
+                if frame and hasattr(frame, "pack_forget"):
+                    frame.pack_forget()
+        for frame in self._toolbox_frames.get(choice, []):
             if frame and hasattr(frame, "pack"):
-                if before:
-                    frame.pack(fill=tk.X, padx=2, pady=2, before=before)
-                else:
-                    frame.pack(fill=tk.X, padx=2, pady=2)
+                frame.pack(fill=tk.X, padx=2, pady=2)
 
     class _SelectDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
         def __init__(self, parent, title: str, options: list[str]):

--- a/tests/test_governance_core_actions.py
+++ b/tests/test_governance_core_actions.py
@@ -1,0 +1,70 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow
+from gui import architecture
+
+
+def test_governance_core_has_add_buttons(monkeypatch):
+    class DummyFrame:
+        def __init__(self, master=None, text=None):
+            self.master = master
+            self.text = text
+            self.children = []
+            if master and hasattr(master, "children"):
+                master.children.append(self)
+
+        def pack(self, *args, **kwargs):
+            pass
+
+        def pack_forget(self, *args, **kwargs):
+            pass
+
+        def destroy(self, *args, **kwargs):
+            pass
+
+    class DummyButton:
+        def __init__(self, master=None, text="", image=None, compound=None, command=None):
+            self.master = master
+            self.text = text
+            self.command = command
+            if master and hasattr(master, "children"):
+                master.children.append(self)
+
+        def pack(self, *args, **kwargs):
+            pass
+
+        def configure(self, **kwargs):
+            self.text = kwargs.get("text", self.text)
+
+        def destroy(self):
+            pass
+
+    monkeypatch.setattr(architecture.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(architecture.ttk, "LabelFrame", DummyFrame)
+    monkeypatch.setattr(architecture.ttk, "Button", DummyButton)
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    toolbox = DummyFrame()
+    toolbox.tk = True
+    win.toolbox = toolbox
+    win.tools_frame = DummyFrame(toolbox)
+    win.rel_frame = DummyFrame(toolbox)
+    win._icon_for = lambda name: None
+    win.toolbox_selector = types.SimpleNamespace(configure=lambda **k: None)
+    win.toolbox_var = types.SimpleNamespace(get=lambda: "Governance Core", set=lambda v: None)
+    win._toolbox_frames = {}
+
+    win._rebuild_toolboxes()
+    core_frames = win._toolbox_frames["Governance Core"]
+    actions = core_frames[1]
+    labels = [child.text for child in getattr(actions, "children", [])]
+    assert {
+        "Add Work Product",
+        "Add Generic Work Product",
+        "Add Process Area",
+        "Add Lifecycle Phase",
+    } <= set(labels)

--- a/tests/test_toolbox_dynamic_relations.py
+++ b/tests/test_toolbox_dynamic_relations.py
@@ -1,0 +1,38 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui import architecture
+from config import load_json_with_comments
+
+
+def test_toolbox_updates_with_new_relation(tmp_path, monkeypatch):
+    orig_path = architecture._CONFIG_PATH
+    cfg = load_json_with_comments(orig_path)
+    before = architecture._toolbox_defs()
+    assert "Reviews" not in before["Entities"]["relations"]
+    assert "Reviews" not in before["Artifacts"]["relations"]
+    new_cfg = json.loads(json.dumps(cfg))
+    conns = new_cfg["connection_rules"].setdefault("Governance Diagram", {})
+    conns.setdefault("Reviews", {})["Role"] = ["Document"]
+    tmp_file = tmp_path / "diagram_rules.json"
+    tmp_file.write_text(json.dumps(new_cfg))
+    try:
+        monkeypatch.setattr(architecture, "_CONFIG_PATH", tmp_file)
+        architecture.reload_config()
+        after = architecture._toolbox_defs()
+        assert "Reviews" in after["Entities"]["relations"]
+        assert "Reviews" in after["Artifacts"]["relations"]
+    finally:
+        monkeypatch.setattr(architecture, "_CONFIG_PATH", orig_path)
+        architecture.reload_config()
+
+
+def test_irrelevant_relations_filtered():
+    defs = architecture._toolbox_defs()
+    # "Propagate" appears in the configuration for Business Unit with no
+    # allowed targets.  It should therefore be excluded from the Entities
+    # toolbox relations.
+    assert "Propagate" not in defs["Entities"]["relations"]


### PR DESCRIPTION
## Summary
- derive toolbox categories from connection rules so each combo box shows elements and relationships relevant to the chosen context
- add Safety & Security Mgmt toolbox and ensure relations appear in every compatible toolbox
- filter toolbox relationship buttons to governance rules with valid targets so only relevant links display
- expose work product, generic work product, process area, and lifecycle phase actions in Governance Core toolbox

## Testing
- `pytest tests/test_diagram_rules_reload.py::test_connection_rules_reload -q`
- `pytest tests/test_diagram_rules_requirement_mappings.py -q`
- `pytest tests/test_toolbox_dynamic_relations.py -q`
- `pytest tests/test_governance_core_actions.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a35e02c5b083279e1915f61bb0720c