### PR TITLE
Enforce lifecycle governance visibility

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -370,7 +370,7 @@ class SafetyManagementToolbox:
             )
             phase = diag.phase if diag else None
         if phase is None:
-            return True
+            return False
         if phase == self.active_module:
             return True
         reuse = self._reuse_map().get(self.active_module, {})

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -494,8 +494,10 @@ class SysMLRepository:
         elem = self.elements.get(elem_id)
         if not elem:
             return False
-        if self.active_phase is None or elem.phase is None:
+        if self.active_phase is None:
             return True
+        if elem.phase is None:
+            return False
         if elem.phase == self.active_phase or elem.phase in getattr(self, "reuse_phases", set()):
             return True
         diag_id = self.element_diagrams.get(elem_id)
@@ -512,8 +514,12 @@ class SysMLRepository:
             return False
         if "safety-management" in getattr(diag, "tags", []):
             return True
-        if self.active_phase is None or diag.phase is None:
+        if self.active_phase is None:
             return True
+        if diag.diag_type == "Governance Diagram" and diag.phase is None:
+            return True
+        if diag.phase is None:
+            return False
         if diag.phase == self.active_phase or diag.phase in getattr(self, "reuse_phases", set()):
             return True
         return diag.diag_type in getattr(self, "reuse_products", set())
@@ -607,8 +613,12 @@ class SysMLRepository:
         diag = self.diagrams.get(diag_id) if diag_id else None
         if diag and ("safety-management" in getattr(diag, "tags", []) or diag.diag_type in getattr(self, "reuse_products", set())):
             return True
-        if self.active_phase is None or obj.get("phase") is None:
+        if self.active_phase is None:
             return True
+        if diag and diag.diag_type == "Governance Diagram" and obj.get("phase") is None:
+            return True
+        if obj.get("phase") is None:
+            return False
         return obj.get("phase") == self.active_phase or obj.get("phase") in getattr(self, "reuse_phases", set())
 
     def connection_visible(self, conn: dict, diag_id: Optional[str] = None) -> bool:
@@ -616,8 +626,12 @@ class SysMLRepository:
         diag = self.diagrams.get(diag_id) if diag_id else None
         if diag and ("safety-management" in getattr(diag, "tags", []) or diag.diag_type in getattr(self, "reuse_products", set())):
             return True
-        if self.active_phase is None or conn.get("phase") is None:
+        if self.active_phase is None:
             return True
+        if diag and diag.diag_type == "Governance Diagram" and conn.get("phase") is None:
+            return True
+        if conn.get("phase") is None:
+            return False
         return conn.get("phase") == self.active_phase or conn.get("phase") in getattr(self, "reuse_phases", set())
 
     def visible_objects(self, diag_id: str) -> list[dict]:

--- a/tests/test_lifecycle_phase_enforces_governance.py
+++ b/tests/test_lifecycle_phase_enforces_governance.py
@@ -1,0 +1,20 @@
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from sysml.sysml_repository import SysMLRepository
+
+def test_diagram_and_elements_hidden_without_phase():
+    repo = SysMLRepository.reset_instance()
+    # create diagram and element before any lifecycle phase is active
+    diag = repo.create_diagram("Control Flow Diagram", name="CF")
+    elem = repo.create_element("Block", name="B1")
+    repo.add_element_to_diagram(diag.diag_id, elem.elem_id)
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1"), GovernanceModule("P2")]
+    # activate first phase
+    toolbox.set_active_module("P1")
+    # diagram and element were created without a phase, so they should now be hidden
+    assert not repo.diagram_visible(diag.diag_id)
+    assert diag.diag_id not in repo.visible_diagrams()
+    assert elem.elem_id not in repo.visible_elements()
+    # document visibility is also blocked
+    assert not toolbox.document_visible("Control Flow Diagram", diag.name)
+


### PR DESCRIPTION
## Summary
- hide diagrams, elements, and connections lacking a lifecycle phase when a phase is active
- block documents without phase assignments from appearing outside a lifecycle
- cover phase gating with a regression test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a3a504260c83278a199a3069814161