### PR TITLE
feat: enrich explorer icons

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3688,8 +3688,6 @@ class SysMLDiagramWindow(tk.Frame):
                     base = name[4:]
                     if base.startswith("Generic "):
                         base = base[8:]
-                    if base == "Process Area":
-                        base = "Process"
                     color = style.get_color(base)
                 if color == "#FFFFFF":
                     color = "black"
@@ -3702,18 +3700,18 @@ class SysMLDiagramWindow(tk.Frame):
             name = name[4:]
             if name.startswith("Generic "):
                 name = name[8:]
-            if name == "Process Area":
-                name = "System Boundary"
         name = "AI Database" if name == "Database" else name
         mapping = {
             "Select": "arrow",
             "Actor": "human",
             "Use Case": "ellipse",
-            "Block": "rect",
-            "Part": "rect",
-            "Port": "circle",
+            "Block": "component",
+            "Part": "puzzle",
+            "Port": "ring",
             "Initial": "circle",
             "Final": "circle",
+            "Action": "action",
+            "CallBehaviorAction": "action",
             "Decision": "diamond",
             "Merge": "diamond",
             "Fork": "bar",
@@ -3731,19 +3729,20 @@ class SysMLDiagramWindow(tk.Frame):
             "Policy": "scroll",
             "Principle": "scale",
             "Procedure": "document",
-            "Record": "circle",
-            "Role": "circle",
+            "Record": "document",
+            "Role": "human",
             "Standard": "ribbon",
             "Process": "gear",
+            "Process Area": "gear",
             "Activity": "rect",
             "Task": "trapezoid",
             "Operation": "wrench",
             "Driving Function": "steering",
-            "Software Component": "rect",
+            "Software Component": "component",
             "Test Suite": "test",
             "System": "nested",
             "Plan": "document",
-            "Component": "rect",
+            "Component": "component",
             "Manufacturing Process": "hexagon",
             "Vehicle": "vehicle",
             "Fleet": "vehicle",
@@ -3753,6 +3752,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Field Data": "cylinder",
             "Model": "document",
             "Lifecycle Phase": "folder",
+            "Work Product": "document",
             # Use more descriptive icon shapes for governance elements
             "Hazard": "hazard",
             "Risk Assessment": "clipboard",
@@ -3760,7 +3760,6 @@ class SysMLDiagramWindow(tk.Frame):
             "Security Threat": "bug",
             "Report": "document",
             "Safety Case": "document",
-            "Work Product": "rect",
         }
         if name in mapping:
             return mapping[name]
@@ -12081,49 +12080,60 @@ class ArchitectureManagerDialog(tk.Frame):
         tree_frame.rowconfigure(0, weight=1)
         tree_frame.columnconfigure(0, weight=1)
 
-        # simple icons to visually distinguish packages, diagrams and objects
+        # style-aware icons to visually distinguish packages, diagrams and objects
         style = StyleManager.get_instance()
