### PR TITLE
Enforce lifecycle governance visibility

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -370,7 +370,7 @@ class SafetyManagementToolbox:
             )
             phase = diag.phase if diag else None
         if phase is None:
-            return True
+            return False
         if phase == self.active_module:
             return True
         reuse = self._reuse_map().get(self.active_module, {})

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4326,8 +4326,21 @@ class SysMLDiagramWindow(tk.Frame):
                 id_map = {}
                 diag = self.repo.diagrams.get(self.diagram_id)
                 allowed = {"Actor", "Block"} if diag and diag.diag_type == "Control Flow Diagram" else None
+                toolbox = getattr(getattr(self, "app", None), "safety_mgmt_toolbox", None)
+                allowed_sources = (
+                    toolbox.analysis_inputs(diag.diag_type)
+                    if toolbox and diag
+                    else None
+                )
                 for eid, el in self.repo.elements.items():
                     if el.elem_type != "Package" and (not allowed or el.elem_type in allowed):
+                        if allowed_sources is not None:
+                            src_id = self.repo.element_diagrams.get(eid)
+                            src_diag = self.repo.diagrams.get(src_id) if src_id else None
+                            if not src_diag or src_diag.diag_type not in allowed_sources:
+                                continue
+                            if not toolbox.document_visible(src_diag.diag_type, src_diag.name):
+                                continue
                         name = el.name or eid
                         names.append(name)
                         id_map[name] = eid

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -494,8 +494,10 @@ class SysMLRepository:
         elem = self.elements.get(elem_id)
         if not elem:
             return False
-        if self.active_phase is None or elem.phase is None:
+        if self.active_phase is None:
             return True
+        if elem.phase is None:
+            return False
         if elem.phase == self.active_phase or elem.phase in getattr(self, "reuse_phases", set()):
             return True
         diag_id = self.element_diagrams.get(elem_id)
@@ -512,8 +514,12 @@ class SysMLRepository:
             return False
         if "safety-management" in getattr(diag, "tags", []):
             return True
-        if self.active_phase is None or diag.phase is None:
+        if self.active_phase is None:
             return True
+        if diag.diag_type == "Governance Diagram" and diag.phase is None:
+            return True
+        if diag.phase is None:
+            return False
         if diag.phase == self.active_phase or diag.phase in getattr(self, "reuse_phases", set()):
             return True
         return diag.diag_type in getattr(self, "reuse_products", set())
@@ -607,8 +613,12 @@ class SysMLRepository:
         diag = self.diagrams.get(diag_id) if diag_id else None
         if diag and ("safety-management" in getattr(diag, "tags", []) or diag.diag_type in getattr(self, "reuse_products", set())):
             return True
-        if self.active_phase is None or obj.get("phase") is None:
+        if self.active_phase is None:
             return True
+        if diag and diag.diag_type == "Governance Diagram" and obj.get("phase") is None:
+            return True
+        if obj.get("phase") is None:
+            return False
         return obj.get("phase") == self.active_phase or obj.get("phase") in getattr(self, "reuse_phases", set())
 
     def connection_visible(self, conn: dict, diag_id: Optional[str] = None) -> bool:
@@ -616,8 +626,12 @@ class SysMLRepository:
         diag = self.diagrams.get(diag_id) if diag_id else None
         if diag and ("safety-management" in getattr(diag, "tags", []) or diag.diag_type in getattr(self, "reuse_products", set())):
             return True
-        if self.active_phase is None or conn.get("phase") is None:
+        if self.active_phase is None:
             return True
+        if diag and diag.diag_type == "Governance Diagram" and conn.get("phase") is None:
+            return True
+        if conn.get("phase") is None:
+            return False
         return conn.get("phase") == self.active_phase or conn.get("phase") in getattr(self, "reuse_phases", set())
 
     def visible_objects(self, diag_id: str) -> list[dict]:

