### PR TITLE
fix: open diagrams from AutoML explorer

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -12334,19 +12334,16 @@ class ArchitectureManagerDialog(tk.Frame):
 
         # If an application instance is available, open the diagram using
         # the main document notebook so duplicate tabs are avoided.
-        if self.app and hasattr(self.app, "diagram_tabs"):
-            idx = next(
-                (i for i, d in enumerate(self.app.arch_diagrams) if d.diag_id == diag_id),
-                -1,
-            )
-            if idx != -1:
-                self.app.open_arch_window(idx)
-                tab = self.app.diagram_tabs.get(diag_id)
-                if tab and tab.winfo_exists():
-                    for child in tab.winfo_children():
-                        if isinstance(child, SysMLDiagramWindow):
-                            return child
-                return None
+        if self.app and hasattr(self.app, "open_arch_window") and hasattr(
+            self.app, "diagram_tabs"
+        ):
+            self.app.open_arch_window(diag_id)
+            tab = self.app.diagram_tabs.get(diag_id)
+            if tab and tab.winfo_exists():
+                for child in tab.winfo_children():
+                    if isinstance(child, SysMLDiagramWindow):
+                        return child
+            return None
 
         master = self.master if self.master else self
         win = None

--- a/tests/test_architecture_open_diagram.py
+++ b/tests/test_architecture_open_diagram.py
@@ -1,0 +1,26 @@
+import types
+
+from gui.architecture import ArchitectureManagerDialog
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_open_diagram_uses_diag_id():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Use Case Diagram", name="UC")
+
+    called = []
+
+    def fake_open_arch_window(arg):
+        called.append(arg)
+
+    app = types.SimpleNamespace(open_arch_window=fake_open_arch_window, diagram_tabs={})
+
+    explorer = ArchitectureManagerDialog.__new__(ArchitectureManagerDialog)
+    explorer.repo = repo
+    explorer.app = app
+    explorer.master = None
+
+    explorer.open_diagram(diag.diag_id)
+
+    assert called == [diag.diag_id]


### PR DESCRIPTION
## Summary
- ensure AutoML Explorer uses diagram IDs when opening diagrams
- add test to prevent regression when opening diagrams

## Testing
- `pytest tests/test_architecture_open_diagram.py tests/test_governance_actions.py tests/test_governance_phase_toggle.py::test_open_diagram_updates_phase_combobox -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3a3c6099483279530a634e8360469