### PR TITLE
Hide CBN toolbox until analysis selected

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -37,7 +37,6 @@ class CausalBayesianNetworkWindow(tk.Frame):
         body.pack(fill=tk.BOTH, expand=True)
 
         self.toolbox = ttk.Frame(body)
-        self.toolbox.pack(side=tk.LEFT, fill=tk.Y)
         for name in (
             "Variable",
             "Triggering Condition",


### PR DESCRIPTION
## Summary
- Hide Causal Bayesian Network editor toolbox until an analysis is chosen

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3b2a5f72083279b48dbf239cd3207