### PR TITLE
Enforce governance inputs when adding diagram elements

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -370,7 +370,7 @@ class SafetyManagementToolbox:
             )
             phase = diag.phase if diag else None
         if phase is None:
-            return True
+            return False
         if phase == self.active_module:
             return True
         reuse = self._reuse_map().get(self.active_module, {})
@@ -478,18 +478,30 @@ class SafetyManagementToolbox:
     # ------------------------------------------------------------------
     def diagrams_in_module(self, name: str) -> set[str]:
         """Return all diagram names contained within module *name*."""
+
         mod = self._find_module(name, self.modules)
-        if not mod:
-            return set()
-
         names: set[str] = set()
+        if mod:
+            def _collect(m: GovernanceModule) -> None:
+                names.update(m.diagrams)
+                for sub in m.modules:
+                    _collect(sub)
 
-        def _collect(m: GovernanceModule) -> None:
-            names.update(m.diagrams)
-            for sub in m.modules:
-                _collect(sub)
+            _collect(mod)
 
-        _collect(mod)
+        # Governance diagrams may also declare their lifecycle via the
+        # repository ``phase`` attribute even when they were not explicitly
+        # placed inside a toolbox folder.  Include those diagrams so that work
+        # products drawn on such diagrams still enable their analyses when the
+        # corresponding phase becomes active.
+        repo = SysMLRepository.get_instance()
+        names.update(
+            d.name
+            for d in repo.diagrams.values()
+            if d.diag_type == "Governance Diagram"
+            and "safety-management" in getattr(d, "tags", [])
+            and d.phase == name
+        )
         return names
 
     # ------------------------------------------------------------------
@@ -524,7 +536,15 @@ class SafetyManagementToolbox:
                     return found
             return None
 
-        return _search(self.modules)
+        found = _search(self.modules)
+        if found:
+            return found
+
+        # Fallback to the repository metadata when the diagram has a lifecycle
+        # phase assigned but is not tracked inside the toolbox hierarchy.
+        repo = SysMLRepository.get_instance()
+        diag = next((d for d in repo.diagrams.values() if d.name == diagram), None)
+        return getattr(diag, "phase", None)
 
     def phase_for_document(self, analysis: str, name: str) -> Optional[str]:
         """Return lifecycle phase assigned to ``analysis`` document ``name``."""

--- a/tests/test_governance_input_block_addition.py
+++ b/tests/test_governance_input_block_addition.py
@@ -1,0 +1,26 @@
+import types
+import pytest
+from sysml.sysml_repository import SysMLRepository
+from analysis import safety_management as sm
+
+
+@pytest.mark.parametrize("target", ["Control Flow Diagram", "HAZOP", "Risk Assessment"])
+def test_existing_elements_require_governance(target):
+    repo = SysMLRepository.reset_instance()
+    arch = repo.create_diagram("Architecture Diagram", name="AD")
+    elem = repo.create_element("Block", name="B1")
+    repo.add_element_to_diagram(arch.diag_id, elem.elem_id)
+    repo.link_diagram(elem.elem_id, arch.diag_id)
+    tgt = repo.create_diagram(target, name="T")
+
+    toolbox = types.SimpleNamespace(analysis_inputs=lambda t, **k: set())
+    sm.ACTIVE_TOOLBOX = toolbox
+
+    repo.add_element_to_diagram(tgt.diag_id, elem.elem_id)
+    assert elem.elem_id not in tgt.elements
+
+    toolbox.analysis_inputs = lambda t, **k: {"Architecture Diagram"}
+    repo.add_element_to_diagram(tgt.diag_id, elem.elem_id)
+    assert elem.elem_id in tgt.elements
+
+    sm.ACTIVE_TOOLBOX = None

--- a/tests/test_governance_phase_membership_infer.py
+++ b/tests/test_governance_phase_membership_infer.py
@@ -1,0 +1,71 @@
+import tkinter as tk
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from sysml.sysml_repository import SysMLRepository
+from AutoML import FaultTreeApp
+
+
+class DummyListbox:
+    def __init__(self):
+        self.items = []
+        self.colors = []
+
+    def get(self, *_):
+        return self.items
+
+    def insert(self, index, item):
+        self.items.insert(index if isinstance(index, int) else len(self.items), item)
+
+    def itemconfig(self, index, foreground="black"):
+        self.colors.append((index, foreground))
+
+
+class DummyMenu:
+    def __init__(self):
+        self.state = None
+
+    def entryconfig(self, _idx, state=tk.DISABLED):
+        self.state = state
+
+
+def test_repository_phase_enables_work_product():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    repo.active_phase = "P1"
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    diag.tags.append("safety-management")
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule(name="P1"), GovernanceModule(name="P2")]
+    toolbox.diagrams = {"Gov": diag.diag_id}
+    toolbox.set_active_module("P1")
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    lb = DummyListbox()
+    info = FaultTreeApp.WORK_PRODUCT_INFO["GSN Argumentation"]
+    app.tool_listboxes = {info[0]: lb}
+    app.tool_categories = {info[0]: []}
+    app.tool_actions = {}
+    wp_menu = DummyMenu()
+    parent_menu = DummyMenu()
+    app.work_product_menus = {"GSN Argumentation": [(wp_menu, 0)], "GSN": [(parent_menu, 0)]}
+    app.enabled_work_products = set()
+    app.enable_process_area = lambda area: None
+    app.tool_to_work_product = {info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()}
+    app.update_views = lambda: None
+    app.safety_mgmt_toolbox = toolbox
+    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(app, FaultTreeApp)
+    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(app, FaultTreeApp)
+    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(app, FaultTreeApp)
+
+    toolbox.add_work_product("Gov", "GSN Argumentation", "")
+    toolbox.on_change = app.refresh_tool_enablement
+    app.refresh_tool_enablement()
+
+    assert "GSN Argumentation" in app.enabled_work_products
+    assert "GSN" in app.enabled_work_products
+    assert wp_menu.state == tk.NORMAL
+    assert parent_menu.state == tk.NORMAL

--- a/tests/test_lifecycle_phase_enforces_governance.py
+++ b/tests/test_lifecycle_phase_enforces_governance.py
@@ -1,0 +1,20 @@
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from sysml.sysml_repository import SysMLRepository
+
+def test_diagram_and_elements_hidden_without_phase():
+    repo = SysMLRepository.reset_instance()
+    # create diagram and element before any lifecycle phase is active
+    diag = repo.create_diagram("Control Flow Diagram", name="CF")
+    elem = repo.create_element("Block", name="B1")
+    repo.add_element_to_diagram(diag.diag_id, elem.elem_id)
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1"), GovernanceModule("P2")]
+    # activate first phase
+    toolbox.set_active_module("P1")
+    # diagram and element were created without a phase, so they should now be hidden
+    assert not repo.diagram_visible(diag.diag_id)
+    assert diag.diag_id not in repo.visible_diagrams()
+    assert elem.elem_id not in repo.visible_elements()
+    # document visibility is also blocked
+    assert not toolbox.document_visible("Control Flow Diagram", diag.name)
+


### PR DESCRIPTION
## Summary
- infer phase membership from repository metadata so governance diagrams always enable declared analyses
- cover repository-phase inference with regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3a504260c83278a199a3069814161