### PR TITLE
Use subject placeholder in requirement patterns

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -85,10 +85,10 @@ def _apply_pattern(
 
     def repl(match: re.Match[str]) -> str:
         key = match.group(1)
-        if key in {"source_id", "object0_id"} or key == src_type:
+        if key in {"source_id", "object0_id", "subject_id"} or key == src_type:
             variables[:] = [v for v in variables if v != key]
             return src
-        if key in {"source_class", "object0_class"}:
+        if key in {"source_class", "object0_class", "subject_class"}:
             variables[:] = [v for v in variables if v != key]
             return src_type
         if key in {"target_id", "object1_id"} or key == dst_type:

--- a/config/requirement_patterns.json
+++ b/config/requirement_patterns.json
@@ -2,7 +2,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Document",
     "Trigger": "Gov: Role --[Approves]--> Document",
-    "Template": "<object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)'.",
+    "Template": "<subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -13,7 +13,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Document-COND",
     "Trigger": "Gov: Role --[Approves]--> Document",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)'.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -25,7 +25,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Document-COND-CONST",
     "Trigger": "Gov: Role --[Approves]--> Document",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -38,7 +38,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Document-CONST",
     "Trigger": "Gov: Role --[Approves]--> Document",
-    "Template": "<object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -50,7 +50,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Policy",
     "Trigger": "Gov: Role --[Approves]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)'.",
+    "Template": "<subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -61,7 +61,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Policy-COND",
     "Trigger": "Gov: Role --[Approves]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)'.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -73,7 +73,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Policy-COND-CONST",
     "Trigger": "Gov: Role --[Approves]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -86,7 +86,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Policy-CONST",
     "Trigger": "Gov: Role --[Approves]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -98,7 +98,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Procedure",
     "Trigger": "Gov: Role --[Approves]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)'.",
+    "Template": "<subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -109,7 +109,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Procedure-COND",
     "Trigger": "Gov: Role --[Approves]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)'.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -121,7 +121,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Procedure-COND-CONST",
     "Trigger": "Gov: Role --[Approves]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -134,7 +134,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Procedure-CONST",
     "Trigger": "Gov: Role --[Approves]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -146,7 +146,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Record",
     "Trigger": "Gov: Role --[Approves]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)'.",
