### PR TITLE
Close tabs on lifecycle phase change

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9459,6 +9459,44 @@ class FaultTreeApp:
             for ch in getattr(widget, "winfo_children", lambda: [])():
                 _refresh_children(ch)
 
+        toolbox = getattr(self, "safety_mgmt_toolbox", None)
+        enabled = toolbox.enabled_products() if toolbox else set()
+        repo = SysMLRepository.get_instance()
+        tab_map = {
+            "Threat": "Threat Analysis",
+            "FMEA List": "FMEA",
+            "FMEDA List": "FMEDA",
+            "Causal Bayesian Network": "Causal Bayesian Network Analysis",
+        }
+        if hasattr(self, "doc_nb"):
+            for tab_id in list(self.doc_nb.tabs()):
+                widget = self.doc_nb.nametowidget(tab_id)
+                # Close diagrams not visible in the active phase
+                for did, tab in list(getattr(self, "diagram_tabs", {}).items()):
+                    if tab is widget and not repo.diagram_visible(did):
+                        self.doc_nb._closing_tab = tab_id
+                        self.doc_nb.event_generate("<<NotebookTabClosed>>")
+                        if tab_id in self.doc_nb.tabs():
+                            try:
+                                self.doc_nb.forget(tab_id)
+                            except Exception:
+                                pass
+                        self.diagram_tabs.pop(did, None)
+                        break
+                else:
+                    title = self._tab_titles.get(tab_id, self.doc_nb.tab(tab_id, "text"))
+                    product = tab_map.get(title, title)
+                    if product not in enabled:
+                        self.doc_nb._closing_tab = tab_id
+                        self.doc_nb.event_generate("<<NotebookTabClosed>>")
+                        if tab_id in self.doc_nb.tabs():
+                            try:
+                                self.doc_nb.forget(tab_id)
+                            except Exception:
+                                pass
+                    else:
+                        _refresh_children(widget)
+
         for tab in getattr(self, "diagram_tabs", {}).values():
             _refresh_children(tab)
 

--- a/tests/test_phase_tab_closure.py
+++ b/tests/test_phase_tab_closure.py
@@ -1,0 +1,73 @@
+import types
+import AutoML
+from AutoML import FaultTreeApp
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule, SafetyWorkProduct
+
+
+def test_phase_change_closes_ungoverned_tabs(monkeypatch):
+    class DummyFrame:
+        def __init__(self, master=None, **kw):
+            pass
+        def winfo_children(self):
+            return []
+    class DummyNotebook:
+        def __init__(self):
+            self._tabs = []
+            self._titles = {}
+            self._widgets = {}
+            self._closing_tab = None
+            self.protected = set()
+        def tabs(self):
+            return list(self._tabs)
+        def add(self, widget, text):
+            tab_id = f"id{len(self._tabs)}"
+            self._tabs.append(tab_id)
+            self._titles[tab_id] = text
+            self._widgets[tab_id] = widget
+        def select(self, tab):
+            pass
+        def tab(self, tab_id, option):
+            return self._titles[tab_id]
+        def nametowidget(self, tab_id):
+            return self._widgets[tab_id]
+        def forget(self, tab_id):
+            self._tabs.remove(tab_id)
+            self._titles.pop(tab_id, None)
+            self._widgets.pop(tab_id, None)
+        def event_generate(self, event):
+            pass
+    monkeypatch.setattr(AutoML, "ttk", types.SimpleNamespace(Frame=lambda *a, **k: DummyFrame()))
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.doc_nb = DummyNotebook()
+    app._tab_titles = {}
+    app.diagram_tabs = {}
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1", diagrams=["Gov1"]), GovernanceModule("P2")]
+    toolbox.work_products = [SafetyWorkProduct("Gov1", "Threat Analysis")]
+    toolbox.set_active_module("P1")
+    app.safety_mgmt_toolbox = toolbox
+    class DummyVar:
+        def __init__(self, val=""):
+            self.val = val
+        def set(self, v):
+            self.val = v
+        def get(self):
+            return self.val
+    app.lifecycle_var = DummyVar("P1")
+    app.update_views = lambda: None
+    app.refresh_tool_enablement = lambda: None
+    app.refresh_all = lambda: None
+    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(app, FaultTreeApp)
+    class DummyThreatWindow(DummyFrame):
+        def __init__(self, master, app):
+            super().__init__(master)
+        def refresh_docs(self):
+            pass
+        def winfo_exists(self):
+            return True
+    monkeypatch.setattr(AutoML, "ThreatWindow", DummyThreatWindow)
+    app.open_threat_window()
+    assert app.doc_nb.tabs()
+    app.lifecycle_var.set("P2")
+    app.on_lifecycle_selected()
+    assert not app.doc_nb.tabs()


### PR DESCRIPTION
## Summary
- close document tabs not governed in selected lifecycle phase
- refresh remaining tabs to show only items from active phase
- add regression test for tab cleanup when switching phases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3981ee3bc8327b37fcee2370c3d06