### PR TITLE
Generate role-based subject variants for requirements

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -122,6 +122,10 @@ def validate_diagram_rules(data: Any) -> dict[str, Any]:
                 raise ValueError(
                     f"requirement_sequences[{label}]['subject'] must be a string"
                 )
+            if "role_subject" in info and not isinstance(info["role_subject"], bool):
+                raise ValueError(
+                    f"requirement_sequences[{label}]['role_subject'] must be a boolean"
+                )
             if "action" in info and not isinstance(info["action"], str):
                 raise ValueError(
                     f"requirement_sequences[{label}]['action'] must be a string"

--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -252,134 +252,498 @@
 
   "requirement_sequences": {
     "incident triage": {
-      "relations": ["Triage", "Develops"],
+      "relations": [
+        "Triage",
+        "Develops"
+      ],
       "subject": "Safety manager",
       "action": "trigger test development"
     },
+    "incident triage role subject": {
+      "relations": [
+        "Triage",
+        "Develops"
+      ],
+      "action": "trigger test development",
+      "role_subject": true
+    },
     "policy compliance": {
-      "relations": ["Constrains", "Produces"],
+      "relations": [
+        "Constrains",
+        "Produces"
+      ],
       "subject": "Governance team",
       "action": "enforce policy"
     },
+    "policy compliance role subject": {
+      "relations": [
+        "Constrains",
+        "Produces"
+      ],
+      "action": "enforce policy",
+      "role_subject": true
+    },
     "model validation": {
-      "relations": ["Validate", "Produces"],
+      "relations": [
+        "Validate",
+        "Produces"
+      ],
       "subject": "Validation team",
       "action": "validate models"
     },
+    "model validation role subject": {
+      "relations": [
+        "Validate",
+        "Produces"
+      ],
+      "action": "validate models",
+      "role_subject": true
+    },
     "hazard mitigation": {
-      "relations": ["Assesses", "Mitigates", "Develops", "Produces"],
+      "relations": [
+        "Assesses",
+        "Mitigates",
+        "Develops",
+        "Produces"
+      ],
       "subject": "Safety engineer",
       "action": "develop hazard mitigation tests"
     },
+    "hazard mitigation role subject": {
+      "relations": [
+        "Assesses",
+        "Mitigates",
+        "Develops",
+        "Produces"
+      ],
+      "action": "develop hazard mitigation tests",
+      "role_subject": true
+    },
     "safety goal verification": {
-      "relations": ["Mitigates", "Develops", "Verify", "Produces"],
+      "relations": [
+        "Mitigates",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
       "subject": "Safety engineer",
       "action": "verify safety goals"
     },
+    "safety goal verification role subject": {
+      "relations": [
+        "Mitigates",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
+      "action": "verify safety goals",
+      "role_subject": true
+    },
     "sotif scenario validation": {
-      "relations": ["Assesses", "Develops", "Produces"],
+      "relations": [
+        "Assesses",
+        "Develops",
+        "Produces"
+      ],
       "subject": "Validation team",
       "action": "validate scenarios"
     },
+    "sotif scenario validation role subject": {
+      "relations": [
+        "Assesses",
+        "Develops",
+        "Produces"
+      ],
+      "action": "validate scenarios",
+      "role_subject": true
+    },
     "cybersecurity threat mitigation": {
-      "relations": ["Assesses", "Mitigates", "Plans", "Produces"],
+      "relations": [
+        "Assesses",
+        "Mitigates",
+        "Plans",
+        "Produces"
+      ],
       "subject": "Cybersecurity team",
       "action": "plan cybersecurity mitigation"
     },
+    "cybersecurity threat mitigation role subject": {
+      "relations": [
+        "Assesses",
+        "Mitigates",
+        "Plans",
+        "Produces"
+      ],
+      "action": "plan cybersecurity mitigation",
+      "role_subject": true
+    },
     "incident validation": {
-      "relations": ["Triage", "Develops", "Validate", "Produces"],
+      "relations": [
+        "Triage",
+        "Develops",
+        "Validate",
+        "Produces"
+      ],
       "subject": "Safety manager",
       "action": "validate incident resolution"
     },
+    "incident validation role subject": {
+      "relations": [
+        "Triage",
+        "Develops",
+        "Validate",
+        "Produces"
+      ],
+      "action": "validate incident resolution",
+      "role_subject": true
+    },
     "product lifecycle safety": {
-      "relations": ["Plans", "Develops", "Produces"],
+      "relations": [
+        "Plans",
+        "Develops",
+        "Produces"
+      ],
       "subject": "Safety manager",
       "action": "manage lifecycle safety"
     },
+    "product lifecycle safety role subject": {
+      "relations": [
+        "Plans",
+        "Develops",
+        "Produces"
+      ],
+      "action": "manage lifecycle safety",
+      "role_subject": true
+    },
     "post deployment monitoring": {
-      "relations": ["Plans", "Develops", "Produces"],
+      "relations": [
+        "Plans",
+        "Develops",
+        "Produces"
+      ],
       "subject": "Operations team",
       "action": "monitor deployed system"
     },
+    "post deployment monitoring role subject": {
+      "relations": [
+        "Plans",
+        "Develops",
+        "Produces"
+      ],
+      "action": "monitor deployed system",
+      "role_subject": true
+    },
     "decommissioning validation": {
-      "relations": ["Plans", "Develops", "Validate", "Produces"],
+      "relations": [
+        "Plans",
+        "Develops",
+        "Validate",
+        "Produces"
+      ],
       "subject": "Safety manager",
       "action": "validate decommissioning"
     },
+    "decommissioning validation role subject": {
+      "relations": [
+        "Plans",
+        "Develops",
+        "Validate",
+        "Produces"
+      ],
+      "action": "validate decommissioning",
+      "role_subject": true
+    },
     "safety audit": {
-      "relations": ["Plans", "Audits", "Produces"],
+      "relations": [
+        "Plans",
+        "Audits",
+        "Produces"
+      ],
       "subject": "Auditor",
       "action": "audit safety processes"
     },
+    "safety audit role subject": {
+      "relations": [
+        "Plans",
+        "Audits",
+        "Produces"
+      ],
+      "action": "audit safety processes",
+      "role_subject": true
+    },
     "security audit": {
-      "relations": ["Plans", "Audits", "Produces"],
+      "relations": [
+        "Plans",
+        "Audits",
+        "Produces"
+      ],
       "subject": "Security auditor",
       "action": "audit security processes"
     },
+    "security audit role subject": {
+      "relations": [
+        "Plans",
+        "Audits",
+        "Produces"
+      ],
+      "action": "audit security processes",
+      "role_subject": true
+    },
     "safety & security case review": {
-      "relations": ["Plans", "Audits", "Reviews"],
+      "relations": [
+        "Plans",
+        "Audits",
+        "Reviews"
+      ],
       "subject": "Safety manager",
       "action": "review safety & security case"
     },
+    "safety & security case review role subject": {
+      "relations": [
+        "Plans",
+        "Audits",
+        "Reviews"
+      ],
+      "action": "review safety & security case",
+      "role_subject": true
+    },
     "threat analysis validation": {
-      "relations": ["Assesses", "Mitigates", "Validate", "Produces"],
+      "relations": [
+        "Assesses",
+        "Mitigates",
+        "Validate",
+        "Produces"
+      ],
       "subject": "Cybersecurity team",
       "action": "validate threat mitigations"
     },
+    "threat analysis validation role subject": {
+      "relations": [
+        "Assesses",
+        "Mitigates",
+        "Validate",
+        "Produces"
+      ],
+      "action": "validate threat mitigations",
+      "role_subject": true
+    },
     "functional safety release": {
-      "relations": ["Plans", "Develops", "Verify", "Produces"],
+      "relations": [
+        "Plans",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
       "subject": "Release manager",
       "action": "verify safety release"
     },
+    "functional safety release role subject": {
+      "relations": [
+        "Plans",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
+      "action": "verify safety release",
+      "role_subject": true
+    },
     "cybersecurity release": {
-      "relations": ["Plans", "Develops", "Verify", "Produces"],
+      "relations": [
+        "Plans",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
       "subject": "Security manager",
       "action": "verify cybersecurity release"
     },
+    "cybersecurity release role subject": {
+      "relations": [
+        "Plans",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
+      "action": "verify cybersecurity release",
+      "role_subject": true
+    },
     "hazard verification": {
-      "relations": ["Assesses", "Mitigates", "Develops", "Verify", "Produces"],
+      "relations": [
+        "Assesses",
+        "Mitigates",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
       "subject": "Safety engineer",
       "action": "verify hazard mitigations"
     },
+    "hazard verification role subject": {
+      "relations": [
+        "Assesses",
+        "Mitigates",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
+      "action": "verify hazard mitigations",
+      "role_subject": true
+    },
     "cybersecurity threat verification": {
-      "relations": ["Assesses", "Mitigates", "Develops", "Verify", "Produces"],
+      "relations": [
+        "Assesses",
+        "Mitigates",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
       "subject": "Cybersecurity team",
       "action": "verify threat mitigations"
     },
+    "cybersecurity threat verification role subject": {
+      "relations": [
+        "Assesses",
+        "Mitigates",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
+      "action": "verify threat mitigations",
+      "role_subject": true
+    },
     "sotif scenario verification": {
-      "relations": ["Assesses", "Develops", "Verify", "Produces"],
+      "relations": [
+        "Assesses",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
       "subject": "Validation team",
       "action": "verify scenarios"
     },
+    "sotif scenario verification role subject": {
+      "relations": [
+        "Assesses",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
+      "action": "verify scenarios",
+      "role_subject": true
+    },
     "deployment readiness": {
-      "relations": ["Plans", "Develops", "Verify", "Produces"],
+      "relations": [
+        "Plans",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
       "subject": "Deployment manager",
       "action": "verify deployment readiness"
     },
+    "deployment readiness role subject": {
+      "relations": [
+        "Plans",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
+      "action": "verify deployment readiness",
+      "role_subject": true
+    },
     "maintenance validation": {
-      "relations": ["Plans", "Develops", "Validate", "Produces"],
+      "relations": [
+        "Plans",
+        "Develops",
+        "Validate",
+        "Produces"
+      ],
       "subject": "Operations team",
       "action": "validate maintenance"
     },
+    "maintenance validation role subject": {
+      "relations": [
+        "Plans",
+        "Develops",
+        "Validate",
+        "Produces"
+      ],
+      "action": "validate maintenance",
+      "role_subject": true
+    },
     "risk-based testing": {
-      "relations": ["Assesses", "Develops", "Verify", "Produces"],
+      "relations": [
+        "Assesses",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
       "subject": "Test team",
       "action": "perform risk-based testing"
     },
+    "risk-based testing role subject": {
+      "relations": [
+        "Assesses",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
+      "action": "perform risk-based testing",
+      "role_subject": true
+    },
     "organizational accountability": {
-      "relations": ["Responsible for", "Produces"],
+      "relations": [
+        "Responsible for",
+        "Produces"
+      ],
       "subject": "Governance board",
       "action": "document responsibilities"
     },
+    "organizational accountability role subject": {
+      "relations": [
+        "Responsible for",
+        "Produces"
+      ],
+      "role_subject": true,
+      "action": "document responsibilities"
+    },
     "governance oversight": {
-      "relations": ["Plans", "Audits", "Produces"],
+      "relations": [
+        "Plans",
+        "Audits",
+        "Produces"
+      ],
       "subject": "Governance board",
       "action": "evaluate governance performance"
     },
+    "governance oversight role subject": {
+      "relations": [
+        "Plans",
+        "Audits",
+        "Produces"
+      ],
+      "action": "evaluate governance performance",
+      "role_subject": true
+    },
     "lifecycle governance review": {
-      "relations": ["Plans", "Develops", "Validate", "Produces"],
+      "relations": [
+        "Plans",
+        "Develops",
+        "Validate",
+        "Produces"
+      ],
       "subject": "Lifecycle manager",
       "action": "review lifecycle governance"
+    },
+    "lifecycle governance review role subject": {
+      "relations": [
+        "Plans",
+        "Develops",
+        "Validate",
+        "Produces"
+      ],
+      "action": "review lifecycle governance",
+      "role_subject": true
     }
   },
 

--- a/tests/test_requirement_rule_generator.py
+++ b/tests/test_requirement_rule_generator.py
@@ -24,6 +24,10 @@ def test_generate_patterns_from_config(tmp_path: Path) -> None:
         "SA-annotation-ANN-AI_Database-COND",
         "SA-annotation-ANN-AI_Database-CONST",
         "SA-annotation-ANN-AI_Database-COND-CONST",
+        "SA-annotation-ANN-AI_Database-ROLE",
+        "SA-annotation-ANN-AI_Database-ROLE-COND",
+        "SA-annotation-ANN-AI_Database-ROLE-CONST",
+        "SA-annotation-ANN-AI_Database-ROLE-COND-CONST",
     }
     assert ids == expected
 
@@ -100,6 +104,26 @@ def test_rule_with_custom_template_and_variables() -> None:
     assert "<tool>" in base["Variables"]
 
 
+def test_rule_role_subject_variant() -> None:
+    cfg = {
+        "requirement_rules": {
+            "annotation": {"action": "annotate", "subject": "Team"}
+        },
+        "safety_ai_relation_rules": {"Annotation": {"ANN": ["AI Database"]}},
+    }
+    patterns = generate_patterns_from_config(cfg)
+    ids = {p["Pattern ID"] for p in patterns}
+    assert "SA-annotation-ANN-AI_Database" in ids
+    assert "SA-annotation-ANN-AI_Database-ROLE" in ids
+    tmpl = next(
+        p["Template"]
+        for p in patterns
+        if p["Pattern ID"] == "SA-annotation-ANN-AI_Database-ROLE"
+    )
+    assert tmpl.startswith("<object0_id> (<object0_class>) shall annotate")
+    assert "using the <object0_id>" not in tmpl
+
+
 def test_sequence_rule_generation() -> None:
     cfg = {
         "safety_ai_relation_rules": {
@@ -120,6 +144,26 @@ def test_sequence_rule_generation() -> None:
     tmpl = next(p["Template"] for p in patterns if p["Pattern ID"] == "SEQ-chain-A-C")
     assert "<object2_id>" in tmpl
     assert "rel1" in tmpl and "rel2" in tmpl
+
+
+def test_sequence_role_subject() -> None:
+    cfg = {
+        "safety_ai_relation_rules": {
+            "Responsible for": {"Role": ["Process"]},
+            "Produces": {"Process": ["Document"]},
+        },
+        "requirement_sequences": {
+            "accountability": {
+                "relations": ["Responsible for", "Produces"],
+                "role_subject": True,
+            }
+        },
+    }
+    patterns = generate_patterns_from_config(cfg)
+    pid = "SEQ-accountability-Role-Document"
+    tmpl = next(p["Template"] for p in patterns if p["Pattern ID"] == pid)
+    assert tmpl.startswith("<object0_id> (<object0_class>) shall responsible for")
+    assert "using the <object0_id>" not in tmpl
 
 
 def test_complex_sequences() -> None:


### PR DESCRIPTION
## Summary
- duplicate each configured sequence with a `role_subject` variant deriving the actor from the model
- emit extra requirement patterns where the source role supplies the subject for basic relations
- test role-subject variants for relation and sequence generation

## Testing
- `pytest`
- `pytest tests/test_requirement_rule_generator.py::test_sequence_role_subject tests/test_requirement_rule_generator.py::test_rule_role_subject_variant -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3793ded8c8327a3507360e791580b