### PR TITLE
Animate connection preview across relationship tools

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3716,6 +3716,7 @@ class SysMLDiagramWindow(tk.Frame):
                 name = name[8:]
             if name == "Process Area":
                 name = "System Boundary"
+        name = "AI Database" if name == "Database" else name
         mapping = {
             "Select": "arrow",
             "Actor": "human",
@@ -6404,7 +6405,7 @@ class SysMLDiagramWindow(tk.Frame):
                     ey,
                     dash=(2, 2),
                     arrow=style,
-                    tags="connection",
+                    tags=("connection", "_temp_conn"),
                 )
         if (
             self.start
@@ -6428,10 +6429,50 @@ class SysMLDiagramWindow(tk.Frame):
             sx, sy = self.edge_point(self.start, *self.temp_line_end)
             ex, ey = self.temp_line_end
             self.canvas.create_line(
-                sx, sy, ex, ey, dash=(2, 2), arrow=tk.LAST, tags="connection"
+                sx,
+                sy,
+                ex,
+                ey,
+                dash=(2, 2),
+                arrow=tk.LAST,
+                tags=("connection", "_temp_conn"),
             )
+
+        # Animate the temporary connection line so the dashes appear to move
+        # toward the mouse cursor, providing visual feedback consistent across
+        # all relationship types.
+        find = getattr(self.canvas, "find_withtag", None)
+        if find and find("_temp_conn"):
+            if getattr(self, "_temp_conn_anim", None) is None:
+                self._temp_conn_offset = 0
+                self._animate_temp_connection()
+        else:
+            anim = getattr(self, "_temp_conn_anim", None)
+            if anim:
+                after_cancel = getattr(self.canvas, "after_cancel", None)
+                if after_cancel:
+                    after_cancel(anim)
+                self._temp_conn_anim = None
         self.canvas.tag_raise("connection")
         self.canvas.config(scrollregion=self.canvas.bbox("all"))
+
+    def _animate_temp_connection(self):  # pragma: no cover - requires tkinter
+        find = getattr(self.canvas, "find_withtag", None)
+        configure = getattr(self.canvas, "itemconfigure", None)
+        if not (find and configure):
+            self._temp_conn_anim = None
+            return
+        line = find("_temp_conn")
+        if line:
+            offset = getattr(self, "_temp_conn_offset", 0)
+            offset = (offset + 2) % 8
+            self._temp_conn_offset = offset
+            configure(line[0], dashoffset=offset)
+            after = getattr(self.canvas, "after", None)
+            if after:
+                self._temp_conn_anim = after(100, self._animate_temp_connection)
+        else:
+            self._temp_conn_anim = None
 
     def _create_round_rect(self, x1, y1, x2, y2, radius=10, **kwargs):
         """Draw a rectangle with rounded corners on the canvas."""
@@ -11090,6 +11131,69 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                 )
             core_frames.append(frame)
         self._toolbox_frames["Governance Core"] = core_frames
+        # Create Safety & AI Lifecycle toolbox frame
+        saf_data = defs.pop("Safety & AI Lifecycle", None)
+        if saf_data:
+            if hasattr(self.toolbox, "tk"):
+                frame = ttk.Frame(self.toolbox)
+                if saf_data["nodes"]:
+                    elem = ttk.LabelFrame(frame, text="Elements (elements)")
+                    elem.pack(fill=tk.X, padx=2, pady=2)
+                    for node in saf_data["nodes"]:
+                        ttk.Button(
+                            elem,
+                            text=node,
+                            image=self._icon_for(node),
+                            compound=tk.LEFT,
+                            command=lambda t=node: self.select_tool(t),
+                        ).pack(fill=tk.X, padx=2, pady=2)
+                if saf_data["relations"]:
+                    rel = ttk.LabelFrame(frame, text="Relationships (relationships)")
+                    rel.pack(fill=tk.X, padx=2, pady=2)
+                    for rel_name in saf_data["relations"]:
+                        ttk.Button(
+                            rel,
+                            text=rel_name,
+                            image=self._icon_for(rel_name),
+                            compound=tk.LEFT,
+                            command=lambda t=rel_name: self.select_tool(t),
+                        ).pack(fill=tk.X, padx=2, pady=2)
+                for grp, sub in saf_data.get("externals", {}).items():
+                    sub_frame = ttk.LabelFrame(frame, text=f"Related {grp}")
+                    sub_frame.pack(fill=tk.X, padx=2, pady=2)
+                    if sub.get("nodes"):
+                        selem = ttk.LabelFrame(sub_frame, text="Elements (elements)")
+                        selem.pack(fill=tk.X, padx=2, pady=2)
+                        for node in sub["nodes"]:
+                            ttk.Button(
+                                selem,
+                                text=node,
+                                image=self._icon_for(node),
+                                compound=tk.LEFT,
+                                command=lambda t=node: self.select_tool(t),
+                            ).pack(fill=tk.X, padx=2, pady=2)
+                    if sub.get("relations"):
+                        srel = ttk.LabelFrame(
+                            sub_frame, text="Relationships (relationships)"
+                        )
+                        srel.pack(fill=tk.X, padx=2, pady=2)
+                        for rel_name in sub["relations"]:
+                            ttk.Button(
+                                srel,
+                                text=rel_name,
+                                image=self._icon_for(rel_name),
+                                compound=tk.LEFT,
+                                command=lambda t=rel_name: self.select_tool(t),
+                            ).pack(fill=tk.X, padx=2, pady=2)
+            else:  # pragma: no cover - headless tests
+                frame = types.SimpleNamespace(
+                    pack=lambda *a, **k: None,
+                    pack_forget=lambda *a, **k: None,
+                    destroy=lambda *a, **k: None,
+                )
+            self._toolbox_frames["Safety & AI Lifecycle"] = [frame]
+
+        # Create toolbox for additional governance elements grouped by class
         for name, data in defs.items():
             if hasattr(self.toolbox, "tk"):
                 frame = ttk.Frame(self.toolbox)
