### PR TITLE
feat: enrich explorer icons

### DIFF
--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -37,19 +37,25 @@ class GSNExplorer(tk.Frame):
         tree_frame.rowconfigure(0, weight=1)
         tree_frame.columnconfigure(0, weight=1)
 
-        # detailed icons to visually distinguish elements
-        self.module_icon = self._create_icon("folder", "#b8860b")
-        self.diagram_icon = self._create_icon("rect", "#4682b4")
+        # Detailed, colour-coded icons to visually distinguish elements
+        style = StyleManager.get_instance()
+
+        def _color(name: str, default: str) -> str:
+            c = style.get_color(name)
+            return default if c == "#FFFFFF" else c
+
+        self.module_icon = self._create_icon("folder", _color("Lifecycle Phase", "#b8860b"))
+        self.diagram_icon = self._create_icon("document", _color("Document", "#4682b4"))
         self.node_icons = {
-            "Goal": self._create_icon("rect", "#2e8b57"),
-            "Strategy": self._create_icon("diamond", "#8b008b"),
-            "Solution": self._create_icon("circle", "#1e90ff"),
-            "Assumption": self._create_icon("rect", "#b22222"),
-            "Justification": self._create_icon("rect", "#ff8c00"),
-            "Context": self._create_icon("rect", "#696969"),
+            "Goal": self._create_icon("shield", _color("Safety Goal", "#2e8b57")),
+            "Strategy": self._create_icon("clipboard", _color("Strategy", "#8b008b")),
+            "Solution": self._create_icon("shield_check", _color("Solution", "#1e90ff")),
+            "Assumption": self._create_icon("triangle", _color("Assumption", "#b22222")),
+            "Justification": self._create_icon("scale", _color("Justification", "#ff8c00")),
+            "Context": self._create_icon("document", _color("Document", "#696969")),
             "Module": self.module_icon,
         }
-        self.default_node_icon = self._create_icon("rect")
+        self.default_node_icon = self._create_icon("document", _color("Existing Element", "gray"))
         self.item_map: dict[str, tuple[str, object]] = {}
 
         btns = ttk.Frame(self)

--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -36,6 +36,7 @@ from analysis.safety_case import SafetyCaseLibrary, SafetyCase
 from gui import messagebox, format_name_with_phase
 from gui.safety_case_table import SafetyCaseTable
 from gui.icon_factory import create_icon
+from gui.style_manager import StyleManager
 
 
 class SafetyCaseExplorer(tk.Frame):
@@ -74,8 +75,14 @@ class SafetyCaseExplorer(tk.Frame):
         tree_frame.rowconfigure(0, weight=1)
         tree_frame.columnconfigure(0, weight=1)
 
-        self.case_icon = self._create_icon("folder", "#b8860b")
-        self.solution_icon = self._create_icon("circle", "#1e90ff")
+        style = StyleManager.get_instance()
+
+        def _color(name: str, default: str) -> str:
+            c = style.get_color(name)
+            return default if c == "#FFFFFF" else c
+
+        self.case_icon = self._create_icon("shield", _color("Safety Case", "#b8860b"))
+        self.solution_icon = self._create_icon("shield_check", _color("Solution", "#1e90ff"))
         self.item_map: Dict[str, Tuple[str, object]] = {}
 
         self.tree.bind("<Double-1>", self._on_double_click)

--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -11,6 +11,7 @@ import re
 
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
 from gui.icon_factory import create_icon
+from gui.style_manager import StyleManager
 
 
 def _strip_phase_suffix(name: str) -> str:
@@ -57,8 +58,14 @@ class SafetyManagementExplorer(tk.Frame):
         tree_frame.rowconfigure(0, weight=1)
         tree_frame.columnconfigure(0, weight=1)
 
-        self.folder_icon = self._create_icon("folder", "#b8860b")
-        self.diagram_icon = self._create_icon("rect", "#4682b4")
+        style = StyleManager.get_instance()
+
+        def _color(name: str, default: str) -> str:
+            c = style.get_color(name)
+            return default if c == "#FFFFFF" else c
+
+        self.folder_icon = self._create_icon("folder", _color("Lifecycle Phase", "#b8860b"))
+        self.diagram_icon = self._create_icon("document", _color("Document", "#4682b4"))
         self.item_map: Dict[str, tuple[str, object]] = {}
         self.root_iid = ""
 


### PR DESCRIPTION
## Summary
- Use style-aware icons for GSN explorer elements
- Adopt shield-based icons for safety cases and solutions
- Apply consistent document and folder icons in safety management explorer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3a6097b248327a06da0fb7e6fc182