-        self.pkg_icon = self._create_icon("folder", "#b8860b")
+
+        def _color(name: str, fallback: str = "black") -> str:
+            c = style.get_color(name)
+            return fallback if c == "#FFFFFF" else c
+
+        self.pkg_icon = self._create_icon("folder", _color("Lifecycle Phase", "#b8860b"))
         self.diagram_icons = {
-            "Use Case Diagram": self._create_icon("ellipse", "blue"),
-            "Activity Diagram": self._create_icon("arrow", "green"),
-            "Governance Diagram": self._create_icon("arrow", "green"),
-            "Block Diagram": self._create_icon("rect", "orange"),
-            "Internal Block Diagram": self._create_icon("nested", "purple"),
+            "Use Case Diagram": self._create_icon("usecase_diag", _color("Use Case Diagram", "blue")),
+            "Activity Diagram": self._create_icon("activity_diag", _color("Activity Diagram", "green")),
+            "Governance Diagram": self._create_icon("activity_diag", _color("Governance Diagram", "green")),
+            "Block Diagram": self._create_icon("block_diag", _color("Block Diagram", "orange")),
+            "Internal Block Diagram": self._create_icon("ibd_diag", _color("Internal Block Diagram", "purple")),
         }
         self.elem_icons = {
-            "Actor": self._create_icon("human", style.get_color("Actor")),
-            "Use Case": self._create_icon("ellipse", style.get_color("Use Case")),
-            "Block": self._create_icon("rect", style.get_color("Block")),
-            "Part": self._create_icon("rect", style.get_color("Part")),
-            "Port": self._create_icon("circle", style.get_color("Port")),
-            "Decision": self._create_icon("diamond", style.get_color("Decision")),
-            "Merge": self._create_icon("diamond", style.get_color("Merge")),
-            "Fork": self._create_icon("bar", style.get_color("Fork")),
-            "Join": self._create_icon("bar", style.get_color("Join")),
-            "AI Database": self._create_icon("cylinder", style.get_color("AI Database")),
-            "ANN": self._create_icon("neural", style.get_color("ANN")),
-            "Data acquisition": self._create_icon("arrow", style.get_color("Data acquisition")),
-            "Business Unit": self._create_icon("department", style.get_color("Business Unit")),
-            "Data": self._create_icon("cylinder", style.get_color("Data")),
-            "Field Data": self._create_icon("cylinder", style.get_color("Field Data")),
-            "Document": self._create_icon("document", style.get_color("Document")),
-            "Guideline": self._create_icon("compass", style.get_color("Guideline")),
-            "Metric": self._create_icon("chart", style.get_color("Metric")),
-            "Organization": self._create_icon("building", style.get_color("Organization")),
-            "Policy": self._create_icon("scroll", style.get_color("Policy")),
-            "Principle": self._create_icon("scale", style.get_color("Principle")),
-            "Procedure": self._create_icon("document", style.get_color("Procedure")),
-            "Record": self._create_icon("circle", style.get_color("Record")),
-            "Role": self._create_icon("circle", style.get_color("Role")),
-            "Standard": self._create_icon("ribbon", style.get_color("Standard")),
-            "Safety Compliance": self._create_icon("shield_check", style.get_color("Safety Compliance")),
-            "Process": self._create_icon("gear", style.get_color("Process")),
-            "Operation": self._create_icon("wrench", style.get_color("Operation")),
-            "Driving Function": self._create_icon("steering", style.get_color("Driving Function")),
+            "Actor": self._create_icon("human", _color("Actor")),
+            "Use Case": self._create_icon("ellipse", _color("Use Case")),
+            "Block": self._create_icon("component", _color("Block")),
+            "Part": self._create_icon("puzzle", _color("Part")),
+            "Port": self._create_icon("ring", _color("Port")),
+            "Decision": self._create_icon("diamond", _color("Decision")),
+            "Merge": self._create_icon("diamond", _color("Merge")),
+            "Fork": self._create_icon("bar", _color("Fork")),
+            "Join": self._create_icon("bar", _color("Join")),
+            "Initial": self._create_icon("circle", _color("Initial")),
+            "Final": self._create_icon("circle", _color("Final")),
+            "Action": self._create_icon("action", _color("Action")),
+            "CallBehaviorAction": self._create_icon("action", _color("CallBehaviorAction")),
+            "AI Database": self._create_icon("cylinder", _color("AI Database")),
+            "ANN": self._create_icon("neural", _color("ANN")),
+            "Data acquisition": self._create_icon("arrow", _color("Data acquisition")),
+            "Business Unit": self._create_icon("department", _color("Business Unit")),
+            "Data": self._create_icon("cylinder", _color("Data")),
+            "Field Data": self._create_icon("cylinder", _color("Field Data")),
+            "Document": self._create_icon("document", _color("Document")),
+            "Guideline": self._create_icon("compass", _color("Guideline")),
+            "Metric": self._create_icon("chart", _color("Metric")),
+            "Organization": self._create_icon("building", _color("Organization")),
+            "Policy": self._create_icon("scroll", _color("Policy")),
+            "Principle": self._create_icon("scale", _color("Principle")),
+            "Procedure": self._create_icon("document", _color("Procedure")),
+            "Record": self._create_icon("document", _color("Record")),
+            "Role": self._create_icon("human", _color("Role")),
+            "Standard": self._create_icon("ribbon", _color("Standard")),
+            "Safety Compliance": self._create_icon("shield_check", _color("Safety Compliance")),
+            "Process": self._create_icon("gear", _color("Process")),
+            "Process Area": self._create_icon("gear", _color("Process Area")),
+            "Work Product": self._create_icon("document", _color("Work Product")),
+            "Operation": self._create_icon("wrench", _color("Operation")),
+            "Driving Function": self._create_icon("steering", _color("Driving Function")),
         }
