### PR TITLE
feat(gui): centralize table creation

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 """Shared GUI helpers and widget customizations."""
 
+import tkinter as tk
 from tkinter import ttk
 
 
@@ -37,10 +38,145 @@ def add_treeview_scrollbars(tree: ttk.Treeview, container: ttk.Widget | None = N
     container.columnconfigure(0, weight=1)
 
 
+class TableController(ttk.Treeview):
+    """Unified table widget with common styling, editing and numbering.
+
+    This controller is meant to standardize all table widgets across the
+    application.  It automatically applies a common style, attaches
+    scrollbars, enables in-place editing on double click and enumerates the
+    visible rows.
+    """
+
+    def __init__(
+        self,
+        master: ttk.Widget | None = None,
+        *,
+        columns: tuple[str, ...] | list[str] | None = None,
+        rowheight: int = 60,
+        enumerate_rows: bool | None = None,
+        **kwargs,
+    ) -> None:
+        container = kwargs.pop("container", None)
+        columns = columns or kwargs.get("columns") or ()
+
+        # Only enumerate rows when explicit columns are supplied (i.e. table
+        # mode).  Tree based views that rely on the default column remain
+        # untouched.
+        if enumerate_rows is None:
+            enumerate_rows = bool(columns)
+        self._enumerate = enumerate_rows
+
+        show = kwargs.get("show", "headings" if columns else "tree")
+
+        if self._enumerate:
+            # Prepend a dedicated enumeration column that doesn't interfere
+            # with the tree column used by existing widgets.
+            columns = list(columns)
+            columns.insert(0, "#")
+        kwargs["columns"] = columns
+        kwargs["show"] = show
+
+        # Configure a uniform style
+        style_name = kwargs.pop("style", "AutoML.Treeview")
+        style = ttk.Style()
+        try:
+            style.theme_use("clam")
+        except tk.TclError:
+            pass
+        style.configure(
+            style_name,
+            font=("Segoe UI", 10),
+            rowheight=rowheight,
+            borderwidth=1,
+            relief="solid",
+            bordercolor="black",
+        )
+        style.configure(
+            f"{style_name}.Heading",
+            font=("Segoe UI", 10, "bold"),
+            background="#d0d0d0",
+            borderwidth=1,
+            relief="raised",
+            bordercolor="black",
+        )
+        kwargs["style"] = style_name
+
+        super().__init__(master, **kwargs)
+
+        # Set up enumeration column
+        if self._enumerate:
+            self.heading("#", text="#")
+            self.column("#", width=40, anchor="e", stretch=False)
+            self._renumber()
+
+        # Attach scrollbars by default
+        add_treeview_scrollbars(self, container)
+
+        # Enable basic in-place editing
+        self._edit_widget: tk.Widget | None = None
+        self.bind("<Double-1>", self._begin_edit, add="+")
+
+    # ------------------------------------------------------------------
+    # row enumeration helpers
+    # ------------------------------------------------------------------
+    def _renumber(self) -> None:
+        if not self._enumerate:
+            return
+        for i, iid in enumerate(self.get_children(""), start=1):
+            self.set(iid, "#", str(i))
+
+    def insert(self, parent: str = "", index: str | int = "end", iid=None, **kw):
+        item = super().insert(parent, index, iid=iid, **kw)
+        self._renumber()
+        return item
+
+    def delete(self, *items):  # type: ignore[override]
+        super().delete(*items)
+        self._renumber()
+
+    # ------------------------------------------------------------------
+    # basic edit support
+    # ------------------------------------------------------------------
+    def _begin_edit(self, event):
+        if self._edit_widget:
+            return
+        region = self.identify("region", event.x, event.y)
+        if region != "cell":
+            return
+        rowid = self.identify_row(event.y)
+        col = self.identify_column(event.x)
+        if not rowid or not col:
+            return
+        if self._enumerate and col == "#1":
+            return
+        col_index = int(col.replace("#", "")) - 1
+        col_name = self.cget("columns")[col_index]
+        value = self.set(rowid, col_name)
+        x, y, w, h = self.bbox(rowid, col)
+        var = tk.StringVar(value=value)
+        widget = tk.Entry(self, textvariable=var)
+        widget.place(x=x, y=y, width=w, height=h)
+        widget.focus_set()
+
+        def save(event=None):
+            self.set(rowid, col_name, var.get())
+            widget.destroy()
+            self._edit_widget = None
+
+        widget.bind("<Return>", save)
+        widget.bind("<FocusOut>", save)
+        self._edit_widget = widget
+
+
+# Replace default Treeview with the consolidated controller
+_BaseTreeview = ttk.Treeview
+ttk.Treeview = TableController
+
+
 # ---------------------------------------------------------------------------
 # Enable clickable column sorting for all ttk.Treeview tables
 # ---------------------------------------------------------------------------
-_orig_heading = ttk.Treeview.heading
+_orig_heading = _BaseTreeview.heading
 
 
 def _sortable_heading(self, column, option=None, **kw):


### PR DESCRIPTION
## Summary
- add TableController wrapper around `ttk.Treeview` for consistent styling and behavior
- apply automatic row enumeration, scrollbars, and in-place editing
- globally replace default Treeview with controller
- ensure row numbers appear in dedicated `#` column for all tables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a39797e1dc8327905ed01d2c17579d