### PR TITLE
Use gear icon for Operation

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3739,7 +3739,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Process Area": "gear",
             "Activity": "rect",
             "Task": "trapezoid",
-            "Operation": "wrench",
+            "Operation": "gear",
             "Driving Function": "steering",
             "Software Component": "component",
             "Test Suite": "test",
@@ -12156,7 +12156,7 @@ class ArchitectureManagerDialog(tk.Frame):
             "Process": self._create_icon("gear", _color("Process")),
             "Process Area": self._create_icon("gear", _color("Process Area")),
             "Work Product": self._create_icon("document", _color("Work Product")),
-            "Operation": self._create_icon("wrench", _color("Operation")),
+            "Operation": self._create_icon("gear", _color("Operation")),
             "Driving Function": self._create_icon("steering", _color("Driving Function")),
         }
         self.default_diag_icon = self._create_icon("document", "gray")

--- a/tests/test_governance_icons.py
+++ b/tests/test_governance_icons.py
@@ -25,7 +25,7 @@ def test_governance_shapes_and_relations():
     assert shape(None, "Metric") == "chart"
     assert shape(None, "Safety Compliance") == "shield_check"
     assert shape(None, "Process") == "gear"
-    assert shape(None, "Operation") == "wrench"
+    assert shape(None, "Operation") == "gear"
     assert shape(None, "Driving Function") == "steering"
     assert shape(None, "Plan") == "document"
     assert shape(None, "Data") == "cylinder"


### PR DESCRIPTION
## Summary
- replace operation's wrench icon with a gear icon to better convey its purpose
- update tests expecting the operation icon

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3b4952fa48327921d8261b80da34e