### PR TITLE
chore: remove governance diagram option

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -11954,7 +11954,6 @@ class NewDiagramDialog(simpledialog.Dialog):
                 values=[
                     "Use Case Diagram",
                     "Activity Diagram",
-                    "Governance Diagram",
                     "Block Diagram",
                     "Internal Block Diagram",
                     "Control Flow Diagram",


### PR DESCRIPTION
## Summary
- Remove Governance Diagram from New Diagram dialog options so users can't select it when creating diagrams

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3a42d32808327bfc1ca916d9be7ef