### PR TITLE
Enable unencrypted save when cryptography is missing

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -19010,39 +19010,56 @@ class FaultTreeApp:
     def save_model(self):
         path = filedialog.asksaveasfilename(
             defaultextension=".autml",
-            filetypes=[("AutoML Project", "*.autml")],
+            filetypes=[("AutoML Project", "*.autml"), ("JSON", "*.json")],
         )
         if not path:
             return
-        try:
-            from cryptography.fernet import Fernet
-        except Exception:  # pragma: no cover - dependency check
-            messagebox.showerror(
-                "Save Model", "cryptography package is required for encrypted save."
-            )
-            return
-        from tkinter import simpledialog
-        import base64
-        import gzip
-        import hashlib
-        import json
 
-        password = simpledialog.askstring(
-            "Password", "Enter encryption password:", show="*"
-        )
-        if password is None:
-            return
+        import json
+        import os
+
         for fmea in self.fmeas:
             self.export_fmea_to_csv(fmea, fmea["file"])
         for fmeda in self.fmedas:
             self.export_fmeda_to_csv(fmeda, fmeda["file"])
         data = self.export_model_data()
-        raw = json.dumps(data).encode("utf-8")
-        compressed = gzip.compress(raw)
-        key = base64.urlsafe_b64encode(hashlib.sha256(password.encode()).digest())
-        token = Fernet(key).encrypt(compressed)
-        with open(path, "wb") as f:
-            f.write(token)
+
+        if path.endswith(".autml"):
+            try:
+                from cryptography.fernet import Fernet
+            except Exception:  # pragma: no cover - dependency check
+                messagebox.showwarning(
+                    "Save Model",
+                    (
+                        "cryptography package is required for encrypted save. "
+                        "Saving unencrypted JSON instead."
+                    ),
+                )
+                path = os.path.splitext(path)[0] + ".json"
+                with open(path, "w", encoding="utf-8") as f:
+                    json.dump(data, f, indent=2)
+            else:
+                from tkinter import simpledialog
+                import base64
+                import gzip
+                import hashlib
+
+                password = simpledialog.askstring(
+                    "Password", "Enter encryption password:", show="*"
+                )
+                if password is None:
+                    return
+                raw = json.dumps(data).encode("utf-8")
+                compressed = gzip.compress(raw)
+                key = base64.urlsafe_b64encode(
+                    hashlib.sha256(password.encode()).digest()
+                )
+                token = Fernet(key).encrypt(compressed)
+                with open(path, "wb") as f:
+                    f.write(token)
+        else:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
         messagebox.showinfo(
             "Saved", "Model saved with all configuration and safety goal information."
         )


### PR DESCRIPTION
## Summary
- Allow Save Model to fall back to unencrypted JSON if the cryptography package isn't available
- Add JSON option to Save dialog and warn when encryption can't be used

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3ca61aa4083278ebd1b5b8a2fbb1a