-        self.default_diag_icon = self._create_icon("rect", "gray")
-        self.default_elem_icon = self._create_icon("rect", style.get_color("Existing Element"))
+        self.default_diag_icon = self._create_icon("document", "gray")
+        self.default_elem_icon = self._create_icon("rect", _color("Existing Element", "gray"))
         btns = ttk.Frame(self)
         btns.pack(fill=tk.X, padx=4, pady=4)
         ttk.Button(btns, text="Open", command=self.open).pack(side=tk.LEFT, padx=2)

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -37,19 +37,25 @@ class GSNExplorer(tk.Frame):
         tree_frame.rowconfigure(0, weight=1)
         tree_frame.columnconfigure(0, weight=1)
 
-        # detailed icons to visually distinguish elements
-        self.module_icon = self._create_icon("folder", "#b8860b")
-        self.diagram_icon = self._create_icon("rect", "#4682b4")
+        # Detailed, colour-coded icons to visually distinguish elements
+        style = StyleManager.get_instance()
+
+        def _color(name: str, default: str) -> str:
+            c = style.get_color(name)
+            return default if c == "#FFFFFF" else c
+
+        self.module_icon = self._create_icon("folder", _color("Lifecycle Phase", "#b8860b"))
+        self.diagram_icon = self._create_icon("document", _color("Document", "#4682b4"))
         self.node_icons = {
-            "Goal": self._create_icon("rect", "#2e8b57"),
-            "Strategy": self._create_icon("diamond", "#8b008b"),
-            "Solution": self._create_icon("circle", "#1e90ff"),
-            "Assumption": self._create_icon("rect", "#b22222"),
-            "Justification": self._create_icon("rect", "#ff8c00"),
-            "Context": self._create_icon("rect", "#696969"),
+            "Goal": self._create_icon("shield", _color("Safety Goal", "#2e8b57")),
+            "Strategy": self._create_icon("clipboard", _color("Strategy", "#8b008b")),
+            "Solution": self._create_icon("shield_check", _color("Solution", "#1e90ff")),
+            "Assumption": self._create_icon("triangle", _color("Assumption", "#b22222")),
+            "Justification": self._create_icon("scale", _color("Justification", "#ff8c00")),
+            "Context": self._create_icon("document", _color("Document", "#696969")),
             "Module": self.module_icon,
         }
-        self.default_node_icon = self._create_icon("rect")
+        self.default_node_icon = self._create_icon("document", _color("Existing Element", "gray"))
         self.item_map: dict[str, tuple[str, object]] = {}
 
         btns = ttk.Frame(self)