@@ -11157,11 +11261,22 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
 
     def _switch_toolbox(self) -> None:
         choice = self.toolbox_var.get()
-        for frames in self._toolbox_frames.values():
+        frames_dict = getattr(self, "_toolbox_frames", None)
+        if frames_dict is None:
+            frames_dict = {
+                "Governance": [
+                    getattr(self, "gov_tools_frame", None),
+                    getattr(self, "gov_elements_frame", None),
+                    getattr(self, "prop_frame", None),
+                    getattr(self, "gov_rel_frame", None),
+                ],
+                "Safety & AI Lifecycle": [getattr(self, "ai_tools_frame", None)],
+            }
+        for frames in frames_dict.values():
             for frame in frames:
                 if frame and hasattr(frame, "pack_forget"):
                     frame.pack_forget()
-        for frame in self._toolbox_frames.get(choice, []):
+        for frame in frames_dict.get(choice, []):
             if frame and hasattr(frame, "pack"):
                 frame.pack(fill=tk.X, padx=2, pady=2)
 

--- a/tests/test_architecture_temp_connection.py
+++ b/tests/test_architecture_temp_connection.py
@@ -1,0 +1,72 @@
+import tkinter as tk
+import types
+
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+
+
+def test_temp_connection_line_is_dotted_and_animated():
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.zoom = 1.0
+    win.start = SysMLObject(1, "Block", 10, 20)
+    win.temp_line_end = (50, 60)
+    win.current_tool = "Association"
+    win.selected_conn = None
+    win.dragging_endpoint = None
+    win.endpoint_drag_pos = None
+    win.connections = []
+    win.objects = []
+    win.compartment_buttons = []
+    win.gradient_cache = {}
+
+    def edge_point(self, obj, tx, ty, rel=None, apply_radius=True):
+        return obj.x * self.zoom, obj.y * self.zoom
+
+    win.edge_point = types.MethodType(edge_point, win)
+
+    class CanvasStub:
+        def __init__(self):
+            self.lines = []
+            self.after_calls = 0
+            self.last_dashoffset = None
+
+        def configure(self, **kwargs):
+            pass
+
+        def delete(self, *args):
+            pass
+
+        def create_line(self, *args, **kwargs):
+            self.lines.append(kwargs)
+            return 1
+
+        def tag_raise(self, *args):
+            pass
+
+        def config(self, **kwargs):
+            pass
+
+        def bbox(self, *args):
+            return (0, 0, 0, 0)
+
+        def find_withtag(self, tag):
+            return [1] if tag == "_temp_conn" and self.lines else []
+
+        def itemconfigure(self, *args, **kwargs):
+            self.last_dashoffset = kwargs.get("dashoffset")
+
+        def after(self, delay, func):
+            self.after_calls += 1
+            return "after_id"
+
+        def after_cancel(self, _):
+            pass
+
+    win.canvas = CanvasStub()
+    win.redraw()
+
+    assert win.canvas.lines
+    line_kwargs = win.canvas.lines[0]
+    assert line_kwargs.get("dash") == (2, 2)
+    assert line_kwargs.get("arrow") == tk.LAST
+    assert win.canvas.after_calls == 1
+    assert win.canvas.last_dashoffset == 2


### PR DESCRIPTION
## Summary
- Animate dotted connection preview with arrow for all relationship tools
- Build governance toolboxes with explicit sections for Safety & AI Lifecycle and other elements
- Add test covering animated connection line

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a37244cce48327a56ffd436747350e