### PR TITLE
Fix role shape size

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -354,6 +354,7 @@ _FIXED_SIZE_TYPES = {
     "Initial",
     "Final",
     "Actor",
+    "Role",
     "Decision",
     "Merge",
     "Work Product",
@@ -6269,6 +6270,8 @@ class SysMLDiagramWindow(tk.Frame):
             min_w, min_h = self._min_data_acquisition_size(obj)
             obj.width = max(obj.width, min_w)
             obj.height = max(obj.height, min_h)
+            return
+        elif obj.obj_type == "Role":
             return
         else:
             label_lines = self._object_label_lines(obj)

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -101,6 +101,22 @@ class EnsureTextFitsTests(unittest.TestCase):
             self.assertEqual(obj.width, 40)
             self.assertEqual(obj.height, 40)
 
+    def test_role_size_remains_fixed(self):
+        win = DummyWindow()
+        role = SysMLObject(
+            1,
+            "Role",
+            0,
+            0,
+            width=80,
+            height=40,
+            properties={"name": "VeryLongRoleName"},
+        )
+        role.requirements = []
+        win.ensure_text_fits(role)
+        self.assertEqual(role.width, 80)
+        self.assertEqual(role.height, 40)
+
     def test_data_acquisition_default_and_resize(self):
         win = DummyWindow()
         obj = SysMLObject(


### PR DESCRIPTION
## Summary
- prevent Role diagram objects from being resized
- ensure Role objects keep constant dimensions when fitting text
- add regression test verifying Role size is fixed

## Testing
- `PYTHONPATH=. pytest tests/test_size.py::EnsureTextFitsTests::test_role_size_remains_fixed tests/test_role_label_position.py`


------
https://chatgpt.com/codex/tasks/task_b_68a3b333d5708327ace25759afe12d7b