--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -440,6 +440,21 @@ def create_icon(
         for y in range(2, size - 2):
             img.put(outline, (2, y))
             img.put(outline, (size - 2, y))
+    elif shape == "action":
+        # Outline rectangle with an internal arrow to hint at behaviour
+        for x in range(2, size - 2):
+            img.put(outline, (x, 2))
+            img.put(outline, (x, size - 2))
+        for y in range(2, size - 2):
+            img.put(outline, (2, y))
+            img.put(outline, (size - 2, y))
+        mid = size // 2
+        for x in range(4, size - 6):
+            img.put(c, (x, mid))
+        head = size - 6
+        for i in range(3):
+            for y in range(mid - i, mid + i + 1):
+                img.put(c, (head + i, y))
     elif shape == "bar":
         top = size // 2 - 2
         img.put(c, to=(2, top, size - 2, top + 4))
@@ -724,10 +739,116 @@ def create_icon(
                 x = x1 + (y - y1) * (x2 - x1) / (y2 - y1)
                 xs.append(int(x))
             xs.sort()
-            for j in range(0, len(xs), 2):
-                img.put(c, to=(xs[j], y, xs[j + 1] + 1, y + 1))
+        for j in range(0, len(xs), 2):
+            img.put(c, to=(xs[j], y, xs[j + 1] + 1, y + 1))
         for x, y in points:
             img.put(outline, (x, y))
+    elif shape == "ring":
+        # Draw a circular ring to represent a connection port
+        cx = cy = size // 2
+        outer = size // 2 - 2
+        inner = outer - 3
+        for y in range(size):
+            for x in range(size):
+                dist = (x - cx) ** 2 + (y - cy) ** 2
+                if inner * inner <= dist <= outer * outer:
+                    img.put(c, (x, y))
+                if outer * outer <= dist <= (outer + 1) * (outer + 1):
+                    img.put(outline, (x, y))
+                if inner * inner <= dist <= (inner + 1) * (inner + 1):
+                    img.put(outline, (x, y))
+    elif shape == "usecase_diag":
+        # Stick figure and ellipse to suggest a use case diagram
+        cx = 4
+        head_r = 2
+        head_cy = 4
+        for y in range(head_cy - head_r, head_cy + head_r + 1):
+            for x in range(cx - head_r, cx + head_r + 1):
+                dist = (x - cx) ** 2 + (y - head_cy) ** 2
+                if dist <= head_r * head_r:
+                    img.put(c, (x, y))
+                if head_r * head_r <= dist <= (head_r + 1) * (head_r + 1):
+                    img.put(outline, (x, y))
+        for y in range(head_cy + head_r, size - 3):
+            img.put(c, (cx, y))
+        arm_y = head_cy + head_r + 1
+        for x in range(cx - 2, cx + 3):
+            img.put(c, (x, arm_y))
+        leg_start = size - 4
+        for i in range(3):
+            img.put(c, (cx - i, leg_start + i))
+            img.put(c, (cx + i, leg_start + i))
+        rx = 4
+        ry = 3
+        ecx = size - 5
+        ecy = size // 2
+        for y in range(ecy - ry, ecy + ry + 1):
+            for x in range(ecx - rx, ecx + rx + 1):
+                norm = ((x - ecx) ** 2) / (rx * rx) + ((y - ecy) ** 2) / (ry * ry)
+                if norm <= 1:
+                    img.put(c, (x, y))
+                if 1 <= norm <= 1.2:
+                    img.put(outline, (x, y))
+    elif shape == "activity_diag":
+        # Simple flow arrow with a diamond decision
+        mid = size // 2
+        for x in range(2, size - 5):
+            img.put(c, (x, mid))
+        head = size - 5
+        for i in range(4):
+            img.put(c, (head + i, mid - i))
+            img.put(c, (head + i, mid + i))
+        dmid = size // 2
+        for i in range(3):
+            img.put(c, (head - 3 + i, dmid - i))
+            img.put(c, (head - 3 + i, dmid + i))
+            img.put(c, (head - 5 + i, dmid))
+    elif shape == "block_diag":
+        for x in range(2, size - 2):
+            img.put(outline, (x, 2))
+            img.put(outline, (x, size - 2))
+        for y in range(2, size - 2):
+            img.put(outline, (2, y))
+            img.put(outline, (size - 2, y))
+        for y in range(4, size - 4, 6):
+            for x in range(4, size - 4, 6):
+                img.put(c, to=(x, y, x + 3, y + 3))
+    elif shape == "ibd_diag":
+        for x in range(2, size - 2):
+            img.put(outline, (x, 2))
+            img.put(outline, (x, size - 2))
+        for y in range(2, size - 2):
+            img.put(outline, (2, y))
+            img.put(outline, (size - 2, y))
+        img.put(c, to=(4, 4, 7, 7))
+        img.put(c, to=(9, 9, 12, 12))
+        for i in range(3):
+            img.put(c, (7 + i, 6))
+            img.put(c, (7 + i, 9))
+    elif shape == "puzzle":
+        # Simple jigsaw puzzle piece for "Part" elements
+        img.put(c, to=(3, 5, size - 3, size - 3))
+        # top tab
+        for y in range(0, 5):
+            for x in range(6, 10):
+                img.put(c, (x, y))
+        # right socket
+        for y in range(7, 11):
+            for x in range(size - 3, size):
+                img.put(bg or "white", (x, y))
+        # outlines
+        for x in range(3, size - 3):
+            img.put(outline, (x, 5))
+            img.put(outline, (x, size - 3))
+        for y in range(5, size - 3):
+            img.put(outline, (3, y))
+            img.put(outline, (size - 3, y))
+        for x in range(6, 10):
+            img.put(outline, (x, 0))
+            img.put(outline, (x, 4))
+        for y in range(7, 11):
+            img.put(outline, (size - 1, y))
+            img.put(outline, (size - 4, y))
     else:
         img.put(c, to=(2, 2, size - 2, size - 2))
         for x in range(2, size - 2):

--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -36,6 +36,7 @@ from analysis.safety_case import SafetyCaseLibrary, SafetyCase
 from gui import messagebox, format_name_with_phase
 from gui.safety_case_table import SafetyCaseTable
 from gui.icon_factory import create_icon
+from gui.style_manager import StyleManager
 
 
 class SafetyCaseExplorer(tk.Frame):
@@ -74,8 +75,14 @@ class SafetyCaseExplorer(tk.Frame):
         tree_frame.rowconfigure(0, weight=1)
         tree_frame.columnconfigure(0, weight=1)
 
-        self.case_icon = self._create_icon("folder", "#b8860b")
-        self.solution_icon = self._create_icon("circle", "#1e90ff")
+        style = StyleManager.get_instance()
+
+        def _color(name: str, default: str) -> str:
+            c = style.get_color(name)
+            return default if c == "#FFFFFF" else c
+
+        self.case_icon = self._create_icon("shield", _color("Safety Case", "#b8860b"))
+        self.solution_icon = self._create_icon("shield_check", _color("Solution", "#1e90ff"))
         self.item_map: Dict[str, Tuple[str, object]] = {}
 
         self.tree.bind("<Double-1>", self._on_double_click)

--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -11,6 +11,7 @@ import re
 
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
 from gui.icon_factory import create_icon
+from gui.style_manager import StyleManager
 
 
 def _strip_phase_suffix(name: str) -> str:
@@ -57,8 +58,14 @@ class SafetyManagementExplorer(tk.Frame):
         tree_frame.rowconfigure(0, weight=1)
         tree_frame.columnconfigure(0, weight=1)
 
-        self.folder_icon = self._create_icon("folder", "#b8860b")
-        self.diagram_icon = self._create_icon("rect", "#4682b4")
+        style = StyleManager.get_instance()
+
+        def _color(name: str, default: str) -> str:
+            c = style.get_color(name)
+            return default if c == "#FFFFFF" else c
+
+        self.folder_icon = self._create_icon("folder", _color("Lifecycle Phase", "#b8860b"))
+        self.diagram_icon = self._create_icon("document", _color("Document", "#4682b4"))
         self.item_map: Dict[str, tuple[str, object]] = {}
         self.root_iid = ""
 


### PR DESCRIPTION
## Summary
- Use style-aware icons for GSN explorer elements
- Adopt shield-based icons for safety cases and solutions
- Apply consistent document and folder icons in safety management explorer
- Bring detailed, shape-based icons to the AutoML explorer and toolboxes
- Show gear and document icons for Process Areas and Work Products in toolboxes
- Refine architecture icons with component, puzzle and ring shapes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3a6097b248327a06da0fb7e6fc182