### PR TITLE
feat: expand sequence subject support to organizations

### DIFF
--- a/analysis/requirement_rule_generator.py
+++ b/analysis/requirement_rule_generator.py
@@ -450,11 +450,19 @@ def generate_patterns_from_rules(rules: dict) -> List[dict]:
                 final_tgt = path[-1][1]
                 tgt_count = len(path)
 
-                # Generate both text-subject and role-subject variants
+                # Generate text-subject and entity-subject variants
+                subject_entities = ["role", "organization", "business_unit"]
                 variants = [
-                    (seq_label, info.get("subject", "Engineering team"), False),
-                    (f"{seq_label}_role_subject", "<subject_id> (<subject_class>)", True),
+                    (seq_label, info.get("subject", "Engineering team"), False)
                 ]
+                for ent in subject_entities:
+                    variants.append(
+                        (
+                            f"{seq_label}_{ent}_subject",
+                            "<subject_id> (<subject_class>)",
+                            True,
+                        )
+                    )
 
                 for label_variant, subj, use_role_subject in variants:
                     tmpl_override = info.get("template")

--- a/tests/test_requirement_rule_generator.py
+++ b/tests/test_requirement_rule_generator.py
@@ -191,6 +191,65 @@ def test_sequence_role_subject_variants() -> None:
     assert "using the <object0_id>" not in tmpl
 
 
+def test_sequence_organization_subject_variants() -> None:
+    cfg = {
+        "connection_rules": {
+            "Governance Diagram": {
+                "Leads": {"Organization": ["Process"]},
+                "Produces": {"Process": ["Document"]},
+            }
+        },
+        "requirement_sequences": {
+            "management": {
+                "relations": ["Leads", "Produces"],
+                "subject": "Management team",
+            }
+        },
+    }
+    patterns = generate_patterns_from_config(cfg)
+    ids = {p["Pattern ID"] for p in patterns}
+    assert "SEQ-management-Organization-Document" in ids
+    assert "SEQ-management_organization_subject-Organization-Document" in ids
+    tmpl = next(
+        p["Template"]
+        for p in patterns
+        if p["Pattern ID"] == "SEQ-management_organization_subject-Organization-Document"
+    )
+    assert tmpl.startswith("<subject_id> (<subject_class>) shall leads")
+    assert "using the <object0_id>" not in tmpl
+
+
+def test_sequence_business_unit_subject_variants() -> None:
+    cfg = {
+        "connection_rules": {
+            "Governance Diagram": {
+                "Owns": {"Business Unit": ["Process"]},
+                "Produces": {"Process": ["Document"]},
+            }
+        },
+        "requirement_sequences": {
+            "responsibility": {
+                "relations": ["Owns", "Produces"],
+                "subject": "Business leadership",
+            }
+        },
+    }
+    patterns = generate_patterns_from_config(cfg)
+    ids = {p["Pattern ID"] for p in patterns}
+    assert "SEQ-responsibility-Business_Unit-Document" in ids
+    assert (
+        "SEQ-responsibility_business_unit_subject-Business_Unit-Document" in ids
+    )
+    tmpl = next(
+        p["Template"]
+        for p in patterns
+        if p["Pattern ID"]
+        == "SEQ-responsibility_business_unit_subject-Business_Unit-Document"
+    )
+    assert tmpl.startswith("<subject_id> (<subject_class>) shall owns")
+    assert "using the <object0_id>" not in tmpl
+
+
 def test_complex_sequences() -> None:
     cfg = {
         "ai_nodes": [


### PR DESCRIPTION
## Summary
- allow requirement sequence rules to use organization and business unit elements as subjects in addition to roles
- add tests covering organization and business unit sequence subject variants

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3bb19b7288327a23e597d1eb6d19d