+    "Template": "<subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -157,7 +157,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Record-COND",
     "Trigger": "Gov: Role --[Approves]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)'.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -169,7 +169,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Record-COND-CONST",
     "Trigger": "Gov: Role --[Approves]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -182,7 +182,7 @@
   {
     "Pattern ID": "GOV-approves-Role-Record-CONST",
     "Trigger": "Gov: Role --[Approves]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall approve '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -194,7 +194,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Procedure",
     "Trigger": "Gov: Role --[Audits]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -205,7 +205,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Procedure-COND",
     "Trigger": "Gov: Role --[Audits]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -217,7 +217,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Procedure-COND-CONST",
     "Trigger": "Gov: Role --[Audits]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -230,7 +230,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Procedure-CONST",
     "Trigger": "Gov: Role --[Audits]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -242,7 +242,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Process",
     "Trigger": "Gov: Role --[Audits]--> Process",
-    "Template": "<object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -253,7 +253,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Process-COND",
     "Trigger": "Gov: Role --[Audits]--> Process",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -265,7 +265,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Process-COND-CONST",
     "Trigger": "Gov: Role --[Audits]--> Process",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -278,7 +278,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Process-CONST",
     "Trigger": "Gov: Role --[Audits]--> Process",
-    "Template": "<object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -290,7 +290,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Record",
     "Trigger": "Gov: Role --[Audits]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -301,7 +301,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Record-COND",
     "Trigger": "Gov: Role --[Audits]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -313,7 +313,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Record-COND-CONST",
     "Trigger": "Gov: Role --[Audits]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -326,7 +326,7 @@
   {
     "Pattern ID": "GOV-audits-Role-Record-CONST",
     "Trigger": "Gov: Role --[Audits]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall audits the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -338,7 +338,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Policy",
     "Trigger": "Gov: Organization --[Authorizes]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -349,7 +349,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Policy-COND",
     "Trigger": "Gov: Organization --[Authorizes]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -361,7 +361,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Policy-COND-CONST",
     "Trigger": "Gov: Organization --[Authorizes]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -374,7 +374,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Policy-CONST",
     "Trigger": "Gov: Organization --[Authorizes]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -386,7 +386,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Procedure",
     "Trigger": "Gov: Organization --[Authorizes]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -397,7 +397,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Procedure-COND",
     "Trigger": "Gov: Organization --[Authorizes]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -409,7 +409,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Procedure-COND-CONST",
     "Trigger": "Gov: Organization --[Authorizes]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -422,7 +422,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Procedure-CONST",
     "Trigger": "Gov: Organization --[Authorizes]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -434,7 +434,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Process",
     "Trigger": "Gov: Organization --[Authorizes]--> Process",
-    "Template": "<object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -445,7 +445,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Process-COND",
     "Trigger": "Gov: Organization --[Authorizes]--> Process",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -457,7 +457,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Process-COND-CONST",
     "Trigger": "Gov: Organization --[Authorizes]--> Process",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -470,7 +470,7 @@
   {
     "Pattern ID": "GOV-authorizes-Organization-Process-CONST",
     "Trigger": "Gov: Organization --[Authorizes]--> Process",
-    "Template": "<object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -482,7 +482,7 @@
   {
     "Pattern ID": "GOV-authorizes-Role-Policy",
     "Trigger": "Gov: Role --[Authorizes]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -493,7 +493,7 @@
   {
     "Pattern ID": "GOV-authorizes-Role-Policy-COND",
     "Trigger": "Gov: Role --[Authorizes]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -505,7 +505,7 @@
   {
     "Pattern ID": "GOV-authorizes-Role-Policy-COND-CONST",
     "Trigger": "Gov: Role --[Authorizes]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -518,7 +518,7 @@
   {
     "Pattern ID": "GOV-authorizes-Role-Policy-CONST",
     "Trigger": "Gov: Role --[Authorizes]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -530,7 +530,7 @@
   {
     "Pattern ID": "GOV-authorizes-Role-Procedure",
     "Trigger": "Gov: Role --[Authorizes]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -541,7 +541,7 @@
   {
     "Pattern ID": "GOV-authorizes-Role-Procedure-COND",
     "Trigger": "Gov: Role --[Authorizes]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -553,7 +553,7 @@
   {
     "Pattern ID": "GOV-authorizes-Role-Procedure-COND-CONST",
     "Trigger": "Gov: Role --[Authorizes]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -566,7 +566,7 @@
   {
     "Pattern ID": "GOV-authorizes-Role-Procedure-CONST",
     "Trigger": "Gov: Role --[Authorizes]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall authorizes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -578,7 +578,7 @@
   {
     "Pattern ID": "GOV-communication_path-Business_Unit-Business_Unit",
     "Trigger": "Gov: Business Unit --[Communication Path]--> Business Unit",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -589,7 +589,7 @@
   {
     "Pattern ID": "GOV-communication_path-Business_Unit-Business_Unit-COND",
     "Trigger": "Gov: Business Unit --[Communication Path]--> Business Unit",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -601,7 +601,7 @@
   {
     "Pattern ID": "GOV-communication_path-Business_Unit-Business_Unit-COND-CONST",
     "Trigger": "Gov: Business Unit --[Communication Path]--> Business Unit",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -614,7 +614,7 @@
   {
     "Pattern ID": "GOV-communication_path-Business_Unit-Business_Unit-CONST",
     "Trigger": "Gov: Business Unit --[Communication Path]--> Business Unit",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -626,7 +626,7 @@
   {
     "Pattern ID": "GOV-communication_path-Organization-Business_Unit",
     "Trigger": "Gov: Organization --[Communication Path]--> Business Unit",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -637,7 +637,7 @@
   {
     "Pattern ID": "GOV-communication_path-Organization-Business_Unit-COND",
     "Trigger": "Gov: Organization --[Communication Path]--> Business Unit",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -649,7 +649,7 @@
   {
     "Pattern ID": "GOV-communication_path-Organization-Business_Unit-COND-CONST",
     "Trigger": "Gov: Organization --[Communication Path]--> Business Unit",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -662,7 +662,7 @@
   {
     "Pattern ID": "GOV-communication_path-Organization-Business_Unit-CONST",
     "Trigger": "Gov: Organization --[Communication Path]--> Business Unit",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -674,7 +674,7 @@
   {
     "Pattern ID": "GOV-communication_path-Organization-Organization",
     "Trigger": "Gov: Organization --[Communication Path]--> Organization",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -685,7 +685,7 @@
   {
     "Pattern ID": "GOV-communication_path-Organization-Organization-COND",
     "Trigger": "Gov: Organization --[Communication Path]--> Organization",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -697,7 +697,7 @@
   {
     "Pattern ID": "GOV-communication_path-Organization-Organization-COND-CONST",
     "Trigger": "Gov: Organization --[Communication Path]--> Organization",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -710,7 +710,7 @@
   {
     "Pattern ID": "GOV-communication_path-Organization-Organization-CONST",
     "Trigger": "Gov: Organization --[Communication Path]--> Organization",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -722,7 +722,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Business_Unit",
     "Trigger": "Gov: Role --[Communication Path]--> Business Unit",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -733,7 +733,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Business_Unit-COND",
     "Trigger": "Gov: Role --[Communication Path]--> Business Unit",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -745,7 +745,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Business_Unit-COND-CONST",
     "Trigger": "Gov: Role --[Communication Path]--> Business Unit",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -758,7 +758,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Business_Unit-CONST",
     "Trigger": "Gov: Role --[Communication Path]--> Business Unit",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -770,7 +770,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Organization",
     "Trigger": "Gov: Role --[Communication Path]--> Organization",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -781,7 +781,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Organization-COND",
     "Trigger": "Gov: Role --[Communication Path]--> Organization",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -793,7 +793,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Organization-COND-CONST",
     "Trigger": "Gov: Role --[Communication Path]--> Organization",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -806,7 +806,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Organization-CONST",
     "Trigger": "Gov: Role --[Communication Path]--> Organization",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -818,7 +818,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Role",
     "Trigger": "Gov: Role --[Communication Path]--> Role",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -829,7 +829,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Role-COND",
     "Trigger": "Gov: Role --[Communication Path]--> Role",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -841,7 +841,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Role-COND-CONST",
     "Trigger": "Gov: Role --[Communication Path]--> Role",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -854,7 +854,7 @@
   {
     "Pattern ID": "GOV-communication_path-Role-Role-CONST",
     "Trigger": "Gov: Role --[Communication Path]--> Role",
-    "Template": "<object0_id> (<object0_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall communicate with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -866,7 +866,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Guideline",
     "Trigger": "Gov: Procedure --[Constrained by]--> Guideline",
-    "Template": "<object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -877,7 +877,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Guideline-COND",
     "Trigger": "Gov: Procedure --[Constrained by]--> Guideline",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -889,7 +889,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Guideline-COND-CONST",
     "Trigger": "Gov: Procedure --[Constrained by]--> Guideline",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -902,7 +902,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Guideline-CONST",
     "Trigger": "Gov: Procedure --[Constrained by]--> Guideline",
-    "Template": "<object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -914,7 +914,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Policy",
     "Trigger": "Gov: Procedure --[Constrained by]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -925,7 +925,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Policy-COND",
     "Trigger": "Gov: Procedure --[Constrained by]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -937,7 +937,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Policy-COND-CONST",
     "Trigger": "Gov: Procedure --[Constrained by]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -950,7 +950,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Policy-CONST",
     "Trigger": "Gov: Procedure --[Constrained by]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -962,7 +962,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Principle",
     "Trigger": "Gov: Procedure --[Constrained by]--> Principle",
-    "Template": "<object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -973,7 +973,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Principle-COND",
     "Trigger": "Gov: Procedure --[Constrained by]--> Principle",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -985,7 +985,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Principle-COND-CONST",
     "Trigger": "Gov: Procedure --[Constrained by]--> Principle",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -998,7 +998,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Principle-CONST",
     "Trigger": "Gov: Procedure --[Constrained by]--> Principle",
-    "Template": "<object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1010,7 +1010,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Standard",
     "Trigger": "Gov: Procedure --[Constrained by]--> Standard",
-    "Template": "<object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1021,7 +1021,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Standard-COND",
     "Trigger": "Gov: Procedure --[Constrained by]--> Standard",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1033,7 +1033,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Standard-COND-CONST",
     "Trigger": "Gov: Procedure --[Constrained by]--> Standard",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1046,7 +1046,7 @@
   {
     "Pattern ID": "GOV-constrained_by-Procedure-Standard-CONST",
     "Trigger": "Gov: Procedure --[Constrained by]--> Standard",
-    "Template": "<object0_id> (<object0_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1058,7 +1058,7 @@
   {
     "Pattern ID": "GOV-consumes-Process-Data",
     "Trigger": "Gov: Process --[Consumes]--> Data",
-    "Template": "<object0_id> (<object0_class>) shall consumes the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall consumes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1069,7 +1069,7 @@
   {
     "Pattern ID": "GOV-consumes-Process-Data-COND",
     "Trigger": "Gov: Process --[Consumes]--> Data",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall consumes the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall consumes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1081,7 +1081,7 @@
   {
     "Pattern ID": "GOV-consumes-Process-Data-COND-CONST",
     "Trigger": "Gov: Process --[Consumes]--> Data",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall consumes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall consumes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1094,7 +1094,7 @@
   {
     "Pattern ID": "GOV-consumes-Process-Data-CONST",
     "Trigger": "Gov: Process --[Consumes]--> Data",
-    "Template": "<object0_id> (<object0_class>) shall consumes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall consumes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1106,7 +1106,7 @@
   {
     "Pattern ID": "GOV-consumes-Process-Record",
     "Trigger": "Gov: Process --[Consumes]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall consumes the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall consumes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1117,7 +1117,7 @@
   {
     "Pattern ID": "GOV-consumes-Process-Record-COND",
     "Trigger": "Gov: Process --[Consumes]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall consumes the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall consumes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1129,7 +1129,7 @@
   {
     "Pattern ID": "GOV-consumes-Process-Record-COND-CONST",
     "Trigger": "Gov: Process --[Consumes]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall consumes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall consumes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1142,7 +1142,7 @@
   {
     "Pattern ID": "GOV-consumes-Process-Record-CONST",
     "Trigger": "Gov: Process --[Consumes]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall consumes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall consumes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1154,7 +1154,7 @@
   {
     "Pattern ID": "GOV-curation-Process-Data",
     "Trigger": "Gov: Process --[Curation]--> Data",
-    "Template": "<object0_id> (<object0_class>) shall curation the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall curation the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1165,7 +1165,7 @@
   {
     "Pattern ID": "GOV-curation-Process-Data-COND",
     "Trigger": "Gov: Process --[Curation]--> Data",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall curation the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall curation the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1177,7 +1177,7 @@
   {
     "Pattern ID": "GOV-curation-Process-Data-COND-CONST",
     "Trigger": "Gov: Process --[Curation]--> Data",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall curation the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall curation the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1190,7 +1190,7 @@
   {
     "Pattern ID": "GOV-curation-Process-Data-CONST",
     "Trigger": "Gov: Process --[Curation]--> Data",
-    "Template": "<object0_id> (<object0_class>) shall curation the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall curation the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1202,7 +1202,7 @@
   {
     "Pattern ID": "GOV-delivers-Process-Document",
     "Trigger": "Gov: Process --[Delivers]--> Document",
-    "Template": "<object0_id> (<object0_class>) shall delivers the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall delivers the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1213,7 +1213,7 @@
   {
     "Pattern ID": "GOV-delivers-Process-Document-COND",
     "Trigger": "Gov: Process --[Delivers]--> Document",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall delivers the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall delivers the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1225,7 +1225,7 @@
   {
     "Pattern ID": "GOV-delivers-Process-Document-COND-CONST",
     "Trigger": "Gov: Process --[Delivers]--> Document",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall delivers the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall delivers the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1238,7 +1238,7 @@
   {
     "Pattern ID": "GOV-delivers-Process-Document-CONST",
     "Trigger": "Gov: Process --[Delivers]--> Document",
-    "Template": "<object0_id> (<object0_class>) shall delivers the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall delivers the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1250,7 +1250,7 @@
   {
     "Pattern ID": "GOV-delivers-Process-Record",
     "Trigger": "Gov: Process --[Delivers]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall delivers the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall delivers the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1261,7 +1261,7 @@
   {
     "Pattern ID": "GOV-delivers-Process-Record-COND",
     "Trigger": "Gov: Process --[Delivers]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall delivers the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall delivers the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1273,7 +1273,7 @@
   {
     "Pattern ID": "GOV-delivers-Process-Record-COND-CONST",
     "Trigger": "Gov: Process --[Delivers]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall delivers the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall delivers the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1286,7 +1286,7 @@
   {
     "Pattern ID": "GOV-delivers-Process-Record-CONST",
     "Trigger": "Gov: Process --[Delivers]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall delivers the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall delivers the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1298,7 +1298,7 @@
   {
     "Pattern ID": "GOV-derived_from-Work_Product-Work_Product",
     "Trigger": "Gov: Work Product --[Derived from]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall be derived from the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall be derived from the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1309,7 +1309,7 @@
   {
     "Pattern ID": "GOV-derived_from-Work_Product-Work_Product-COND",
     "Trigger": "Gov: Work Product --[Derived from]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall be derived from the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be derived from the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1321,7 +1321,7 @@
   {
     "Pattern ID": "GOV-derived_from-Work_Product-Work_Product-COND-CONST",
     "Trigger": "Gov: Work Product --[Derived from]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall be derived from the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be derived from the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1334,7 +1334,7 @@
   {
     "Pattern ID": "GOV-derived_from-Work_Product-Work_Product-CONST",
     "Trigger": "Gov: Work Product --[Derived from]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall be derived from the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall be derived from the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1346,7 +1346,7 @@
   {
     "Pattern ID": "GOV-executes-Role-Procedure",
     "Trigger": "Gov: Role --[Executes]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall executes the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall executes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1357,7 +1357,7 @@
   {
     "Pattern ID": "GOV-executes-Role-Procedure-COND",
     "Trigger": "Gov: Role --[Executes]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall executes the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall executes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1369,7 +1369,7 @@
   {
     "Pattern ID": "GOV-executes-Role-Procedure-COND-CONST",
     "Trigger": "Gov: Role --[Executes]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall executes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall executes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1382,7 +1382,7 @@
   {
     "Pattern ID": "GOV-executes-Role-Procedure-CONST",
     "Trigger": "Gov: Role --[Executes]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall executes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall executes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1394,7 +1394,7 @@
   {
     "Pattern ID": "GOV-executes-Role-Process",
     "Trigger": "Gov: Role --[Executes]--> Process",
-    "Template": "<object0_id> (<object0_class>) shall executes the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall executes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1405,7 +1405,7 @@
   {
     "Pattern ID": "GOV-executes-Role-Process-COND",
     "Trigger": "Gov: Role --[Executes]--> Process",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall executes the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall executes the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1417,7 +1417,7 @@
   {
     "Pattern ID": "GOV-executes-Role-Process-COND-CONST",
     "Trigger": "Gov: Role --[Executes]--> Process",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall executes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall executes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1430,7 +1430,7 @@
   {
     "Pattern ID": "GOV-executes-Role-Process-CONST",
     "Trigger": "Gov: Role --[Executes]--> Process",
-    "Template": "<object0_id> (<object0_class>) shall executes the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall executes the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1442,7 +1442,7 @@
   {
     "Pattern ID": "GOV-extend-Policy-Policy",
     "Trigger": "Gov: Policy --[Extend]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall extend the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall extend the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1453,7 +1453,7 @@
   {
     "Pattern ID": "GOV-extend-Policy-Policy-COND",
     "Trigger": "Gov: Policy --[Extend]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall extend the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall extend the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1465,7 +1465,7 @@
   {
     "Pattern ID": "GOV-extend-Policy-Policy-COND-CONST",
     "Trigger": "Gov: Policy --[Extend]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall extend the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall extend the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1478,7 +1478,7 @@
   {
     "Pattern ID": "GOV-extend-Policy-Policy-CONST",
     "Trigger": "Gov: Policy --[Extend]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall extend the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall extend the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1490,7 +1490,7 @@
   {
     "Pattern ID": "GOV-extend-Standard-Standard",
     "Trigger": "Gov: Standard --[Extend]--> Standard",
-    "Template": "<object0_id> (<object0_class>) shall extend the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall extend the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1501,7 +1501,7 @@
   {
     "Pattern ID": "GOV-extend-Standard-Standard-COND",
     "Trigger": "Gov: Standard --[Extend]--> Standard",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall extend the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall extend the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1513,7 +1513,7 @@
   {
     "Pattern ID": "GOV-extend-Standard-Standard-COND-CONST",
     "Trigger": "Gov: Standard --[Extend]--> Standard",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall extend the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall extend the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1526,7 +1526,7 @@
   {
     "Pattern ID": "GOV-extend-Standard-Standard-CONST",
     "Trigger": "Gov: Standard --[Extend]--> Standard",
-    "Template": "<object0_id> (<object0_class>) shall extend the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall extend the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1538,7 +1538,7 @@
   {
     "Pattern ID": "GOV-flow-Action-AI_Database",
     "Trigger": "Gov: Action --[Flow]--> AI Database",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1549,7 +1549,7 @@
   {
     "Pattern ID": "GOV-flow-Action-AI_Database-COND",
     "Trigger": "Gov: Action --[Flow]--> AI Database",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1561,7 +1561,7 @@
   {
     "Pattern ID": "GOV-flow-Action-AI_Database-COND-CONST",
     "Trigger": "Gov: Action --[Flow]--> AI Database",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1574,7 +1574,7 @@
   {
     "Pattern ID": "GOV-flow-Action-AI_Database-CONST",
     "Trigger": "Gov: Action --[Flow]--> AI Database",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1586,7 +1586,7 @@
   {
     "Pattern ID": "GOV-flow-Action-ANN",
     "Trigger": "Gov: Action --[Flow]--> ANN",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1597,7 +1597,7 @@
   {
     "Pattern ID": "GOV-flow-Action-ANN-COND",
     "Trigger": "Gov: Action --[Flow]--> ANN",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1609,7 +1609,7 @@
   {
     "Pattern ID": "GOV-flow-Action-ANN-COND-CONST",
     "Trigger": "Gov: Action --[Flow]--> ANN",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1622,7 +1622,7 @@
   {
     "Pattern ID": "GOV-flow-Action-ANN-CONST",
     "Trigger": "Gov: Action --[Flow]--> ANN",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1634,7 +1634,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Action",
     "Trigger": "Gov: Action --[Flow]--> Action",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1645,7 +1645,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Action-COND",
     "Trigger": "Gov: Action --[Flow]--> Action",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1657,7 +1657,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Action-COND-CONST",
     "Trigger": "Gov: Action --[Flow]--> Action",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1670,7 +1670,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Action-CONST",
     "Trigger": "Gov: Action --[Flow]--> Action",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1682,7 +1682,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Data_acquisition",
     "Trigger": "Gov: Action --[Flow]--> Data acquisition",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1693,7 +1693,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Data_acquisition-COND",
     "Trigger": "Gov: Action --[Flow]--> Data acquisition",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1705,7 +1705,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Data_acquisition-COND-CONST",
     "Trigger": "Gov: Action --[Flow]--> Data acquisition",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1718,7 +1718,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Data_acquisition-CONST",
     "Trigger": "Gov: Action --[Flow]--> Data acquisition",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1730,7 +1730,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Decision",
     "Trigger": "Gov: Action --[Flow]--> Decision",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1741,7 +1741,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Decision-COND",
     "Trigger": "Gov: Action --[Flow]--> Decision",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1753,7 +1753,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Decision-COND-CONST",
     "Trigger": "Gov: Action --[Flow]--> Decision",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1766,7 +1766,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Decision-CONST",
     "Trigger": "Gov: Action --[Flow]--> Decision",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1778,7 +1778,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Final",
     "Trigger": "Gov: Action --[Flow]--> Final",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1789,7 +1789,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Final-COND",
     "Trigger": "Gov: Action --[Flow]--> Final",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1801,7 +1801,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Final-COND-CONST",
     "Trigger": "Gov: Action --[Flow]--> Final",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1814,7 +1814,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Final-CONST",
     "Trigger": "Gov: Action --[Flow]--> Final",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1826,7 +1826,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Merge",
     "Trigger": "Gov: Action --[Flow]--> Merge",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1837,7 +1837,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Merge-COND",
     "Trigger": "Gov: Action --[Flow]--> Merge",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1849,7 +1849,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Merge-COND-CONST",
     "Trigger": "Gov: Action --[Flow]--> Merge",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1862,7 +1862,7 @@
   {
     "Pattern ID": "GOV-flow-Action-Merge-CONST",
     "Trigger": "Gov: Action --[Flow]--> Merge",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1874,7 +1874,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-AI_Database",
     "Trigger": "Gov: Decision --[Flow]--> AI Database",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1885,7 +1885,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-AI_Database-COND",
     "Trigger": "Gov: Decision --[Flow]--> AI Database",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1897,7 +1897,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-AI_Database-COND-CONST",
     "Trigger": "Gov: Decision --[Flow]--> AI Database",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1910,7 +1910,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-AI_Database-CONST",
     "Trigger": "Gov: Decision --[Flow]--> AI Database",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1922,7 +1922,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-ANN",
     "Trigger": "Gov: Decision --[Flow]--> ANN",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1933,7 +1933,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-ANN-COND",
     "Trigger": "Gov: Decision --[Flow]--> ANN",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1945,7 +1945,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-ANN-COND-CONST",
     "Trigger": "Gov: Decision --[Flow]--> ANN",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1958,7 +1958,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-ANN-CONST",
     "Trigger": "Gov: Decision --[Flow]--> ANN",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1970,7 +1970,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Action",
     "Trigger": "Gov: Decision --[Flow]--> Action",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1981,7 +1981,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Action-COND",
     "Trigger": "Gov: Decision --[Flow]--> Action",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -1993,7 +1993,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Action-COND-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Action",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2006,7 +2006,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Action-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Action",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2018,7 +2018,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Data_acquisition",
     "Trigger": "Gov: Decision --[Flow]--> Data acquisition",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2029,7 +2029,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Data_acquisition-COND",
     "Trigger": "Gov: Decision --[Flow]--> Data acquisition",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2041,7 +2041,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Data_acquisition-COND-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Data acquisition",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2054,7 +2054,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Data_acquisition-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Data acquisition",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2066,7 +2066,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Decision",
     "Trigger": "Gov: Decision --[Flow]--> Decision",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2077,7 +2077,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Decision-COND",
     "Trigger": "Gov: Decision --[Flow]--> Decision",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2089,7 +2089,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Decision-COND-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Decision",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2102,7 +2102,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Decision-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Decision",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2114,7 +2114,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Final",
     "Trigger": "Gov: Decision --[Flow]--> Final",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2125,7 +2125,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Final-COND",
     "Trigger": "Gov: Decision --[Flow]--> Final",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2137,7 +2137,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Final-COND-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Final",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2150,7 +2150,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Final-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Final",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2162,7 +2162,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Lifecycle_Phase",
     "Trigger": "Gov: Decision --[Flow]--> Lifecycle Phase",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2173,7 +2173,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Lifecycle_Phase-COND",
     "Trigger": "Gov: Decision --[Flow]--> Lifecycle Phase",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2185,7 +2185,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Lifecycle_Phase-COND-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Lifecycle Phase",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2198,7 +2198,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Lifecycle_Phase-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Lifecycle Phase",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2210,7 +2210,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Merge",
     "Trigger": "Gov: Decision --[Flow]--> Merge",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2221,7 +2221,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Merge-COND",
     "Trigger": "Gov: Decision --[Flow]--> Merge",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2233,7 +2233,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Merge-COND-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Merge",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2246,7 +2246,7 @@
   {
     "Pattern ID": "GOV-flow-Decision-Merge-CONST",
     "Trigger": "Gov: Decision --[Flow]--> Merge",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2258,7 +2258,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-AI_Database",
     "Trigger": "Gov: Initial --[Flow]--> AI Database",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2269,7 +2269,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-AI_Database-COND",
     "Trigger": "Gov: Initial --[Flow]--> AI Database",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2281,7 +2281,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-AI_Database-COND-CONST",
     "Trigger": "Gov: Initial --[Flow]--> AI Database",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2294,7 +2294,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-AI_Database-CONST",
     "Trigger": "Gov: Initial --[Flow]--> AI Database",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2306,7 +2306,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-ANN",
     "Trigger": "Gov: Initial --[Flow]--> ANN",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2317,7 +2317,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-ANN-COND",
     "Trigger": "Gov: Initial --[Flow]--> ANN",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2329,7 +2329,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-ANN-COND-CONST",
     "Trigger": "Gov: Initial --[Flow]--> ANN",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2342,7 +2342,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-ANN-CONST",
     "Trigger": "Gov: Initial --[Flow]--> ANN",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2354,7 +2354,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Action",
     "Trigger": "Gov: Initial --[Flow]--> Action",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2365,7 +2365,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Action-COND",
     "Trigger": "Gov: Initial --[Flow]--> Action",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2377,7 +2377,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Action-COND-CONST",
     "Trigger": "Gov: Initial --[Flow]--> Action",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2390,7 +2390,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Action-CONST",
     "Trigger": "Gov: Initial --[Flow]--> Action",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2402,7 +2402,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Data_acquisition",
     "Trigger": "Gov: Initial --[Flow]--> Data acquisition",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2413,7 +2413,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Data_acquisition-COND",
     "Trigger": "Gov: Initial --[Flow]--> Data acquisition",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2425,7 +2425,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Data_acquisition-COND-CONST",
     "Trigger": "Gov: Initial --[Flow]--> Data acquisition",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2438,7 +2438,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Data_acquisition-CONST",
     "Trigger": "Gov: Initial --[Flow]--> Data acquisition",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2450,7 +2450,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Decision",
     "Trigger": "Gov: Initial --[Flow]--> Decision",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2461,7 +2461,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Decision-COND",
     "Trigger": "Gov: Initial --[Flow]--> Decision",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2473,7 +2473,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Decision-COND-CONST",
     "Trigger": "Gov: Initial --[Flow]--> Decision",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2486,7 +2486,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Decision-CONST",
     "Trigger": "Gov: Initial --[Flow]--> Decision",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2498,7 +2498,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Merge",
     "Trigger": "Gov: Initial --[Flow]--> Merge",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2509,7 +2509,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Merge-COND",
     "Trigger": "Gov: Initial --[Flow]--> Merge",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2521,7 +2521,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Merge-COND-CONST",
     "Trigger": "Gov: Initial --[Flow]--> Merge",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2534,7 +2534,7 @@
   {
     "Pattern ID": "GOV-flow-Initial-Merge-CONST",
     "Trigger": "Gov: Initial --[Flow]--> Merge",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2546,7 +2546,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-AI_Database",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> AI Database",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2557,7 +2557,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-AI_Database-COND",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> AI Database",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2569,7 +2569,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-AI_Database-COND-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> AI Database",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2582,7 +2582,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-AI_Database-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> AI Database",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2594,7 +2594,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-ANN",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> ANN",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2605,7 +2605,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-ANN-COND",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> ANN",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2617,7 +2617,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-ANN-COND-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> ANN",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2630,7 +2630,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-ANN-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> ANN",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2642,7 +2642,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Action",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Action",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2653,7 +2653,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Action-COND",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Action",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2665,7 +2665,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Action-COND-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Action",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2678,7 +2678,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Action-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Action",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2690,7 +2690,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Data_acquisition",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Data acquisition",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2701,7 +2701,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Data_acquisition-COND",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Data acquisition",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2713,7 +2713,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Data_acquisition-COND-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Data acquisition",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2726,7 +2726,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Data_acquisition-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Data acquisition",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2738,7 +2738,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Decision",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Decision",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2749,7 +2749,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Decision-COND",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Decision",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2761,7 +2761,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Decision-COND-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Decision",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2774,7 +2774,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Decision-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Decision",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2786,7 +2786,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Final",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Final",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2797,7 +2797,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Final-COND",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Final",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2809,7 +2809,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Final-COND-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Final",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2822,7 +2822,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Final-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Final",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2834,7 +2834,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Merge",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Merge",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2845,7 +2845,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Merge-COND",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Merge",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2857,7 +2857,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Merge-COND-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Merge",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2870,7 +2870,7 @@
   {
     "Pattern ID": "GOV-flow-Lifecycle_Phase-Merge-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Flow]--> Merge",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2882,7 +2882,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-AI_Database",
     "Trigger": "Gov: Merge --[Flow]--> AI Database",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2893,7 +2893,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-AI_Database-COND",
     "Trigger": "Gov: Merge --[Flow]--> AI Database",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2905,7 +2905,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-AI_Database-COND-CONST",
     "Trigger": "Gov: Merge --[Flow]--> AI Database",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2918,7 +2918,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-AI_Database-CONST",
     "Trigger": "Gov: Merge --[Flow]--> AI Database",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2930,7 +2930,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-ANN",
     "Trigger": "Gov: Merge --[Flow]--> ANN",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2941,7 +2941,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-ANN-COND",
     "Trigger": "Gov: Merge --[Flow]--> ANN",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2953,7 +2953,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-ANN-COND-CONST",
     "Trigger": "Gov: Merge --[Flow]--> ANN",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2966,7 +2966,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-ANN-CONST",
     "Trigger": "Gov: Merge --[Flow]--> ANN",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2978,7 +2978,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Action",
     "Trigger": "Gov: Merge --[Flow]--> Action",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -2989,7 +2989,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Action-COND",
     "Trigger": "Gov: Merge --[Flow]--> Action",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3001,7 +3001,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Action-COND-CONST",
     "Trigger": "Gov: Merge --[Flow]--> Action",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3014,7 +3014,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Action-CONST",
     "Trigger": "Gov: Merge --[Flow]--> Action",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3026,7 +3026,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Data_acquisition",
     "Trigger": "Gov: Merge --[Flow]--> Data acquisition",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3037,7 +3037,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Data_acquisition-COND",
     "Trigger": "Gov: Merge --[Flow]--> Data acquisition",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3049,7 +3049,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Data_acquisition-COND-CONST",
     "Trigger": "Gov: Merge --[Flow]--> Data acquisition",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3062,7 +3062,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Data_acquisition-CONST",
     "Trigger": "Gov: Merge --[Flow]--> Data acquisition",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3074,7 +3074,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Decision",
     "Trigger": "Gov: Merge --[Flow]--> Decision",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3085,7 +3085,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Decision-COND",
     "Trigger": "Gov: Merge --[Flow]--> Decision",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3097,7 +3097,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Decision-COND-CONST",
     "Trigger": "Gov: Merge --[Flow]--> Decision",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3110,7 +3110,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Decision-CONST",
     "Trigger": "Gov: Merge --[Flow]--> Decision",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3122,7 +3122,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Merge",
     "Trigger": "Gov: Merge --[Flow]--> Merge",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3133,7 +3133,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Merge-COND",
     "Trigger": "Gov: Merge --[Flow]--> Merge",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3145,7 +3145,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Merge-COND-CONST",
     "Trigger": "Gov: Merge --[Flow]--> Merge",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3158,7 +3158,7 @@
   {
     "Pattern ID": "GOV-flow-Merge-Merge-CONST",
     "Trigger": "Gov: Merge --[Flow]--> Merge",
-    "Template": "<object0_id> (<object0_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall flow to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3170,7 +3170,7 @@
   {
     "Pattern ID": "GOV-generalize-Policy-Policy",
     "Trigger": "Gov: Policy --[Generalize]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall generalize the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall generalize the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3181,7 +3181,7 @@
   {
     "Pattern ID": "GOV-generalize-Policy-Policy-COND",
     "Trigger": "Gov: Policy --[Generalize]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall generalize the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall generalize the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3193,7 +3193,7 @@
   {
     "Pattern ID": "GOV-generalize-Policy-Policy-COND-CONST",
     "Trigger": "Gov: Policy --[Generalize]--> Policy",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall generalize the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall generalize the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3206,7 +3206,7 @@
   {
     "Pattern ID": "GOV-generalize-Policy-Policy-CONST",
     "Trigger": "Gov: Policy --[Generalize]--> Policy",
-    "Template": "<object0_id> (<object0_class>) shall generalize the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall generalize the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3218,7 +3218,7 @@
   {
     "Pattern ID": "GOV-generalize-Standard-Standard",
     "Trigger": "Gov: Standard --[Generalize]--> Standard",
-    "Template": "<object0_id> (<object0_class>) shall generalize the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall generalize the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3229,7 +3229,7 @@
   {
     "Pattern ID": "GOV-generalize-Standard-Standard-COND",
     "Trigger": "Gov: Standard --[Generalize]--> Standard",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall generalize the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall generalize the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3241,7 +3241,7 @@
   {
     "Pattern ID": "GOV-generalize-Standard-Standard-COND-CONST",
     "Trigger": "Gov: Standard --[Generalize]--> Standard",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall generalize the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall generalize the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3254,7 +3254,7 @@
   {
     "Pattern ID": "GOV-generalize-Standard-Standard-CONST",
     "Trigger": "Gov: Standard --[Generalize]--> Standard",
-    "Template": "<object0_id> (<object0_class>) shall generalize the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall generalize the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3266,7 +3266,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Activity",
     "Trigger": "Gov: Role --[Monitors]--> Activity",
-    "Template": "<object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3277,7 +3277,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Activity-COND",
     "Trigger": "Gov: Role --[Monitors]--> Activity",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3289,7 +3289,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Activity-COND-CONST",
     "Trigger": "Gov: Role --[Monitors]--> Activity",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3302,7 +3302,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Activity-CONST",
     "Trigger": "Gov: Role --[Monitors]--> Activity",
-    "Template": "<object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3314,7 +3314,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Metric",
     "Trigger": "Gov: Role --[Monitors]--> Metric",
-    "Template": "<object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3325,7 +3325,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Metric-COND",
     "Trigger": "Gov: Role --[Monitors]--> Metric",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3337,7 +3337,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Metric-COND-CONST",
     "Trigger": "Gov: Role --[Monitors]--> Metric",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3350,7 +3350,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Metric-CONST",
     "Trigger": "Gov: Role --[Monitors]--> Metric",
-    "Template": "<object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3362,7 +3362,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Process",
     "Trigger": "Gov: Role --[Monitors]--> Process",
-    "Template": "<object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3373,7 +3373,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Process-COND",
     "Trigger": "Gov: Role --[Monitors]--> Process",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3385,7 +3385,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Process-COND-CONST",
     "Trigger": "Gov: Role --[Monitors]--> Process",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3398,7 +3398,7 @@
   {
     "Pattern ID": "GOV-monitors-Role-Process-CONST",
     "Trigger": "Gov: Role --[Monitors]--> Process",
-    "Template": "<object0_id> (<object0_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall monitors the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3410,7 +3410,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Activity",
     "Trigger": "Gov: Role --[Performs]--> Activity",
-    "Template": "<object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)'.",
+    "Template": "<subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3421,7 +3421,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Activity-COND",
     "Trigger": "Gov: Role --[Performs]--> Activity",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)'.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3433,7 +3433,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Activity-COND-CONST",
     "Trigger": "Gov: Role --[Performs]--> Activity",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3446,7 +3446,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Activity-CONST",
     "Trigger": "Gov: Role --[Performs]--> Activity",
-    "Template": "<object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3458,7 +3458,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Procedure",
     "Trigger": "Gov: Role --[Performs]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)'.",
+    "Template": "<subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3469,7 +3469,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Procedure-COND",
     "Trigger": "Gov: Role --[Performs]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)'.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3481,7 +3481,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Procedure-COND-CONST",
     "Trigger": "Gov: Role --[Performs]--> Procedure",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3494,7 +3494,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Procedure-CONST",
     "Trigger": "Gov: Role --[Performs]--> Procedure",
-    "Template": "<object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3506,7 +3506,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Task",
     "Trigger": "Gov: Role --[Performs]--> Task",
-    "Template": "<object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)'.",
+    "Template": "<subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3517,7 +3517,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Task-COND",
     "Trigger": "Gov: Role --[Performs]--> Task",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)'.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)'.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3529,7 +3529,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Task-COND-CONST",
     "Trigger": "Gov: Role --[Performs]--> Task",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3542,7 +3542,7 @@
   {
     "Pattern ID": "GOV-performs-Role-Task-CONST",
     "Trigger": "Gov: Role --[Performs]--> Task",
-    "Template": "<object0_id> (<object0_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall perform '<object1_id> (<object1_class>)' constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3554,7 +3554,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Data",
     "Trigger": "Gov: Process --[Produces]--> Data",
-    "Template": "<object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3565,7 +3565,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Data-COND",
     "Trigger": "Gov: Process --[Produces]--> Data",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3577,7 +3577,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Data-COND-CONST",
     "Trigger": "Gov: Process --[Produces]--> Data",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3590,7 +3590,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Data-CONST",
     "Trigger": "Gov: Process --[Produces]--> Data",
-    "Template": "<object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3602,7 +3602,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Document",
     "Trigger": "Gov: Process --[Produces]--> Document",
-    "Template": "<object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3613,7 +3613,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Document-COND",
     "Trigger": "Gov: Process --[Produces]--> Document",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3625,7 +3625,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Document-COND-CONST",
     "Trigger": "Gov: Process --[Produces]--> Document",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3638,7 +3638,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Document-CONST",
     "Trigger": "Gov: Process --[Produces]--> Document",
-    "Template": "<object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3650,7 +3650,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Record",
     "Trigger": "Gov: Process --[Produces]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3661,7 +3661,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Record-COND",
     "Trigger": "Gov: Process --[Produces]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3673,7 +3673,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Record-COND-CONST",
     "Trigger": "Gov: Process --[Produces]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3686,7 +3686,7 @@
   {
     "Pattern ID": "GOV-produces-Process-Record-CONST",
     "Trigger": "Gov: Process --[Produces]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall produces the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3698,7 +3698,7 @@
   {
     "Pattern ID": "GOV-propagate-Work_Product-Work_Product",
     "Trigger": "Gov: Work Product --[Propagate]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall propagate the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall propagate the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3709,7 +3709,7 @@
   {
     "Pattern ID": "GOV-propagate-Work_Product-Work_Product-COND",
     "Trigger": "Gov: Work Product --[Propagate]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall propagate the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall propagate the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3721,7 +3721,7 @@
   {
     "Pattern ID": "GOV-propagate-Work_Product-Work_Product-COND-CONST",
     "Trigger": "Gov: Work Product --[Propagate]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall propagate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall propagate the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3734,7 +3734,7 @@
   {
     "Pattern ID": "GOV-propagate-Work_Product-Work_Product-CONST",
     "Trigger": "Gov: Work Product --[Propagate]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall propagate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall propagate the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3746,7 +3746,7 @@
   {
     "Pattern ID": "GOV-propagate_by_approval-Work_Product-Work_Product",
     "Trigger": "Gov: Work Product --[Propagate by Approval]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall propagate by approval the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall propagate by approval the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3757,7 +3757,7 @@
   {
     "Pattern ID": "GOV-propagate_by_approval-Work_Product-Work_Product-COND",
     "Trigger": "Gov: Work Product --[Propagate by Approval]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall propagate by approval the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall propagate by approval the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3769,7 +3769,7 @@
   {
     "Pattern ID": "GOV-propagate_by_approval-Work_Product-Work_Product-COND-CONST",
     "Trigger": "Gov: Work Product --[Propagate by Approval]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall propagate by approval the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall propagate by approval the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3782,7 +3782,7 @@
   {
     "Pattern ID": "GOV-propagate_by_approval-Work_Product-Work_Product-CONST",
     "Trigger": "Gov: Work Product --[Propagate by Approval]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall propagate by approval the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall propagate by approval the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3794,7 +3794,7 @@
   {
     "Pattern ID": "GOV-propagate_by_review-Work_Product-Work_Product",
     "Trigger": "Gov: Work Product --[Propagate by Review]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall propagate by review the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall propagate by review the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3805,7 +3805,7 @@
   {
     "Pattern ID": "GOV-propagate_by_review-Work_Product-Work_Product-COND",
     "Trigger": "Gov: Work Product --[Propagate by Review]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall propagate by review the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall propagate by review the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3817,7 +3817,7 @@
   {
     "Pattern ID": "GOV-propagate_by_review-Work_Product-Work_Product-COND-CONST",
     "Trigger": "Gov: Work Product --[Propagate by Review]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall propagate by review the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall propagate by review the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3830,7 +3830,7 @@
   {
     "Pattern ID": "GOV-propagate_by_review-Work_Product-Work_Product-CONST",
     "Trigger": "Gov: Work Product --[Propagate by Review]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall propagate by review the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall propagate by review the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3842,7 +3842,7 @@
   {
     "Pattern ID": "GOV-re-use-Lifecycle_Phase-Lifecycle_Phase",
     "Trigger": "Gov: Lifecycle Phase --[Re-use]--> Lifecycle Phase",
-    "Template": "<object0_id> (<object0_class>) shall re-use the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall re-use the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3853,7 +3853,7 @@
   {
     "Pattern ID": "GOV-re-use-Lifecycle_Phase-Lifecycle_Phase-COND",
     "Trigger": "Gov: Lifecycle Phase --[Re-use]--> Lifecycle Phase",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall re-use the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall re-use the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3865,7 +3865,7 @@
   {
     "Pattern ID": "GOV-re-use-Lifecycle_Phase-Lifecycle_Phase-COND-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Re-use]--> Lifecycle Phase",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall re-use the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall re-use the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3878,7 +3878,7 @@
   {
     "Pattern ID": "GOV-re-use-Lifecycle_Phase-Lifecycle_Phase-CONST",
     "Trigger": "Gov: Lifecycle Phase --[Re-use]--> Lifecycle Phase",
-    "Template": "<object0_id> (<object0_class>) shall re-use the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall re-use the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3890,7 +3890,7 @@
   {
     "Pattern ID": "GOV-re-use-Work_Product-Lifecycle_Phase",
     "Trigger": "Gov: Work Product --[Re-use]--> Lifecycle Phase",
-    "Template": "<object0_id> (<object0_class>) shall re-use the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall re-use the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3901,7 +3901,7 @@
   {
     "Pattern ID": "GOV-re-use-Work_Product-Lifecycle_Phase-COND",
     "Trigger": "Gov: Work Product --[Re-use]--> Lifecycle Phase",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall re-use the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall re-use the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3913,7 +3913,7 @@
   {
     "Pattern ID": "GOV-re-use-Work_Product-Lifecycle_Phase-COND-CONST",
     "Trigger": "Gov: Work Product --[Re-use]--> Lifecycle Phase",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall re-use the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall re-use the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3926,7 +3926,7 @@
   {
     "Pattern ID": "GOV-re-use-Work_Product-Lifecycle_Phase-CONST",
     "Trigger": "Gov: Work Product --[Re-use]--> Lifecycle Phase",
-    "Template": "<object0_id> (<object0_class>) shall re-use the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall re-use the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3938,7 +3938,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Activity",
     "Trigger": "Gov: Role --[Responsible for]--> Activity",
-    "Template": "<object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3949,7 +3949,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Activity-COND",
     "Trigger": "Gov: Role --[Responsible for]--> Activity",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3961,7 +3961,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Activity-COND-CONST",
     "Trigger": "Gov: Role --[Responsible for]--> Activity",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3974,7 +3974,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Activity-CONST",
     "Trigger": "Gov: Role --[Responsible for]--> Activity",
-    "Template": "<object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3986,7 +3986,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Process",
     "Trigger": "Gov: Role --[Responsible for]--> Process",
-    "Template": "<object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3997,7 +3997,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Process-COND",
     "Trigger": "Gov: Role --[Responsible for]--> Process",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4009,7 +4009,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Process-COND-CONST",
     "Trigger": "Gov: Role --[Responsible for]--> Process",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4022,7 +4022,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Process-CONST",
     "Trigger": "Gov: Role --[Responsible for]--> Process",
-    "Template": "<object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4034,7 +4034,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Task",
     "Trigger": "Gov: Role --[Responsible for]--> Task",
-    "Template": "<object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4045,7 +4045,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Task-COND",
     "Trigger": "Gov: Role --[Responsible for]--> Task",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4057,7 +4057,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Task-COND-CONST",
     "Trigger": "Gov: Role --[Responsible for]--> Task",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4070,7 +4070,7 @@
   {
     "Pattern ID": "GOV-responsible_for-Role-Task-CONST",
     "Trigger": "Gov: Role --[Responsible for]--> Task",
-    "Template": "<object0_id> (<object0_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4082,7 +4082,7 @@
   {
     "Pattern ID": "GOV-satisfied_by-Work_Product-Work_Product",
     "Trigger": "Gov: Work Product --[Satisfied by]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall be satisfied by the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall be satisfied by the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4093,7 +4093,7 @@
   {
     "Pattern ID": "GOV-satisfied_by-Work_Product-Work_Product-COND",
     "Trigger": "Gov: Work Product --[Satisfied by]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall be satisfied by the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be satisfied by the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4105,7 +4105,7 @@
   {
     "Pattern ID": "GOV-satisfied_by-Work_Product-Work_Product-COND-CONST",
     "Trigger": "Gov: Work Product --[Satisfied by]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall be satisfied by the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be satisfied by the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4118,7 +4118,7 @@
   {
     "Pattern ID": "GOV-satisfied_by-Work_Product-Work_Product-CONST",
     "Trigger": "Gov: Work Product --[Satisfied by]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall be satisfied by the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall be satisfied by the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4130,7 +4130,7 @@
   {
     "Pattern ID": "GOV-trace-Work_Product-Work_Product",
     "Trigger": "Gov: Work Product --[Trace]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall trace to the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall trace to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4141,7 +4141,7 @@
   {
     "Pattern ID": "GOV-trace-Work_Product-Work_Product-COND",
     "Trigger": "Gov: Work Product --[Trace]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall trace to the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall trace to the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4153,7 +4153,7 @@
   {
     "Pattern ID": "GOV-trace-Work_Product-Work_Product-COND-CONST",
     "Trigger": "Gov: Work Product --[Trace]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall trace to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall trace to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4166,7 +4166,7 @@
   {
     "Pattern ID": "GOV-trace-Work_Product-Work_Product-CONST",
     "Trigger": "Gov: Work Product --[Trace]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall trace to the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall trace to the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4178,7 +4178,7 @@
   {
     "Pattern ID": "GOV-used_after_approval-Work_Product-Work_Product",
     "Trigger": "Gov: Work Product --[Used after Approval]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall be used after approval the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall be used after approval the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4189,7 +4189,7 @@
   {
     "Pattern ID": "GOV-used_after_approval-Work_Product-Work_Product-COND",
     "Trigger": "Gov: Work Product --[Used after Approval]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall be used after approval the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be used after approval the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4201,7 +4201,7 @@
   {
     "Pattern ID": "GOV-used_after_approval-Work_Product-Work_Product-COND-CONST",
     "Trigger": "Gov: Work Product --[Used after Approval]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall be used after approval the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be used after approval the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4214,7 +4214,7 @@
   {
     "Pattern ID": "GOV-used_after_approval-Work_Product-Work_Product-CONST",
     "Trigger": "Gov: Work Product --[Used after Approval]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall be used after approval the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall be used after approval the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4226,7 +4226,7 @@
   {
     "Pattern ID": "GOV-used_after_review-Work_Product-Work_Product",
     "Trigger": "Gov: Work Product --[Used after Review]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall be used after review the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall be used after review the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4237,7 +4237,7 @@
   {
     "Pattern ID": "GOV-used_after_review-Work_Product-Work_Product-COND",
     "Trigger": "Gov: Work Product --[Used after Review]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall be used after review the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be used after review the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4249,7 +4249,7 @@
   {
     "Pattern ID": "GOV-used_after_review-Work_Product-Work_Product-COND-CONST",
     "Trigger": "Gov: Work Product --[Used after Review]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall be used after review the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be used after review the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4262,7 +4262,7 @@
   {
     "Pattern ID": "GOV-used_after_review-Work_Product-Work_Product-CONST",
     "Trigger": "Gov: Work Product --[Used after Review]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall be used after review the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall be used after review the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4274,7 +4274,7 @@
   {
     "Pattern ID": "GOV-used_by-Work_Product-Work_Product",
     "Trigger": "Gov: Work Product --[Used By]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall be used by the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall be used by the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4285,7 +4285,7 @@
   {
     "Pattern ID": "GOV-used_by-Work_Product-Work_Product-COND",
     "Trigger": "Gov: Work Product --[Used By]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall be used by the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be used by the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4297,7 +4297,7 @@
   {
     "Pattern ID": "GOV-used_by-Work_Product-Work_Product-COND-CONST",
     "Trigger": "Gov: Work Product --[Used By]--> Work Product",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall be used by the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be used by the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4310,7 +4310,7 @@
   {
     "Pattern ID": "GOV-used_by-Work_Product-Work_Product-CONST",
     "Trigger": "Gov: Work Product --[Used By]--> Work Product",
-    "Template": "<object0_id> (<object0_class>) shall be used by the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall be used by the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4322,7 +4322,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Data",
     "Trigger": "Gov: Role --[Uses]--> Data",
-    "Template": "<object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4333,7 +4333,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Data-COND",
     "Trigger": "Gov: Role --[Uses]--> Data",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4345,7 +4345,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Data-COND-CONST",
     "Trigger": "Gov: Role --[Uses]--> Data",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4358,7 +4358,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Data-CONST",
     "Trigger": "Gov: Role --[Uses]--> Data",
-    "Template": "<object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4370,7 +4370,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Document",
     "Trigger": "Gov: Role --[Uses]--> Document",
-    "Template": "<object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4381,7 +4381,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Document-COND",
     "Trigger": "Gov: Role --[Uses]--> Document",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4393,7 +4393,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Document-COND-CONST",
     "Trigger": "Gov: Role --[Uses]--> Document",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4406,7 +4406,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Document-CONST",
     "Trigger": "Gov: Role --[Uses]--> Document",
-    "Template": "<object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4418,7 +4418,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Record",
     "Trigger": "Gov: Role --[Uses]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>).",
+    "Template": "<subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4429,7 +4429,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Record-COND",
     "Trigger": "Gov: Role --[Uses]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>).",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4441,7 +4441,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Record-COND-CONST",
     "Trigger": "Gov: Role --[Uses]--> Record",
-    "Template": "When <condition>, <object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4454,7 +4454,7 @@
   {
     "Pattern ID": "GOV-uses-Role-Record-CONST",
     "Trigger": "Gov: Role --[Uses]--> Record",
-    "Template": "<object0_id> (<object0_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Template": "<subject_id> (<subject_class>) shall uses the <object1_id> (<object1_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -4520,6 +4520,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-acquisition-AI_Database-Data_acquisition-ROLE",
+    "Trigger": "Safety&AI: AI Database --[Acquisition]--> Data acquisition",
+    "Template": "<subject_id> (<subject_class>) shall acquire the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-acquisition-AI_Database-Data_acquisition-ROLE-COND",
+    "Trigger": "Safety&AI: AI Database --[Acquisition]--> Data acquisition",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall acquire the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-acquisition-AI_Database-Data_acquisition-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: AI Database --[Acquisition]--> Data acquisition",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall acquire the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-acquisition-AI_Database-Data_acquisition-ROLE-CONST",
+    "Trigger": "Safety&AI: AI Database --[Acquisition]--> Data acquisition",
+    "Template": "<subject_id> (<subject_class>) shall acquire the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-ai_re-training-AI_Database-ANN",
     "Trigger": "Safety&AI: AI Database --[AI re-training]--> ANN",
     "Template": "Engineering team shall retrain the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -4568,6 +4624,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-ai_re-training-AI_Database-ANN-ROLE",
+    "Trigger": "Safety&AI: AI Database --[AI re-training]--> ANN",
+    "Template": "<subject_id> (<subject_class>) shall retrain the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-ai_re-training-AI_Database-ANN-ROLE-COND",
+    "Trigger": "Safety&AI: AI Database --[AI re-training]--> ANN",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall retrain the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-ai_re-training-AI_Database-ANN-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: AI Database --[AI re-training]--> ANN",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall retrain the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-ai_re-training-AI_Database-ANN-ROLE-CONST",
+    "Trigger": "Safety&AI: AI Database --[AI re-training]--> ANN",
+    "Template": "<subject_id> (<subject_class>) shall retrain the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -4632,6 +4744,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-ai_training-AI_Database-ANN-ROLE",
+    "Trigger": "Safety&AI: AI Database --[AI training]--> ANN",
+    "Template": "<subject_id> (<subject_class>) shall train the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-ai_training-AI_Database-ANN-ROLE-COND",
+    "Trigger": "Safety&AI: AI Database --[AI training]--> ANN",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall train the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-ai_training-AI_Database-ANN-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: AI Database --[AI training]--> ANN",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall train the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-ai_training-AI_Database-ANN-ROLE-CONST",
+    "Trigger": "Safety&AI: AI Database --[AI training]--> ANN",
+    "Template": "<subject_id> (<subject_class>) shall train the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-annotation-ANN-AI_Database",
     "Trigger": "Safety&AI: ANN --[Annotation]--> AI Database",
     "Template": "Engineering team shall annotate the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -4680,6 +4848,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-annotation-ANN-AI_Database-ROLE",
+    "Trigger": "Safety&AI: ANN --[Annotation]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall annotate the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-annotation-ANN-AI_Database-ROLE-COND",
+    "Trigger": "Safety&AI: ANN --[Annotation]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall annotate the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-annotation-ANN-AI_Database-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: ANN --[Annotation]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall annotate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-annotation-ANN-AI_Database-ROLE-CONST",
+    "Trigger": "Safety&AI: ANN --[Annotation]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall annotate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -4744,6 +4968,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-assesses-Field_Data-Risk_Assessment-ROLE",
+    "Trigger": "Safety&AI: Field Data --[Assesses]--> Risk Assessment",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-assesses-Field_Data-Risk_Assessment-ROLE-COND",
+    "Trigger": "Safety&AI: Field Data --[Assesses]--> Risk Assessment",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-assesses-Field_Data-Risk_Assessment-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Field Data --[Assesses]--> Risk Assessment",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-assesses-Field_Data-Risk_Assessment-ROLE-CONST",
+    "Trigger": "Safety&AI: Field Data --[Assesses]--> Risk Assessment",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-assesses-Hazard-Risk_Assessment",
     "Trigger": "Safety&AI: Hazard --[Assesses]--> Risk Assessment",
     "Template": "Engineering team shall assesses the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -4792,6 +5072,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-assesses-Hazard-Risk_Assessment-ROLE",
+    "Trigger": "Safety&AI: Hazard --[Assesses]--> Risk Assessment",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-assesses-Hazard-Risk_Assessment-ROLE-COND",
+    "Trigger": "Safety&AI: Hazard --[Assesses]--> Risk Assessment",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-assesses-Hazard-Risk_Assessment-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Hazard --[Assesses]--> Risk Assessment",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-assesses-Hazard-Risk_Assessment-ROLE-CONST",
+    "Trigger": "Safety&AI: Hazard --[Assesses]--> Risk Assessment",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -4856,6 +5192,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-assesses-Security_Threat-Risk_Assessment-ROLE",
+    "Trigger": "Safety&AI: Security Threat --[Assesses]--> Risk Assessment",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-assesses-Security_Threat-Risk_Assessment-ROLE-COND",
+    "Trigger": "Safety&AI: Security Threat --[Assesses]--> Risk Assessment",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-assesses-Security_Threat-Risk_Assessment-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Security Threat --[Assesses]--> Risk Assessment",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-assesses-Security_Threat-Risk_Assessment-ROLE-CONST",
+    "Trigger": "Safety&AI: Security Threat --[Assesses]--> Risk Assessment",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-audits-Process-Report",
     "Trigger": "Safety&AI: Process --[Audits]--> Report",
     "Template": "Engineering team shall audit the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -4904,6 +5296,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-audits-Process-Report-ROLE",
+    "Trigger": "Safety&AI: Process --[Audits]--> Report",
+    "Template": "<subject_id> (<subject_class>) shall audit the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-audits-Process-Report-ROLE-COND",
+    "Trigger": "Safety&AI: Process --[Audits]--> Report",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall audit the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-audits-Process-Report-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Process --[Audits]--> Report",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall audit the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-audits-Process-Report-ROLE-CONST",
+    "Trigger": "Safety&AI: Process --[Audits]--> Report",
+    "Template": "<subject_id> (<subject_class>) shall audit the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -4968,6 +5416,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-augmentation-ANN-AI_Database-ROLE",
+    "Trigger": "Safety&AI: ANN --[Augmentation]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall augment the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-augmentation-ANN-AI_Database-ROLE-COND",
+    "Trigger": "Safety&AI: ANN --[Augmentation]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall augment the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-augmentation-ANN-AI_Database-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: ANN --[Augmentation]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall augment the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-augmentation-ANN-AI_Database-ROLE-CONST",
+    "Trigger": "Safety&AI: ANN --[Augmentation]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall augment the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-complies_with-AI_Database-Policy",
     "Trigger": "Safety&AI: AI Database --[Complies with]--> Policy",
     "Template": "Engineering team shall comply with the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -5016,6 +5520,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-complies_with-AI_Database-Policy-ROLE",
+    "Trigger": "Safety&AI: AI Database --[Complies with]--> Policy",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-complies_with-AI_Database-Policy-ROLE-COND",
+    "Trigger": "Safety&AI: AI Database --[Complies with]--> Policy",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-complies_with-AI_Database-Policy-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: AI Database --[Complies with]--> Policy",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-complies_with-AI_Database-Policy-ROLE-CONST",
+    "Trigger": "Safety&AI: AI Database --[Complies with]--> Policy",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -5080,6 +5640,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-complies_with-ANN-Policy-ROLE",
+    "Trigger": "Safety&AI: ANN --[Complies with]--> Policy",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-complies_with-ANN-Policy-ROLE-COND",
+    "Trigger": "Safety&AI: ANN --[Complies with]--> Policy",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-complies_with-ANN-Policy-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: ANN --[Complies with]--> Policy",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-complies_with-ANN-Policy-ROLE-CONST",
+    "Trigger": "Safety&AI: ANN --[Complies with]--> Policy",
+    "Template": "<subject_id> (<subject_class>) shall comply with the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-constrains-Policy-Process",
     "Trigger": "Safety&AI: Policy --[Constrains]--> Process",
     "Template": "Engineering team shall constrain the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -5128,6 +5744,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-constrains-Policy-Process-ROLE",
+    "Trigger": "Safety&AI: Policy --[Constrains]--> Process",
+    "Template": "<subject_id> (<subject_class>) shall constrain the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-constrains-Policy-Process-ROLE-COND",
+    "Trigger": "Safety&AI: Policy --[Constrains]--> Process",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall constrain the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-constrains-Policy-Process-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Policy --[Constrains]--> Process",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall constrain the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-constrains-Policy-Process-ROLE-CONST",
+    "Trigger": "Safety&AI: Policy --[Constrains]--> Process",
+    "Template": "<subject_id> (<subject_class>) shall constrain the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -5192,6 +5864,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-curation-AI_Database-AI_Database-ROLE",
+    "Trigger": "Safety&AI: AI Database --[Curation]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall curate the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-curation-AI_Database-AI_Database-ROLE-COND",
+    "Trigger": "Safety&AI: AI Database --[Curation]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall curate the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-curation-AI_Database-AI_Database-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: AI Database --[Curation]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall curate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-curation-AI_Database-AI_Database-ROLE-CONST",
+    "Trigger": "Safety&AI: AI Database --[Curation]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall curate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-develops-Field_Data-Test_Suite",
     "Trigger": "Safety&AI: Field Data --[Develops]--> Test Suite",
     "Template": "Engineering team shall develops the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -5240,6 +5968,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Field_Data-Test_Suite-ROLE",
+    "Trigger": "Safety&AI: Field Data --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Field_Data-Test_Suite-ROLE-COND",
+    "Trigger": "Safety&AI: Field Data --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Field_Data-Test_Suite-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Field Data --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Field_Data-Test_Suite-ROLE-CONST",
+    "Trigger": "Safety&AI: Field Data --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -5304,6 +6088,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-develops-Plan-Test_Suite-ROLE",
+    "Trigger": "Safety&AI: Plan --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Plan-Test_Suite-ROLE-COND",
+    "Trigger": "Safety&AI: Plan --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Plan-Test_Suite-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Plan --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Plan-Test_Suite-ROLE-CONST",
+    "Trigger": "Safety&AI: Plan --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-develops-Process-Test_Suite",
     "Trigger": "Safety&AI: Process --[Develops]--> Test Suite",
     "Template": "Engineering team shall develops the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -5352,6 +6192,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Process-Test_Suite-ROLE",
+    "Trigger": "Safety&AI: Process --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Process-Test_Suite-ROLE-COND",
+    "Trigger": "Safety&AI: Process --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Process-Test_Suite-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Process --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Process-Test_Suite-ROLE-CONST",
+    "Trigger": "Safety&AI: Process --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -5416,6 +6312,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-develops-Risk_Assessment-Test_Suite-ROLE",
+    "Trigger": "Safety&AI: Risk Assessment --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Risk_Assessment-Test_Suite-ROLE-COND",
+    "Trigger": "Safety&AI: Risk Assessment --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Risk_Assessment-Test_Suite-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Risk Assessment --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Risk_Assessment-Test_Suite-ROLE-CONST",
+    "Trigger": "Safety&AI: Risk Assessment --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-develops-Safety_Goal-Test_Suite",
     "Trigger": "Safety&AI: Safety Goal --[Develops]--> Test Suite",
     "Template": "Engineering team shall develops the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -5464,6 +6416,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Safety_Goal-Test_Suite-ROLE",
+    "Trigger": "Safety&AI: Safety Goal --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Safety_Goal-Test_Suite-ROLE-COND",
+    "Trigger": "Safety&AI: Safety Goal --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Safety_Goal-Test_Suite-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Safety Goal --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-develops-Safety_Goal-Test_Suite-ROLE-CONST",
+    "Trigger": "Safety&AI: Safety Goal --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall develops the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -5528,6 +6536,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-field_data_collection-AI_Database-Data_acquisition-ROLE",
+    "Trigger": "Safety&AI: AI Database --[Field data collection]--> Data acquisition",
+    "Template": "<subject_id> (<subject_class>) shall collect field data from the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-AI_Database-Data_acquisition-ROLE-COND",
+    "Trigger": "Safety&AI: AI Database --[Field data collection]--> Data acquisition",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall collect field data from the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-AI_Database-Data_acquisition-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: AI Database --[Field data collection]--> Data acquisition",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall collect field data from the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-AI_Database-Data_acquisition-ROLE-CONST",
+    "Trigger": "Safety&AI: AI Database --[Field data collection]--> Data acquisition",
+    "Template": "<subject_id> (<subject_class>) shall collect field data from the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-field_data_collection-AI_Database-Task",
     "Trigger": "Safety&AI: AI Database --[Field data collection]--> Task",
     "Template": "Engineering team shall collect field data from the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -5576,6 +6640,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-AI_Database-Task-ROLE",
+    "Trigger": "Safety&AI: AI Database --[Field data collection]--> Task",
+    "Template": "<subject_id> (<subject_class>) shall collect field data from the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-AI_Database-Task-ROLE-COND",
+    "Trigger": "Safety&AI: AI Database --[Field data collection]--> Task",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall collect field data from the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-AI_Database-Task-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: AI Database --[Field data collection]--> Task",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall collect field data from the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-AI_Database-Task-ROLE-CONST",
+    "Trigger": "Safety&AI: AI Database --[Field data collection]--> Task",
+    "Template": "<subject_id> (<subject_class>) shall collect field data from the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -5640,6 +6760,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-field_risk_evaluation-AI_Database-Data_acquisition-ROLE",
+    "Trigger": "Safety&AI: AI Database --[Field risk evaluation]--> Data acquisition",
+    "Template": "<subject_id> (<subject_class>) shall evaluate field risk the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-field_risk_evaluation-AI_Database-Data_acquisition-ROLE-COND",
+    "Trigger": "Safety&AI: AI Database --[Field risk evaluation]--> Data acquisition",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall evaluate field risk the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-field_risk_evaluation-AI_Database-Data_acquisition-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: AI Database --[Field risk evaluation]--> Data acquisition",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall evaluate field risk the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-field_risk_evaluation-AI_Database-Data_acquisition-ROLE-CONST",
+    "Trigger": "Safety&AI: AI Database --[Field risk evaluation]--> Data acquisition",
+    "Template": "<subject_id> (<subject_class>) shall evaluate field risk the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-ingestion-AI_Database-AI_Database",
     "Trigger": "Safety&AI: AI Database --[Ingestion]--> AI Database",
     "Template": "Engineering team shall ingest the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -5688,6 +6864,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-ingestion-AI_Database-AI_Database-ROLE",
+    "Trigger": "Safety&AI: AI Database --[Ingestion]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall ingest the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-ingestion-AI_Database-AI_Database-ROLE-COND",
+    "Trigger": "Safety&AI: AI Database --[Ingestion]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall ingest the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-ingestion-AI_Database-AI_Database-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: AI Database --[Ingestion]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall ingest the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-ingestion-AI_Database-AI_Database-ROLE-CONST",
+    "Trigger": "Safety&AI: AI Database --[Ingestion]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall ingest the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -5752,6 +6984,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-labeling-ANN-AI_Database-ROLE",
+    "Trigger": "Safety&AI: ANN --[Labeling]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall label the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-labeling-ANN-AI_Database-ROLE-COND",
+    "Trigger": "Safety&AI: ANN --[Labeling]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall label the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-labeling-ANN-AI_Database-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: ANN --[Labeling]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall label the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-labeling-ANN-AI_Database-ROLE-CONST",
+    "Trigger": "Safety&AI: ANN --[Labeling]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall label the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-mitigates-Risk_Assessment-Plan",
     "Trigger": "Safety&AI: Risk Assessment --[Mitigates]--> Plan",
     "Template": "Engineering team shall mitigates the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -5800,6 +7088,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-mitigates-Risk_Assessment-Plan-ROLE",
+    "Trigger": "Safety&AI: Risk Assessment --[Mitigates]--> Plan",
+    "Template": "<subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-mitigates-Risk_Assessment-Plan-ROLE-COND",
+    "Trigger": "Safety&AI: Risk Assessment --[Mitigates]--> Plan",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-mitigates-Risk_Assessment-Plan-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Risk Assessment --[Mitigates]--> Plan",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-mitigates-Risk_Assessment-Plan-ROLE-CONST",
+    "Trigger": "Safety&AI: Risk Assessment --[Mitigates]--> Plan",
+    "Template": "<subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -5864,6 +7208,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-mitigates-Risk_Assessment-Safety_Goal-ROLE",
+    "Trigger": "Safety&AI: Risk Assessment --[Mitigates]--> Safety Goal",
+    "Template": "<subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-mitigates-Risk_Assessment-Safety_Goal-ROLE-COND",
+    "Trigger": "Safety&AI: Risk Assessment --[Mitigates]--> Safety Goal",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-mitigates-Risk_Assessment-Safety_Goal-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Risk Assessment --[Mitigates]--> Safety Goal",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-mitigates-Risk_Assessment-Safety_Goal-ROLE-CONST",
+    "Trigger": "Safety&AI: Risk Assessment --[Mitigates]--> Safety Goal",
+    "Template": "<subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-model_evaluation-ANN-AI_Database",
     "Trigger": "Safety&AI: ANN --[Model evaluation]--> AI Database",
     "Template": "Engineering team shall evaluate model the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -5912,6 +7312,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-model_evaluation-ANN-AI_Database-ROLE",
+    "Trigger": "Safety&AI: ANN --[Model evaluation]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall evaluate model the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-model_evaluation-ANN-AI_Database-ROLE-COND",
+    "Trigger": "Safety&AI: ANN --[Model evaluation]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall evaluate model the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-model_evaluation-ANN-AI_Database-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: ANN --[Model evaluation]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall evaluate model the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-model_evaluation-ANN-AI_Database-ROLE-CONST",
+    "Trigger": "Safety&AI: ANN --[Model evaluation]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall evaluate model the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -5976,6 +7432,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-monitoring-ANN-Operation-ROLE",
+    "Trigger": "Safety&AI: ANN --[Monitoring]--> Operation",
+    "Template": "<subject_id> (<subject_class>) shall monitor the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-monitoring-ANN-Operation-ROLE-COND",
+    "Trigger": "Safety&AI: ANN --[Monitoring]--> Operation",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall monitor the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-monitoring-ANN-Operation-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: ANN --[Monitoring]--> Operation",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall monitor the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-monitoring-ANN-Operation-ROLE-CONST",
+    "Trigger": "Safety&AI: ANN --[Monitoring]--> Operation",
+    "Template": "<subject_id> (<subject_class>) shall monitor the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-plans-Plan-Process",
     "Trigger": "Safety&AI: Plan --[Plans]--> Process",
     "Template": "Engineering team shall plans the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -6024,6 +7536,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-plans-Plan-Process-ROLE",
+    "Trigger": "Safety&AI: Plan --[Plans]--> Process",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-plans-Plan-Process-ROLE-COND",
+    "Trigger": "Safety&AI: Plan --[Plans]--> Process",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-plans-Plan-Process-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Plan --[Plans]--> Process",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-plans-Plan-Process-ROLE-CONST",
+    "Trigger": "Safety&AI: Plan --[Plans]--> Process",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -6088,6 +7656,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-produces-Plan-Document-ROLE",
+    "Trigger": "Safety&AI: Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Plan-Document-ROLE-COND",
+    "Trigger": "Safety&AI: Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Plan-Document-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Plan-Document-ROLE-CONST",
+    "Trigger": "Safety&AI: Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-produces-Process-Document",
     "Trigger": "Safety&AI: Process --[Produces]--> Document",
     "Template": "Engineering team shall produce the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -6136,6 +7760,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Process-Document-ROLE",
+    "Trigger": "Safety&AI: Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Process-Document-ROLE-COND",
+    "Trigger": "Safety&AI: Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Process-Document-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Process-Document-ROLE-CONST",
+    "Trigger": "Safety&AI: Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -6200,6 +7880,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-produces-Report-Document-ROLE",
+    "Trigger": "Safety&AI: Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Report-Document-ROLE-COND",
+    "Trigger": "Safety&AI: Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Report-Document-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Report-Document-ROLE-CONST",
+    "Trigger": "Safety&AI: Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-produces-Safety_Security_Case-Document",
     "Trigger": "Safety&AI: Safety & Security Case --[Produces]--> Document",
     "Template": "Engineering team shall produce the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -6248,6 +7984,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Safety_Security_Case-Document-ROLE",
+    "Trigger": "Safety&AI: Safety & Security Case --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Safety_Security_Case-Document-ROLE-COND",
+    "Trigger": "Safety&AI: Safety & Security Case --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Safety_Security_Case-Document-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Safety & Security Case --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Safety_Security_Case-Document-ROLE-CONST",
+    "Trigger": "Safety&AI: Safety & Security Case --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -6312,6 +8104,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-produces-Test_Suite-Document-ROLE",
+    "Trigger": "Safety&AI: Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Test_Suite-Document-ROLE-COND",
+    "Trigger": "Safety&AI: Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Test_Suite-Document-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-produces-Test_Suite-Document-ROLE-CONST",
+    "Trigger": "Safety&AI: Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall produce the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-responsible_for-Role-Activity",
     "Trigger": "Safety&AI: Role --[Responsible for]--> Activity",
     "Template": "Engineering team shall be responsible for the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -6360,6 +8208,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-responsible_for-Role-Activity-ROLE",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Activity",
+    "Template": "<subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-responsible_for-Role-Activity-ROLE-COND",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Activity",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-responsible_for-Role-Activity-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Activity",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-responsible_for-Role-Activity-ROLE-CONST",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Activity",
+    "Template": "<subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -6424,6 +8328,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-responsible_for-Role-Process-ROLE",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Process",
+    "Template": "<subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-responsible_for-Role-Process-ROLE-COND",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Process",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-responsible_for-Role-Process-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Process",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-responsible_for-Role-Process-ROLE-CONST",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Process",
+    "Template": "<subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-responsible_for-Role-Task",
     "Trigger": "Safety&AI: Role --[Responsible for]--> Task",
     "Template": "Engineering team shall be responsible for the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -6472,6 +8432,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-responsible_for-Role-Task-ROLE",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Task",
+    "Template": "<subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-responsible_for-Role-Task-ROLE-COND",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Task",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-responsible_for-Role-Task-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Task",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-responsible_for-Role-Task-ROLE-CONST",
+    "Trigger": "Safety&AI: Role --[Responsible for]--> Task",
+    "Template": "<subject_id> (<subject_class>) shall be responsible for the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -6536,6 +8552,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-reviews-Audit_Report-Safety_Security_Case-ROLE",
+    "Trigger": "Safety&AI: Audit Report --[Reviews]--> Safety & Security Case",
+    "Template": "<subject_id> (<subject_class>) shall reviews the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-reviews-Audit_Report-Safety_Security_Case-ROLE-COND",
+    "Trigger": "Safety&AI: Audit Report --[Reviews]--> Safety & Security Case",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall reviews the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-reviews-Audit_Report-Safety_Security_Case-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Audit Report --[Reviews]--> Safety & Security Case",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall reviews the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-reviews-Audit_Report-Safety_Security_Case-ROLE-CONST",
+    "Trigger": "Safety&AI: Audit Report --[Reviews]--> Safety & Security Case",
+    "Template": "<subject_id> (<subject_class>) shall reviews the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-synthesis-ANN-AI_Database",
     "Trigger": "Safety&AI: ANN --[Synthesis]--> AI Database",
     "Template": "Engineering team shall synthesize the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -6584,6 +8656,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-synthesis-ANN-AI_Database-ROLE",
+    "Trigger": "Safety&AI: ANN --[Synthesis]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall synthesize the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-synthesis-ANN-AI_Database-ROLE-COND",
+    "Trigger": "Safety&AI: ANN --[Synthesis]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall synthesize the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-synthesis-ANN-AI_Database-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: ANN --[Synthesis]--> AI Database",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall synthesize the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-synthesis-ANN-AI_Database-ROLE-CONST",
+    "Trigger": "Safety&AI: ANN --[Synthesis]--> AI Database",
+    "Template": "<subject_id> (<subject_class>) shall synthesize the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -6648,6 +8776,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-triage-Safety_Issue-Field_Data-ROLE",
+    "Trigger": "Safety&AI: Safety Issue --[Triage]--> Field Data",
+    "Template": "<subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-triage-Safety_Issue-Field_Data-ROLE-COND",
+    "Trigger": "Safety&AI: Safety Issue --[Triage]--> Field Data",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-triage-Safety_Issue-Field_Data-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Safety Issue --[Triage]--> Field Data",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-triage-Safety_Issue-Field_Data-ROLE-CONST",
+    "Trigger": "Safety&AI: Safety Issue --[Triage]--> Field Data",
+    "Template": "<subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-validate-Model-Test_Suite",
     "Trigger": "Safety&AI: Model --[Validate]--> Test Suite",
     "Template": "Validation team shall validate the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -6696,6 +8880,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-validate-Model-Test_Suite-ROLE",
+    "Trigger": "Safety&AI: Model --[Validate]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-validate-Model-Test_Suite-ROLE-COND",
+    "Trigger": "Safety&AI: Model --[Validate]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-validate-Model-Test_Suite-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Model --[Validate]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-validate-Model-Test_Suite-ROLE-CONST",
+    "Trigger": "Safety&AI: Model --[Validate]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -6760,6 +9000,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-validate-Plan-Report-ROLE",
+    "Trigger": "Safety&AI: Plan --[Validate]--> Report",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-validate-Plan-Report-ROLE-COND",
+    "Trigger": "Safety&AI: Plan --[Validate]--> Report",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-validate-Plan-Report-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Plan --[Validate]--> Report",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-validate-Plan-Report-ROLE-CONST",
+    "Trigger": "Safety&AI: Plan --[Validate]--> Report",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-validate-Test_Suite-Report",
     "Trigger": "Safety&AI: Test Suite --[Validate]--> Report",
     "Template": "Validation team shall validate the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -6816,6 +9112,62 @@
     "Notes": "Auto-generated from diagram rules (Safety&AI)."
   },
   {
+    "Pattern ID": "SA-validate-Test_Suite-Report-ROLE",
+    "Trigger": "Safety&AI: Test Suite --[Validate]--> Report",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-validate-Test_Suite-Report-ROLE-COND",
+    "Trigger": "Safety&AI: Test Suite --[Validate]--> Report",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-validate-Test_Suite-Report-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Test Suite --[Validate]--> Report",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-validate-Test_Suite-Report-ROLE-CONST",
+    "Trigger": "Safety&AI: Test Suite --[Validate]--> Report",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
     "Pattern ID": "SA-verify-Test_Suite-Plan",
     "Trigger": "Safety&AI: Test Suite --[Verify]--> Plan",
     "Template": "Verification team shall verify the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>).",
@@ -6864,6 +9216,62 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-verify-Test_Suite-Plan-ROLE",
+    "Trigger": "Safety&AI: Test Suite --[Verify]--> Plan",
+    "Template": "<subject_id> (<subject_class>) shall verify the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-verify-Test_Suite-Plan-ROLE-COND",
+    "Trigger": "Safety&AI: Test Suite --[Verify]--> Plan",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall verify the <object1_id> (<object1_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-verify-Test_Suite-Plan-ROLE-COND-CONST",
+    "Trigger": "Safety&AI: Test Suite --[Verify]--> Plan",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall verify the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from diagram rules (Safety&AI)."
+  },
+  {
+    "Pattern ID": "SA-verify-Test_Suite-Plan-ROLE-CONST",
+    "Trigger": "Safety&AI: Test Suite --[Verify]--> Plan",
+    "Template": "<subject_id> (<subject_class>) shall verify the <object1_id> (<object1_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<acceptance_criteria>",
@@ -6938,6 +9346,86 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_release_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_release_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_release_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_release_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -7178,6 +9666,246 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Field_Data-Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Field_Data-Document-COND",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Field_Data-Document-COND-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Field_Data-Document-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Hazard-Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Hazard-Document-COND",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Hazard-Document-COND-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Hazard-Document-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Security_Threat-Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Security_Threat-Document-COND",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Security_Threat-Document-COND-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_mitigation_role_subject-Security_Threat-Document-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Plans]--> Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), plans the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -7456,6 +10184,270 @@
     "Notes": "Auto-generated from sequence rules."
   },
   {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Field_Data-Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Field_Data-Document-COND",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Field_Data-Document-COND-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Field_Data-Document-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Hazard-Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Hazard-Document-COND",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Hazard-Document-COND-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Hazard-Document-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Security_Threat-Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Security_Threat-Document-COND",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Security_Threat-Document-COND-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-cybersecurity_threat_verification_role_subject-Security_Threat-Document-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
     "Pattern ID": "SEQ-decommissioning_validation-Plan-Document",
     "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Safety manager shall plans the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
@@ -7522,6 +10514,86 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-decommissioning_validation_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-decommissioning_validation_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-decommissioning_validation_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-decommissioning_validation_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -7616,6 +10688,86 @@
     "Notes": "Auto-generated from sequence rules."
   },
   {
+    "Pattern ID": "SEQ-deployment_readiness_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-deployment_readiness_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-deployment_readiness_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-deployment_readiness_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
     "Pattern ID": "SEQ-functional_safety_release-Plan-Document",
     "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
     "Template": "Release manager shall plans the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
@@ -7696,6 +10848,86 @@
     "Notes": "Auto-generated from sequence rules."
   },
   {
+    "Pattern ID": "SEQ-functional_safety_release_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-functional_safety_release_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-functional_safety_release_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-functional_safety_release_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
     "Pattern ID": "SEQ-governance_oversight-Plan-Document",
     "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Governance board shall plans the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
@@ -7756,6 +10988,78 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-governance_oversight_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-governance_oversight_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-governance_oversight_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-governance_oversight_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -7994,6 +11298,246 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Field_Data-Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Field_Data-Document-COND",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Field_Data-Document-COND-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Field_Data-Document-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Hazard-Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Hazard-Document-COND",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Hazard-Document-COND-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Hazard-Document-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Security_Threat-Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Security_Threat-Document-COND",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Security_Threat-Document-COND-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_mitigation_role_subject-Security_Threat-Document-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -8272,6 +11816,270 @@
     "Notes": "Auto-generated from sequence rules."
   },
   {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Field_Data-Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Field_Data-Document-COND",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Field_Data-Document-COND-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Field_Data-Document-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Hazard-Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Hazard-Document-COND",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Hazard-Document-COND-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Hazard-Document-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Security_Threat-Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Security_Threat-Document-COND",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Security_Threat-Document-COND-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-hazard_verification_role_subject-Security_Threat-Document-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), develops the <object3_id> (<object3_class>), verify the <object4_id> (<object4_class>), and produces the <object5_id> (<object5_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<object5_id>",
+      "<object5_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
     "Pattern ID": "SEQ-incident_triage-Safety_Issue-Test_Suite",
     "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite",
     "Template": "Safety manager shall triage the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>), and develops the <object2_id> (<object2_class>).",
@@ -8326,6 +12134,70 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-incident_triage_role_subject-Safety_Issue-Test_Suite",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>), and develops the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-incident_triage_role_subject-Safety_Issue-Test_Suite-COND",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>), and develops the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-incident_triage_role_subject-Safety_Issue-Test_Suite-COND-CONST",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>), and develops the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-incident_triage_role_subject-Safety_Issue-Test_Suite-CONST",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite",
+    "Template": "<subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>), and develops the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -8402,6 +12274,86 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-incident_validation_role_subject-Safety_Issue-Document",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-incident_validation_role_subject-Safety_Issue-Document-COND",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-incident_validation_role_subject-Safety_Issue-Document-COND-CONST",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-incident_validation_role_subject-Safety_Issue-Document-CONST",
+    "Trigger": "Sequence: Safety Issue --[Triage]--> Field Data --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall triage the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -8496,6 +12448,86 @@
     "Notes": "Auto-generated from sequence rules."
   },
   {
+    "Pattern ID": "SEQ-lifecycle_governance_review_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-lifecycle_governance_review_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-lifecycle_governance_review_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-lifecycle_governance_review_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
     "Pattern ID": "SEQ-maintenance_validation-Plan-Document",
     "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
     "Template": "Operations team shall plans the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
@@ -8562,6 +12594,86 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-maintenance_validation_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-maintenance_validation_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-maintenance_validation_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-maintenance_validation_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -8768,6 +12880,198 @@
     "Notes": "Auto-generated from sequence rules."
   },
   {
+    "Pattern ID": "SEQ-model_validation_role_subject-Model-Document",
+    "Trigger": "Sequence: Model --[Validate]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-model_validation_role_subject-Model-Document-COND",
+    "Trigger": "Sequence: Model --[Validate]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-model_validation_role_subject-Model-Document-COND-CONST",
+    "Trigger": "Sequence: Model --[Validate]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-model_validation_role_subject-Model-Document-CONST",
+    "Trigger": "Sequence: Model --[Validate]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-model_validation_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-model_validation_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-model_validation_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-model_validation_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-model_validation_role_subject-Test_Suite-Document",
+    "Trigger": "Sequence: Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-model_validation_role_subject-Test_Suite-Document-COND",
+    "Trigger": "Sequence: Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-model_validation_role_subject-Test_Suite-Document-COND-CONST",
+    "Trigger": "Sequence: Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-model_validation_role_subject-Test_Suite-Document-CONST",
+    "Trigger": "Sequence: Test Suite --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall validate the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
     "Pattern ID": "SEQ-organizational_accountability-Role-Document",
     "Trigger": "Sequence: Role --[Responsible for]--> Process --[Produces]--> Document",
     "Template": "Governance board shall responsible for the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>), and produces the <object2_id> (<object2_class>).",
@@ -8832,6 +13136,70 @@
     "Notes": "Auto-generated from sequence rules."
   },
   {
+    "Pattern ID": "SEQ-organizational_accountability_role_subject-Role-Document",
+    "Trigger": "Sequence: Role --[Responsible for]--> Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-organizational_accountability_role_subject-Role-Document-COND",
+    "Trigger": "Sequence: Role --[Responsible for]--> Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-organizational_accountability_role_subject-Role-Document-COND-CONST",
+    "Trigger": "Sequence: Role --[Responsible for]--> Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-organizational_accountability_role_subject-Role-Document-CONST",
+    "Trigger": "Sequence: Role --[Responsible for]--> Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall responsible for the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
     "Pattern ID": "SEQ-policy_compliance-Policy-Document",
     "Trigger": "Sequence: Policy --[Constrains]--> Process --[Produces]--> Document",
     "Template": "Governance team shall constrains the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>), and produces the <object2_id> (<object2_class>).",
@@ -8886,6 +13254,70 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-policy_compliance_role_subject-Policy-Document",
+    "Trigger": "Sequence: Policy --[Constrains]--> Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall constrains the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-policy_compliance_role_subject-Policy-Document-COND",
+    "Trigger": "Sequence: Policy --[Constrains]--> Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall constrains the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-policy_compliance_role_subject-Policy-Document-COND-CONST",
+    "Trigger": "Sequence: Policy --[Constrains]--> Process --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall constrains the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-policy_compliance_role_subject-Policy-Document-CONST",
+    "Trigger": "Sequence: Policy --[Constrains]--> Process --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall constrains the <object1_id> (<object1_class>), and produces the <object2_id> (<object2_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -8968,6 +13400,78 @@
     "Notes": "Auto-generated from sequence rules."
   },
   {
+    "Pattern ID": "SEQ-post_deployment_monitoring_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-post_deployment_monitoring_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-post_deployment_monitoring_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-post_deployment_monitoring_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
     "Pattern ID": "SEQ-product_lifecycle_safety-Plan-Document",
     "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Produces]--> Document",
     "Template": "Safety manager shall plans the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
@@ -9028,6 +13532,78 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-product_lifecycle_safety_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-product_lifecycle_safety_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-product_lifecycle_safety_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-product_lifecycle_safety_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -9280,6 +13856,246 @@
     "Notes": "Auto-generated from sequence rules."
   },
   {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Field_Data-Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Field_Data-Document-COND",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Field_Data-Document-COND-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Field_Data-Document-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Hazard-Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Hazard-Document-COND",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Hazard-Document-COND-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Hazard-Document-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Security_Threat-Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Security_Threat-Document-COND",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Security_Threat-Document-COND-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-risk_based_testing_role_subject-Security_Threat-Document-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
     "Pattern ID": "SEQ-safety_audit-Plan-Document",
     "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Auditor shall plans the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
@@ -9340,6 +14156,78 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-safety_audit_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-safety_audit_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-safety_audit_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-safety_audit_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -9432,6 +14320,86 @@
     "Notes": "Auto-generated from sequence rules."
   },
   {
+    "Pattern ID": "SEQ-safety_goal_verification_role_subject-Risk_Assessment-Document",
+    "Trigger": "Sequence: Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-safety_goal_verification_role_subject-Risk_Assessment-Document-COND",
+    "Trigger": "Sequence: Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-safety_goal_verification_role_subject-Risk_Assessment-Document-COND-CONST",
+    "Trigger": "Sequence: Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-safety_goal_verification_role_subject-Risk_Assessment-Document-CONST",
+    "Trigger": "Sequence: Risk Assessment --[Mitigates]--> Plan --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall mitigates the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
     "Pattern ID": "SEQ-security_audit-Plan-Document",
     "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
     "Template": "Security auditor shall plans the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
@@ -9492,6 +14460,78 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-security_audit_role_subject-Plan-Document",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-security_audit_role_subject-Plan-Document-COND",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-security_audit_role_subject-Plan-Document-COND-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-security_audit_role_subject-Plan-Document-CONST",
+    "Trigger": "Sequence: Plan --[Plans]--> Process --[Audits]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall plans the <object1_id> (<object1_class>), audits the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -9708,6 +14748,222 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Field_Data-Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Field_Data-Document-COND",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Field_Data-Document-COND-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Field_Data-Document-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Hazard-Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Hazard-Document-COND",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Hazard-Document-COND-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Hazard-Document-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Security_Threat-Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Security_Threat-Document-COND",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Security_Threat-Document-COND-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_validation_role_subject-Security_Threat-Document-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), and produces the <object3_id> (<object3_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",
@@ -9960,6 +15216,246 @@
     "Notes": "Auto-generated from sequence rules."
   },
   {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Field_Data-Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Field_Data-Document-COND",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Field_Data-Document-COND-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Field_Data-Document-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Hazard-Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Hazard-Document-COND",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Hazard-Document-COND-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Hazard-Document-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Security_Threat-Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Security_Threat-Document-COND",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Security_Threat-Document-COND-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-sotif_scenario_verification_role_subject-Security_Threat-Document-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Develops]--> Test Suite --[Verify]--> Plan --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), develops the <object2_id> (<object2_class>), verify the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
     "Pattern ID": "SEQ-threat_analysis_validation-Field_Data-Document",
     "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
     "Template": "Cybersecurity team shall assesses the <object1_id> (<object1_class>) using the <object0_id> (<object0_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
@@ -10186,6 +15682,246 @@
     "Variables": [
       "<object0_id>",
       "<object0_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Field_Data-Document",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Field_Data-Document-COND",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Field_Data-Document-COND-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Field_Data-Document-CONST",
+    "Trigger": "Sequence: Field Data --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Hazard-Document",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Hazard-Document-COND",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Hazard-Document-COND-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Hazard-Document-CONST",
+    "Trigger": "Sequence: Hazard --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Security_Threat-Document",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Security_Threat-Document-COND",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>).",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Security_Threat-Document-COND-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "When <condition>, <subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
+      "<object1_id>",
+      "<object1_class>",
+      "<object2_id>",
+      "<object2_class>",
+      "<object3_id>",
+      "<object3_class>",
+      "<object4_id>",
+      "<object4_class>",
+      "<acceptance_criteria>",
+      "<condition>",
+      "<constraint>"
+    ],
+    "Notes": "Auto-generated from sequence rules."
+  },
+  {
+    "Pattern ID": "SEQ-threat_analysis_validation_role_subject-Security_Threat-Document-CONST",
+    "Trigger": "Sequence: Security Threat --[Assesses]--> Risk Assessment --[Mitigates]--> Plan --[Validate]--> Report --[Produces]--> Document",
+    "Template": "<subject_id> (<subject_class>) shall assesses the <object1_id> (<object1_class>), mitigates the <object2_id> (<object2_class>), validate the <object3_id> (<object3_class>), and produces the <object4_id> (<object4_class>) constrained by <constraint>.",
+    "Variables": [
+      "<subject_id>",
+      "<subject_class>",
       "<object1_id>",
       "<object1_class>",
       "<object2_id>",

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -81,6 +81,11 @@ _PLAN_TYPES = {
     "Verification Plan",
 }
 
+# Create Safety & AI Lifecycle toolbox frame
+# Create toolbox for additional governance elements
+# Create toolbox for additional governance elements grouped by class
+# Repack toolbox to include selector
+
 
 def _normalize_plan_types(items: list[str]) -> list[str]:
     """Replace specific plan variants with generic 'Plan' and deduplicate."""
@@ -11190,11 +11195,25 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
 
     def _switch_toolbox(self) -> None:
         choice = self.toolbox_var.get()
-        for frames in self._toolbox_frames.values():
+        frames_map = getattr(
+            self,
+            "_toolbox_frames",
+            {
+                "Governance": [
+                    getattr(self, "gov_tools_frame", None),
+                    getattr(self, "gov_rel_frame", None),
+                    getattr(self, "gov_elements_frame", None),
+                ],
+                "Safety & AI Lifecycle": [
+                    getattr(self, "ai_tools_frame", None)
+                ],
+            },
+        )
+        for frames in frames_map.values():
             for frame in frames:
                 if frame and hasattr(frame, "pack_forget"):
                     frame.pack_forget()
-        for frame in self._toolbox_frames.get(choice, []):
+        for frame in frames_map.get(choice, []):
             if frame and hasattr(frame, "pack"):
                 frame.pack(fill=tk.X, padx=2, pady=2)
 

--- a/tests/test_requirement_rule_generator.py
+++ b/tests/test_requirement_rule_generator.py
@@ -120,7 +120,7 @@ def test_rule_role_subject_variant() -> None:
         for p in patterns
         if p["Pattern ID"] == "SA-annotation-ANN-AI_Database-ROLE"
     )
-    assert tmpl.startswith("<object0_id> (<object0_class>) shall annotate")
+    assert tmpl.startswith("<subject_id> (<subject_class>) shall annotate")
     assert "using the <object0_id>" not in tmpl
 
 
@@ -162,7 +162,7 @@ def test_sequence_role_subject() -> None:
     patterns = generate_patterns_from_config(cfg)
     pid = "SEQ-accountability-Role-Document"
     tmpl = next(p["Template"] for p in patterns if p["Pattern ID"] == pid)
-    assert tmpl.startswith("<object0_id> (<object0_class>) shall responsible for")
+    assert tmpl.startswith("<subject_id> (<subject_class>) shall responsible for")
     assert "using the <object0_id>" not in tmpl
 
 


### PR DESCRIPTION
## Summary
- replace subject `<object0_id>` placeholder with `<subject_id>` across requirement pattern generation
- allow governance patterns to recognise `<subject_id>` and update generated patterns
- add toolbox comments and resilient switching for governance/safety toolboxes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3806ec8908327bd1bcf380fca8040