### PR TITLE
Resize block when toggling compartments

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4181,6 +4181,7 @@ class SysMLDiagramWindow(tk.Frame):
             hit = self.hit_compartment_toggle(obj, x, y)
             if hit:
                 obj.collapsed[hit] = not obj.collapsed.get(hit, False)
+                self._resize_block_to_content(obj)
                 self._sync_to_repository()
                 self.redraw()
                 return
@@ -6042,6 +6043,14 @@ class SysMLDiagramWindow(tk.Frame):
                 total_lines += 1 + len(lines)
         height_px = total_lines * 20 * self.zoom
         return width_px / self.zoom, height_px / self.zoom
+
+    def _resize_block_to_content(self, obj: SysMLObject) -> None:
+        """Resize a Block so its compartments fit its current state."""
+        if obj.obj_type != "Block":  # pragma: no cover - safety check
+            return
+        min_w, min_h = self._min_block_size(obj)
+        obj.width = min_w
+        obj.height = min_h
 
     def _min_action_size(self, obj: SysMLObject) -> tuple[float, float]:
         """Return minimum width and height to display Action text without wrapping."""

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -17,10 +17,12 @@ class DummyWindow:
 
     ensure_text_fits = SysMLDiagramWindow.ensure_text_fits
     _object_label_lines = SysMLDiagramWindow._object_label_lines
+    _block_compartments = SysMLDiagramWindow._block_compartments
     _min_block_size = SysMLDiagramWindow._min_block_size
     _min_action_size = SysMLDiagramWindow._min_action_size
     _min_data_acquisition_size = SysMLDiagramWindow._min_data_acquisition_size
     _wrap_text_to_width = SysMLDiagramWindow._wrap_text_to_width
+    _resize_block_to_content = SysMLDiagramWindow._resize_block_to_content
 
 class EnsureTextFitsTests(unittest.TestCase):
     def setUp(self):
@@ -122,6 +124,28 @@ class EnsureTextFitsTests(unittest.TestCase):
         obj.properties["compartments"] = ";".join(f"line{i}" for i in range(100))
         win.ensure_text_fits(obj)
         self.assertGreater(obj.height, 80)
+
+    def test_block_resizes_when_compartments_toggle(self):
+        win = DummyWindow()
+        block = SysMLObject(
+            1,
+            "Block",
+            0,
+            0,
+            width=10,
+            height=10,
+            properties={"name": "B", "partProperties": "p1,p2"},
+        )
+        block.requirements = []
+        win._resize_block_to_content(block)
+        expanded_h = block.height
+        block.collapsed["Parts"] = True
+        win._resize_block_to_content(block)
+        collapsed_h = block.height
+        self.assertLess(collapsed_h, expanded_h)
+        block.collapsed["Parts"] = False
+        win._resize_block_to_content(block)
+        self.assertGreater(block.height, collapsed_h)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- resize blocks to fit content when compartments expand or collapse
- test block resizing behavior during compartment toggling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3b2f8f1f083278c794793eef389f3