### PR TITLE
Remove stereotype from system boundary labels on governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -691,6 +691,8 @@ def _format_label(
                 elem_type = repo.elements[obj.element_id].elem_type
             if elem_type in {"Decision", "Initial", "Final", "Merge"}:
                 return ""
+            if elem_type == "System Boundary":
+                return label
             stereo = _GOV_TYPE_ALIASES.get(elem_type, elem_type).lower()
             label = f"<<{stereo}>>\n{label}".strip()
     return label

--- a/tests/test_governance_element_stereotype_label.py
+++ b/tests/test_governance_element_stereotype_label.py
@@ -60,6 +60,14 @@ class GovernanceElementStereotypeTests(unittest.TestCase):
             lines = win._object_label_lines(obj)
             self.assertEqual([], lines)
 
+    def test_system_boundary_label_has_no_stereotype(self):
+        repo = SysMLRepository.get_instance()
+        diag = repo.create_diagram("Governance Diagram")
+        obj = SysMLObject(1, "System Boundary", 0.0, 0.0, properties={"name": "Area"})
+        win = DummyWindow(diag.diag_id)
+        lines = win._object_label_lines(obj)
+        self.assertEqual(["Area"], lines)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Skip stereotype prefixes for system boundary shapes in governance diagrams
- Test that system boundary labels display only their names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a3b08997c4832789abe495bf580a42