--- a/tests/test_existing_element_governance.py
+++ b/tests/test_existing_element_governance.py
@@ -1,0 +1,82 @@
+import types
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from sysml.sysml_repository import SysMLRepository
+from gui.architecture import SysMLDiagramWindow, SysMLObjectDialog
+from analysis.safety_management import SafetyManagementToolbox
+
+
+def test_existing_element_respects_governance(monkeypatch):
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+
+    # Source architecture diagram with an element
+    arch = repo.create_diagram("Architecture Diagram", name="Arch")
+    elem = repo.create_element("Block", name="B1")
+    repo.add_element_to_diagram(arch.diag_id, elem.elem_id)
+    repo.link_diagram(elem.elem_id, arch.diag_id)
+
+    # Target control flow diagram
+    cfd = repo.create_diagram("Control Flow Diagram", name="CFD")
+
+    toolbox = SafetyManagementToolbox()
+    app = types.SimpleNamespace(safety_mgmt_toolbox=toolbox)
+
+    class DummyCanvas:
+        def canvasx(self, v):
+            return v
+
+        def canvasy(self, v):
+            return v
+
+    class DummyWin:
+        def __init__(self):
+            self.repo = repo
+            self.diagram_id = cfd.diag_id
+            self.zoom = 1
+            self.current_tool = "Existing Element"
+            self.canvas = DummyCanvas()
+            self.app = app
+            self.objects = []
+
+        def find_object(self, *a, **k):
+            return None
+
+    win = DummyWin()
+    event = types.SimpleNamespace(x=0, y=0, state=0)
+
+    messages = []
+    monkeypatch.setattr("gui.architecture.messagebox.showinfo", lambda *a, **k: messages.append(a))
+
+    captured = []
+
+    class DummyDialog:
+        def __init__(self, parent, names, title="Select Element"):
+            captured.extend(names)
+            self.result = None
+
+    monkeypatch.setattr(SysMLObjectDialog, "SelectElementDialog", DummyDialog)
+
+    # Without governance no elements are available
+    SysMLDiagramWindow.on_left_press(win, event)
+    assert messages and not captured
+
+    # Establish governance: Architecture Diagram -> Control Flow Diagram
+    gov = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams["Gov"] = gov.diag_id
+    gov.objects = [
+        {"obj_id": 1, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "Architecture Diagram"}},
+        {"obj_id": 2, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "Control Flow Diagram"}},
+    ]
+    gov.connections = [{"src": 1, "dst": 2, "conn_type": "Used By"}]
+    toolbox.add_work_product("Gov", "Architecture Diagram", "")
+    toolbox.add_work_product("Gov", "Control Flow Diagram", "")
+
+    messages.clear()
+    captured.clear()
+    SysMLDiagramWindow.on_left_press(win, event)
+    assert not messages
+    assert captured == ["B1"]

--- a/tests/test_lifecycle_phase_enforces_governance.py
+++ b/tests/test_lifecycle_phase_enforces_governance.py
@@ -1,0 +1,20 @@
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from sysml.sysml_repository import SysMLRepository
+
+def test_diagram_and_elements_hidden_without_phase():
+    repo = SysMLRepository.reset_instance()
+    # create diagram and element before any lifecycle phase is active
+    diag = repo.create_diagram("Control Flow Diagram", name="CF")
+    elem = repo.create_element("Block", name="B1")
+    repo.add_element_to_diagram(diag.diag_id, elem.elem_id)
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1"), GovernanceModule("P2")]
+    # activate first phase
+    toolbox.set_active_module("P1")
+    # diagram and element were created without a phase, so they should now be hidden
+    assert not repo.diagram_visible(diag.diag_id)
+    assert diag.diag_id not in repo.visible_diagrams()
+    assert elem.elem_id not in repo.visible_elements()
+    # document visibility is also blocked
+    assert not toolbox.document_visible("Control Flow Diagram", diag.name)
+


### PR DESCRIPTION
## Summary
- hide diagrams, elements, and connections lacking a lifecycle phase when a phase is active
- block documents without phase assignments from appearing outside a lifecycle
- cover phase gating with a regression test
- restrict adding existing elements unless their source work product is permitted by governance
- add regression test for existing-element governance

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3a504260c83278a199a3069814161