### PR TITLE
Hide CBN toolbox until analysis selected

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -36,8 +36,8 @@ class CausalBayesianNetworkWindow(tk.Frame):
         body = ttk.Frame(self)
         body.pack(fill=tk.BOTH, expand=True)
 
-        toolbox = ttk.Frame(body)
-        toolbox.pack(side=tk.LEFT, fill=tk.Y)
+        self.toolbox = ttk.Frame(body)
+        self.toolbox.pack(side=tk.LEFT, fill=tk.Y)
         for name in (
             "Variable",
             "Triggering Condition",
@@ -47,9 +47,9 @@ class CausalBayesianNetworkWindow(tk.Frame):
             "Existing Malfunction",
             "Relationship",
         ):
-            ttk.Button(toolbox, text=name, command=lambda t=name: self.select_tool(t)).pack(
-                fill=tk.X, padx=2, pady=2
-            )
+            ttk.Button(
+                self.toolbox, text=name, command=lambda t=name: self.select_tool(t)
+            ).pack(fill=tk.X, padx=2, pady=2)
         self.current_tool = "Select"
 
         canvas_container = ttk.Frame(body)
@@ -108,7 +108,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
             self.doc_var.set("")
             self.app.active_cbn = None
             self.canvas.delete("all")
-
+        self._update_toolbox_visibility()
     # ------------------------------------------------------------------
     def redraw(self):
         self.canvas.configure(background=StyleManager.get_instance().canvas_bg)
@@ -124,6 +124,16 @@ class CausalBayesianNetworkWindow(tk.Frame):
         else:
             self.app.active_cbn = None
         self.load_doc()
+        self._update_toolbox_visibility()
+
+    # ------------------------------------------------------------------
+    def _update_toolbox_visibility(self) -> None:
+        if self.doc_var.get():
+            if not self.toolbox.winfo_ismapped():
+                self.toolbox.pack(side=tk.LEFT, fill=tk.Y)
+        else:
+            if self.toolbox.winfo_ismapped():
+                self.toolbox.pack_forget()
 
     # ------------------------------------------------------------------
     def new_doc(self) -> None:

--- a/tests/test_causal_bayesian_toolbox_visibility.py
+++ b/tests/test_causal_bayesian_toolbox_visibility.py
@@ -1,0 +1,68 @@
+import types
+from gui.causal_bayesian_network_window import CausalBayesianNetworkWindow
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, v):
+        self.value = v
+
+
+class DummyCB:
+    def __init__(self):
+        self.values = None
+
+    def configure(self, **kw):
+        if "values" in kw:
+            self.values = kw["values"]
+
+    def bind(self, *a, **k):
+        pass
+
+
+class DummyCanvas:
+    def delete(self, *a, **k):
+        pass
+
+
+class DummyToolbox:
+    def __init__(self):
+        self.packed = False
+
+    def pack(self, *a, **k):
+        self.packed = True
+
+    def pack_forget(self, *a, **k):
+        self.packed = False
+
+    def winfo_ismapped(self):
+        return self.packed
+
+
+def _make_window(docs):
+    win = object.__new__(CausalBayesianNetworkWindow)
+    win.doc_var = DummyVar()
+    win.doc_cb = DummyCB()
+    win.canvas = DummyCanvas()
+    win.toolbox = DummyToolbox()
+    win.app = types.SimpleNamespace(cbn_docs=docs, active_cbn=None)
+    win.load_doc = lambda *a, **k: None
+    return win
+
+
+def test_toolbox_hidden_without_analysis():
+    win = _make_window([])
+    CausalBayesianNetworkWindow.refresh_docs(win)
+    assert not win.toolbox.packed
+
+
+def test_toolbox_shown_with_analysis():
+    doc = types.SimpleNamespace(name="A")
+    win = _make_window([doc])
+    CausalBayesianNetworkWindow.refresh_docs(win)
+    assert win.toolbox.packed


### PR DESCRIPTION
## Summary
- Hide Causal Bayesian Network toolbox buttons until an analysis is selected
- Add tests verifying toolbox visibility toggles with analysis selection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3addd1614832793920cbb2608eda8