### PR TITLE
Add icon-based left toolbox for GSN diagrams

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -16,6 +16,7 @@ from .gsn_config_window import GSNElementConfig
 from .gsn_connection_config import GSNConnectionConfig
 from . import messagebox
 from .style_manager import StyleManager
+from .icon_factory import create_icon
 
 
 class ModuleSelectDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
@@ -67,22 +68,43 @@ class GSNDiagramWindow(tk.Frame):
 
         # toolbox with buttons to add nodes and connectors
         self.toolbox_container = ttk.Frame(self)
-        self.toolbox_container.pack(side=tk.TOP, fill=tk.X)
+        self.toolbox_container.pack(side=tk.LEFT, fill=tk.Y)
         self.toolbox_canvas = tk.Canvas(self.toolbox_container, highlightthickness=0)
-        self.toolbox_canvas.pack(side=tk.TOP, fill=tk.X, expand=True)
+        self.toolbox_canvas.pack(side=tk.LEFT, fill=tk.Y, expand=True)
         toolbox_scroll = ttk.Scrollbar(
-            self.toolbox_container, orient=tk.HORIZONTAL, command=self.toolbox_canvas.xview
+            self.toolbox_container, orient=tk.VERTICAL, command=self.toolbox_canvas.yview
         )
-        toolbox_scroll.pack(side=tk.BOTTOM, fill=tk.X)
-        self.toolbox_canvas.configure(xscrollcommand=toolbox_scroll.set)
+        toolbox_scroll.pack(side=tk.RIGHT, fill=tk.Y)
+        self.toolbox_canvas.configure(yscrollcommand=toolbox_scroll.set)
         self.toolbox = ttk.Frame(self.toolbox_canvas)
         self.toolbox_canvas.create_window((0, 0), window=self.toolbox, anchor="nw")
         self.toolbox.bind(
             "<Configure>",
             lambda e: self.toolbox_canvas.configure(
-                scrollregion=self.toolbox_canvas.bbox("all"), height=e.height
+                scrollregion=self.toolbox_canvas.bbox("all"), width=e.width
             ),
         )
+
+        style = StyleManager.get_instance()
+
+        def _color(name: str, default: str) -> str:
+            c = style.get_color(name)
+            return default if c == "#FFFFFF" else c
+
+        self._icons = {
+            "Goal": create_icon("rect", _color("Goal", "#2e8b57")),
+            "Strategy": create_icon("parallelogram", _color("Strategy", "#8b008b")),
+            "Solution": create_icon("circle", _color("Solution", "#1e90ff")),
+            "Assumption": create_icon("ellipse", _color("Assumption", "#b22222")),
+            "Justification": create_icon("ellipse", _color("Justification", "#ff8c00")),
+            "Context": create_icon("ellipse", _color("Context", "#696969")),
+            "Module": create_icon("folder", _color("Module", "#b8860b")),
+            "Solved By": create_icon("arrow", _color("Solved By", "black")),
+            "In Context Of": create_icon("relation", _color("In Context Of", "black")),
+            "Zoom In": create_icon("plus", "black"),
+            "Zoom Out": create_icon("minus", "black"),
+            "Export CSV": create_icon("disk", "black"),
+        }
 
         node_cmds = [
             ("Goal", self.add_goal),
@@ -96,7 +118,13 @@ class GSNDiagramWindow(tk.Frame):
         node_frame = ttk.LabelFrame(self.toolbox, text="Elements (elements)")
         node_frame.pack(side=tk.TOP, fill=tk.X)
         for name, cmd in node_cmds:
-            ttk.Button(node_frame, text=name, command=cmd).pack(side=tk.LEFT)
+            ttk.Button(
+                node_frame,
+                text=name,
+                command=cmd,
+                image=self._icons.get(name),
+                compound=tk.LEFT,
+            ).pack(fill=tk.X, padx=2, pady=2)
 
         rel_cmds = [
             ("Solved By", self.connect_solved_by),
@@ -105,7 +133,13 @@ class GSNDiagramWindow(tk.Frame):
         rel_frame = ttk.LabelFrame(self.toolbox, text="Relationships (relationships)")
         rel_frame.pack(side=tk.TOP, fill=tk.X)
         for name, cmd in rel_cmds:
-            ttk.Button(rel_frame, text=name, command=cmd).pack(side=tk.LEFT)
+            ttk.Button(
+                rel_frame,
+                text=name,
+                command=cmd,
+                image=self._icons.get(name),
+                compound=tk.LEFT,
+            ).pack(fill=tk.X, padx=2, pady=2)
 
         util_cmds = [
             ("Zoom In", self.zoom_in),
@@ -115,11 +149,17 @@ class GSNDiagramWindow(tk.Frame):
         util_frame = ttk.Frame(self.toolbox)
         util_frame.pack(side=tk.TOP, fill=tk.X)
         for name, cmd in util_cmds:
-            ttk.Button(util_frame, text=name, command=cmd).pack(side=tk.LEFT)
+            ttk.Button(
+                util_frame,
+                text=name,
+                command=cmd,
+                image=self._icons.get(name),
+                compound=tk.LEFT,
+            ).pack(fill=tk.X, padx=2, pady=2)
 
         # drawing canvas with scrollbars so large diagrams remain accessible
         canvas_frame = ttk.Frame(self)
-        canvas_frame.pack(fill=tk.BOTH, expand=True)
+        canvas_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.canvas = tk.Canvas(
             canvas_frame,
             width=800,

--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -78,6 +78,20 @@ def create_icon(
         for y in range(3, size - 3):
             img.put(outline, (3, y))
             img.put(outline, (size - 4, y))
+    elif shape == "parallelogram":
+        offset = size // 4
+        top = 3
+        bottom = size - 3
+        for y in range(top, bottom):
+            t = (y - top) / (bottom - top - 1)
+            x1 = int(3 + offset - offset * t)
+            x2 = int(size - 3 - offset * t)
+            img.put(c, to=(x1, y, x2, y + 1))
+            if y in (top, bottom - 1):
+                for x in range(x1, x2):
+                    img.put(outline, (x, y))
+            img.put(outline, (x1, y))
+            img.put(outline, (x2 - 1, y))
     elif shape == "folder":
         img.put(c, to=(1, 5, size - 2, size - 2))
         img.put(c, to=(1, 3, size // 2, 5))
@@ -604,6 +618,13 @@ def create_icon(
             img.put(outline, (i, mid))
             img.put(outline, (i, i))
             img.put(outline, (i, size - i - 1))
+    elif shape == "minus":
+        mid = size // 2
+        for x in range(3, size - 3):
+            img.put(c, (x, mid))
+        for x in range(3, size - 3):
+            img.put(outline, (x, mid - 1))
+            img.put(outline, (x, mid + 1))
     elif shape == "plus":
         mid = size // 2
         for x in range(3, size - 3):


### PR DESCRIPTION
## Summary
- Move GSN diagram toolbox to a vertical left panel
- Add color-coded icons for GSN elements, relationships, and utilities
- Extend icon factory with parallelogram and minus icons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3b6ba50c48327a08367282b442963