### PR TITLE
Hide gateway node labels in governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -678,6 +678,8 @@ def _format_label(
             elem_type = obj.obj_type
             if repo and obj.element_id in repo.elements:
                 elem_type = repo.elements[obj.element_id].elem_type
+            if elem_type in {"Decision", "Initial", "Final", "Merge"}:
+                return ""
             stereo = _GOV_TYPE_ALIASES.get(elem_type, elem_type).lower()
             label = f"<<{stereo}>>\n{label}".strip()
     return label

--- a/tests/test_governance_element_stereotype_label.py
+++ b/tests/test_governance_element_stereotype_label.py
@@ -1,4 +1,8 @@
 import unittest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from gui.architecture import SysMLDiagramWindow, SysMLObject
 from sysml.sysml_repository import SysMLRepository
@@ -39,15 +43,22 @@ class GovernanceElementStereotypeTests(unittest.TestCase):
         self.assertEqual("<<task>>", lines[0])
         self.assertEqual("Draft Plan", lines[1])
 
-    def test_decision_label_includes_stereotype(self):
+    def test_gateway_labels_hidden(self):
         repo = SysMLRepository.get_instance()
         diag = repo.create_diagram("Governance Diagram")
-        elem = repo.create_element("Decision", name="Gate")
-        obj = SysMLObject(2, "Decision", 0.0, 0.0, element_id=elem.elem_id, properties={"name": "Gate"})
         win = DummyWindow(diag.diag_id)
-        lines = win._object_label_lines(obj)
-        self.assertEqual("<<decision>>", lines[0])
-        self.assertEqual("Gate", lines[1])
+        for idx, node_type in enumerate(["Decision", "Initial", "Final", "Merge"], start=1):
+            elem = repo.create_element(node_type, name="Gate")
+            obj = SysMLObject(
+                idx,
+                node_type,
+                0.0,
+                0.0,
+                element_id=elem.elem_id,
+                properties={"name": "Gate"},
+            )
+            lines = win._object_label_lines(obj)
+            self.assertEqual([], lines)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- omit names and stereotypes for decision, initial, final and merge nodes on governance diagrams
- test that gateway nodes render without text while task nodes retain stereotype labels

## Testing
- `pytest tests/test_governance_element_stereotype_label.py -q`
- `pytest tests/test_governance_diagram_visibility.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a371371fbc8327b7552bf1d1f7f63c