### PR TITLE
Render use cases as ovals

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -7641,15 +7641,14 @@ class SysMLDiagramWindow(tk.Frame):
                 fill=outline,
             )
         elif obj.obj_type == "Use Case":
-            radius = min(w, h)
-            self.drawing_helper._fill_gradient_circle(
-                self.canvas, x, y, radius, color
+            self.drawing_helper._fill_gradient_oval(
+                self.canvas, x, y, w, h, color
             )
             self.canvas.create_oval(
-                x - radius,
-                y - radius,
-                x + radius,
-                y + radius,
+                x - w,
+                y - h,
+                x + w,
+                y + h,
                 fill="",
                 outline=outline,
             )

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -124,6 +124,33 @@ class FTADrawingHelper:
             x += 0.5
         return ids
 
+    def _fill_gradient_oval(
+        self,
+        canvas,
+        cx: float,
+        cy: float,
+        rx: float,
+        ry: float,
+        color: str,
+        tag: str | None = None,
+    ) -> list[int]:
+        """Fill ellipse with gradient from white to *color* and return created line IDs."""
+        left = math.floor(cx - rx)
+        right = math.ceil(cx + rx)
+        if right <= left or rx == 0 or ry == 0:
+            return []
+        ids: list[int] = []
+        x = left
+        while x <= right:
+            ratio = (x - left) / (right - left) if right > left else 1
+            fill = self._interpolate_color(color, ratio)
+            dx = x - cx
+            dy = ry * math.sqrt(max(1 - (dx / rx) ** 2, 0))
+            line_id = canvas.create_line(x, cy - dy, x, cy + dy, fill=fill, tags=tag)
+            ids.append(line_id)
+            x += 0.5
+        return ids
+
     def _fill_gradient_rect(self, canvas, left: float, top: float, right: float, bottom: float, color: str) -> None:
         """Fill rectangle with gradient from white to *color*."""
         if right <= left:

--- a/tests/test_use_case_shape.py
+++ b/tests/test_use_case_shape.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+import tkinter.font as tkFont
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import SysMLDiagramWindow
+from gui.style_manager import StyleManager
+
+
+class DummyFont:
+    def configure(self, **kwargs):
+        pass
+
+
+class DummyCanvas:
+    def __init__(self):
+        self.oval_coords = None
+
+    def create_oval(self, x1, y1, x2, y2, **kwargs):
+        self.oval_coords = (x1, y1, x2, y2)
+
+    def create_text(self, *args, **kwargs):
+        pass
+
+    def create_polygon(self, *args, **kwargs):
+        pass
+
+    def create_rectangle(self, *args, **kwargs):
+        pass
+
+    def create_line(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture
+def dummy_window(monkeypatch):
+    monkeypatch.setattr(tkFont, "Font", lambda *a, **k: DummyFont())
+    StyleManager._instance = None
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.zoom = 1
+    win.canvas = DummyCanvas()
+    win.drawing_helper = SimpleNamespace(_fill_gradient_oval=lambda *a, **k: None)
+    win.font = DummyFont()
+    win.selected_objs = set()
+    win.repo = SimpleNamespace(
+        elements={}, diagrams={}, element_diagrams={}, relationships=[], get_linked_diagram=lambda _id: None
+    )
+    win.diagram_id = "D1"
+    return win
+
+
+def test_use_case_draws_oval(dummy_window):
+    class DummyObj(SimpleNamespace):
+        __hash__ = object.__hash__
+
+    obj = DummyObj(
+        obj_type="Use Case",
+        x=0,
+        y=0,
+        width=100,
+        height=60,
+        obj_id=1,
+        properties={},
+        element_id=None,
+        phase="",
+        requirements=[],
+    )
+    dummy_window.draw_object(obj)
+    x1, y1, x2, y2 = dummy_window.canvas.oval_coords
+    assert x2 - x1 == pytest.approx(100)
+    assert y2 - y1 == pytest.approx(60)


### PR DESCRIPTION
## Summary
- draw use case nodes as ovals instead of circles
- add gradient helper for ellipses
- cover use case shape drawing with unit test

## Testing
- `pytest tests/test_use_case_shape.py tests/test_standard_shape_label.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3a44023f083278739cdd3ca145310