### PR TITLE
Refactor governance work product placement

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -104,6 +104,45 @@ GOV_ELEMENT_NODES = _normalize_plan_types(
 )
 GOV_ELEMENT_RELATIONS = SAFETY_AI_RELATIONS
 
+# Process areas available in governance diagrams
+PROCESS_AREA_OPTIONS = [
+    "System Design (Item Definition)",
+    "Hazard & Threat Analysis",
+    "Risk Assessment",
+    "Safety & Security Management",
+    "Safety Analysis",
+    "Scenario",
+]
+
+# Mapping of work products to the process areas that allow them
+WORK_PRODUCT_AREA_MAP = {
+    "Architecture Diagram": "System Design (Item Definition)",
+    "Safety & Security Concept": "System Design (Item Definition)",
+    "Mission Profile": "Safety Analysis",
+    "Reliability Analysis": "Safety Analysis",
+    "Causal Bayesian Network Analysis": "Safety Analysis",
+    "Safety & Security Case": "Safety & Security Management",
+    "GSN Argumentation": "Safety & Security Management",
+    "Product Goal Specification": "System Design (Item Definition)",
+    **{wp: "System Design (Item Definition)" for wp in REQUIREMENT_WORK_PRODUCTS},
+    "HAZOP": "Hazard & Threat Analysis",
+    "STPA": "Hazard & Threat Analysis",
+    "Threat Analysis": "Hazard & Threat Analysis",
+    "FI2TC": "Hazard & Threat Analysis",
+    "TC2FI": "Hazard & Threat Analysis",
+    "Risk Assessment": "Risk Assessment",
+    "FTA": "Safety Analysis",
+    "FMEA": "Safety Analysis",
+    "FMEDA": "Safety Analysis",
+    "SPI Work Document": "Safety & Security Management",
+    "Scenario Library": "Scenario",
+    "ODD": "Scenario",
+}
+
+
+def _work_products_for_area(area: str) -> list[str]:
+    return [wp for wp, a in WORK_PRODUCT_AREA_MAP.items() if a == area]
+
 # Create Safety & AI Lifecycle toolbox frame
 # Create toolbox for additional governance elements grouped by class
 # Repack toolbox to include selector
@@ -3494,6 +3533,7 @@ class SysMLDiagramWindow(tk.Frame):
         self.temp_line_end: tuple[float, float] | None = None
         self.endpoint_drag_pos: tuple[float, float] | None = None
         self.rc_dragged = False
+        self._child_drag_offsets: dict[int, tuple[float, float]] = {}
 
         # Provide default drawing helper for gradient fills and shapes
         self.drawing_helper = fta_drawing_helper
@@ -4521,6 +4561,18 @@ class SysMLDiagramWindow(tk.Frame):
                 self.resize_edge = self.hit_resize_handle(obj, x, y)
                 if self.resize_edge:
                     self.resizing_obj = obj
+                if obj.obj_type == "System Boundary":
+                    self._child_drag_offsets = {
+                        o.obj_id: (o.x - obj.x, o.y - obj.y)
+                        for o in self.objects
+                        if (
+                            o.obj_type == "Work Product"
+                            and o.properties.get("parent") == str(obj.obj_id)
+                        )
+                        or o.properties.get("boundary") == str(obj.obj_id)
+                    }
+                else:
+                    self._child_drag_offsets = {}
                 self.redraw()
                 self.update_property_view()
             else:
@@ -4794,6 +4846,8 @@ class SysMLDiagramWindow(tk.Frame):
             new_x = self._constrain_horizontal_movement(self.selected_obj, new_x)
             self.selected_obj.x = new_x
             self.selected_obj.y = y / self.zoom - self.drag_offset[1]
+            if self.selected_obj.obj_type == "Work Product":
+                self._constrain_to_parent(self.selected_obj)
             dx = self.selected_obj.x - old_x
             dy = self.selected_obj.y - old_y
             if self.selected_obj.obj_type in ("Part", "Block Boundary"):
@@ -4818,9 +4872,26 @@ class SysMLDiagramWindow(tk.Frame):
                                 p.y += dy
             if self.selected_obj.obj_type == "System Boundary":
                 for o in self.objects:
-                    if o.properties.get("boundary") == str(self.selected_obj.obj_id):
-                        o.x += dx
-                        o.y += dy
+                    if (
+                        o.obj_type == "Work Product"
+                        and o.properties.get("parent") == str(self.selected_obj.obj_id)
+                    ):
+                        off = self._child_drag_offsets.get(o.obj_id)
+                        if off is not None:
+                            o.x = self.selected_obj.x + off[0]
+                            o.y = self.selected_obj.y + off[1]
+                        else:
+                            o.x += dx
+                            o.y += dy
+                        self._constrain_to_parent(o, self.selected_obj)
+                    elif o.properties.get("boundary") == str(self.selected_obj.obj_id):
+                        off = self._child_drag_offsets.get(o.obj_id)
+                        if off is not None:
+                            o.x = self.selected_obj.x + off[0]
+                            o.y = self.selected_obj.y + off[1]
+                        else:
+                            o.x += dx
+                            o.y += dy
             boundary = self.get_ibd_boundary()
             if boundary:
                 ensure_boundary_contains_parts(boundary, self.objects)
@@ -5185,13 +5256,16 @@ class SysMLDiagramWindow(tk.Frame):
             self.dragging_endpoint = None
             self.conn_drag_offset = None
             self.endpoint_drag_pos = None
+        self._child_drag_offsets = {}
         if self.selected_obj and self.current_tool == "Select":
-            if self.selected_obj.obj_type != "System Boundary":
+            if self.selected_obj.obj_type not in ("System Boundary", "Work Product"):
                 b = self.find_boundary_for_obj(self.selected_obj)
                 if b:
                     self.selected_obj.properties["boundary"] = str(b.obj_id)
                 else:
                     self.selected_obj.properties.pop("boundary", None)
+            elif self.selected_obj.obj_type == "Work Product":
+                self.selected_obj.properties.pop("boundary", None)
             self._sync_to_repository()
         self.redraw()
 
@@ -5303,6 +5377,15 @@ class SysMLDiagramWindow(tk.Frame):
 
     def on_rc_release(self, event):
         if not self.rc_dragged:
+            x = self.canvas.canvasx(event.x) / self.zoom
+            y = self.canvas.canvasy(event.y) / self.zoom
+            area = self.find_boundary_at(x, y)
+            if area:
+                name = area.properties.get("name", "")
+                wp_name = self._select_work_product_for_area(name)
+                if wp_name:
+                    self._place_work_product(wp_name, x, y, area=area)
+                return
             self.show_context_menu(event)
 
     def show_context_menu(self, event):
@@ -8901,6 +8984,22 @@ class SysMLDiagramWindow(tk.Frame):
                 return b
         return None
 
+    def find_boundary_at(self, x: float, y: float) -> SysMLObject | None:
+        """Return the process area containing (x, y) if any.
+
+        Coordinates are in diagram space, not canvas pixels.
+        """
+        for b in reversed(self.objects):
+            if b.obj_type != "System Boundary":
+                continue
+            left = b.x - b.width / 2
+            right = b.x + b.width / 2
+            top = b.y - b.height / 2
+            bottom = b.y + b.height / 2
+            if left <= x <= right and top <= y <= bottom:
+                return b
+        return None
+
     def _update_drag_selection(self, x: float, y: float) -> None:
         if not self.select_rect_start:
             return
@@ -11224,7 +11323,8 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         self._activate_parent_phase()
         self.refresh_from_repository()
         self._pending_wp_name: str | None = None
-        self._pending_area_name: str | None = None
+        self._pending_wp_step: str = ""
+        self._pending_wp_lock: bool = True
 
     def _activate_parent_phase(self) -> None:
         """Activate the lifecycle phase containing this diagram.
@@ -11268,7 +11368,6 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             cmds = [
                 ("Add Work Product", self.add_work_product),
                 ("Add Generic Work Product", self.add_generic_work_product),
-                ("Add Process Area", self.add_process_area),
                 ("Add Lifecycle Phase", self.add_lifecycle_phase),
             ]
             for name, cmd in cmds:
@@ -11409,87 +11508,30 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             self.selection = self.var.get()
 
     def add_work_product(self):  # pragma: no cover - requires tkinter
-        def _fmt(req: str) -> str:
-            return " ".join(
-                word.upper() if word.isupper() else word.capitalize()
-                for word in req.split()
-            )
-
-        options = [
-            "Architecture Diagram",
-            "Safety & Security Concept",
-            "Mission Profile",
-            "Reliability Analysis",
-            "Causal Bayesian Network Analysis",
-            "Safety & Security Case",
-            "GSN Argumentation",
-            *REQUIREMENT_WORK_PRODUCTS,
-            "HAZOP",
-            "STPA",
-            "Threat Analysis",
-            "FI2TC",
-            "TC2FI",
-            "Risk Assessment",
-            "Product Goal Specification",
-            "FTA",
-            "FMEA",
-            "FMEDA",
-            "SPI Work Document",
-            "Scenario Library",
-            "ODD",
-        ]
-        options = list(dict.fromkeys(options))
-        area_map = {
-            "Architecture Diagram": "System Design (Item Definition)",
-            "Safety & Security Concept": "System Design (Item Definition)",
-            "Mission Profile": "Safety Analysis",
-            "Reliability Analysis": "Safety Analysis",
-            "Causal Bayesian Network Analysis": "Safety Analysis",
-            "Safety & Security Case": "Safety & Security Management",
-            "GSN Argumentation": "Safety & Security Management",
-            "Product Goal Specification": "System Design (Item Definition)",
-            **{wp: "System Design (Item Definition)" for wp in REQUIREMENT_WORK_PRODUCTS},
-            "HAZOP": "Hazard & Threat Analysis",
-            "STPA": "Hazard & Threat Analysis",
-            "Threat Analysis": "Hazard & Threat Analysis",
-            "FI2TC": "Hazard & Threat Analysis",
-            "TC2FI": "Hazard & Threat Analysis",
-            "Risk Assessment": "Risk Assessment",
-            "FTA": "Safety Analysis",
-            "FMEA": "Safety Analysis",
-            "FMEDA": "Safety Analysis",
-            "SPI Work Document": "Safety & Security Management",
-            "Scenario Library": "Scenario",
-            "ODD": "Scenario",
-        }
-        areas = {
-            o.properties.get("name")
-            for o in self.objects
-            if o.obj_type == "System Boundary"
-        }
-        options = [
-            opt for opt in options if not area_map.get(opt) or area_map[opt] in areas
-        ]
-        dlg = self._SelectDialog(self, "Add Work Product", options)
-        name = getattr(dlg, "selection", "")
-        if not name:
-            return
-        required = area_map.get(name)
-        if required and required not in areas:
-            messagebox.showerror(
-                "Missing Process Area",
-                f"Add process area '{required}' before adding this work product.",
-            )
-            return
         if not getattr(self, "canvas", None):
-            self._place_work_product(name, 100.0, 100.0)
+            area_name = self._select_process_area()
+            if not area_name:
+                return
+            area = self._place_process_area(area_name, 100.0, 100.0)
+            wp_name = self._select_work_product_for_area(area_name)
+            if not wp_name:
+                return
+            self._place_work_product(wp_name, 100.0, 100.0, area=area)
         else:
-            self._pending_wp_name = name
-            self._pending_wp_lock = True
+            self._pending_wp_step = "loc"
             try:
                 self.canvas.configure(cursor="crosshair")
             except Exception:
                 pass
+
+    def _select_process_area(self) -> str:  # pragma: no cover - requires tkinter
+        dlg = self._SelectDialog(self, "Add Process Area", PROCESS_AREA_OPTIONS)
+        return getattr(dlg, "selection", "")
+
+    def _select_work_product_for_area(self, area_name: str) -> str:  # pragma: no cover - requires tkinter
+        options = _work_products_for_area(area_name)
+        dlg = self._SelectDialog(self, "Add Work Product", options)
+        return getattr(dlg, "selection", "")
 
     def add_generic_work_product(self):  # pragma: no cover - requires tkinter
         name = simpledialog.askstring("Add Work Product", "Enter work product name:")
@@ -11515,34 +11557,20 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             except Exception:
                 pass
 
-    def add_process_area(self):  # pragma: no cover - requires tkinter
-        options = [
-            "System Design (Item Definition)",
-            "Hazard & Threat Analysis",
-            "Risk Assessment",
-            "Safety & Security Management",
-            "Safety Analysis",
-            "Scenario",
-        ]
-        dlg = self._SelectDialog(self, "Add Process Area", options)
-        name = getattr(dlg, "selection", "")
-        if not name:
-            return
-        if not getattr(self, "canvas", None):
-            self._place_process_area(name, 100.0, 100.0)
-        else:
-            self._pending_area_name = name
-            try:
-                self.canvas.configure(cursor="crosshair")
-            except Exception:
-                pass
-
     def _place_work_product(
-        self, name: str, x: float, y: float, *, lock_name: bool = True
+        self,
+        name: str,
+        x: float,
+        y: float,
+        *,
+        lock_name: bool = True,
+        area: SysMLObject | None = None,
     ) -> SysMLObject:
         props = {"name": name}
         if lock_name:
             props["name_locked"] = "1"
+        if area:
+            props["parent"] = str(area.obj_id)
         obj = SysMLObject(
             _get_next_id(),
             "Work Product",
@@ -11552,6 +11580,8 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             height=80.0,
             properties=props,
         )
+        if area:
+            self._constrain_to_parent(obj, area)
         self.objects.append(obj)
         self.sort_objects()
         self._sync_to_repository()
@@ -11567,7 +11597,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             self.app.refresh_tool_enablement()
         return obj
 
-    def _place_process_area(self, name: str, x: float, y: float) -> None:
+    def _place_process_area(self, name: str, x: float, y: float) -> SysMLObject:
         obj = SysMLObject(
             _get_next_id(),
             "System Boundary",
@@ -11583,21 +11613,62 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         self.redraw()
         if getattr(self.app, "enable_process_area", None):
             self.app.enable_process_area(name)
+        return obj
+
+    def _constrain_to_parent(
+        self, obj: SysMLObject, area: SysMLObject | None = None
+    ) -> None:
+        if obj.obj_type != "Work Product":
+            return
+        if area is None:
+            pid = obj.properties.get("parent")
+            if not pid:
+                return
+            area = self.get_object(int(pid))
+        if not area:
+            return
+        left = area.x - area.width / 2 + obj.width / 2
+        right = area.x + area.width / 2 - obj.width / 2
+        top = area.y - area.height / 2 + obj.height / 2
+        bottom = area.y + area.height / 2 - obj.height / 2
+        obj.x = min(max(obj.x, left), right)
+        obj.y = min(max(obj.y, top), bottom)
 
     def on_left_press(self, event):  # pragma: no cover - requires tkinter
         pending_wp = getattr(self, "_pending_wp_name", None)
-        pending_area = getattr(self, "_pending_area_name", None)
-        if pending_wp or pending_area:
+        step = getattr(self, "_pending_wp_step", "")
+        if step == "loc":
             x = self.canvas.canvasx(event.x) / self.zoom
             y = self.canvas.canvasy(event.y) / self.zoom
-            if pending_wp:
-                self._pending_wp_name = None
-                lock = getattr(self, "_pending_wp_lock", True)
-                self._pending_wp_lock = True
-                self._place_work_product(pending_wp, x, y, lock_name=lock)
-            else:
-                self._pending_area_name = None
-                self._place_process_area(pending_area, x, y)
+            self._pending_wp_step = ""
+            try:
+                self.canvas.configure(cursor="arrow")
+            except Exception:
+                pass
+            area = self.find_boundary_at(x, y)
+            if area:
+                area_name = area.properties.get("name", "")
+                wp_name = self._select_work_product_for_area(area_name)
+                if not wp_name:
+                    return
+                self._place_work_product(wp_name, x, y, area=area)
+                return
+            area_name = self._select_process_area()
+            if not area_name:
+                return
+            area = self._place_process_area(area_name, x, y)
+            wp_name = self._select_work_product_for_area(area_name)
+            if not wp_name:
+                return
+            self._place_work_product(wp_name, x, y, area=area)
+            return
+        if pending_wp:
+            x = self.canvas.canvasx(event.x) / self.zoom
+            y = self.canvas.canvasy(event.y) / self.zoom
+            self._pending_wp_name = None
+            lock = getattr(self, "_pending_wp_lock", True)
+            self._pending_wp_lock = True
+            self._place_work_product(pending_wp, x, y, lock_name=lock)
             try:
                 self.canvas.configure(cursor="arrow")
             except Exception:

--- a/tests/test_governance_core_actions.py
+++ b/tests/test_governance_core_actions.py
@@ -67,9 +67,9 @@ def test_governance_core_has_add_buttons(monkeypatch):
     assert {
         "Add Work Product",
         "Add Generic Work Product",
-        "Add Process Area",
         "Add Lifecycle Phase",
     } <= set(labels)
+    assert "Add Process Area" not in labels
 
     rel_sections = [child for child in getattr(core_frames[-1], "children", []) if getattr(child, "text", "") == "Relationships (relationships)"]
     assert len(rel_sections) == 1

--- a/tests/test_governance_phase_toggle.py
+++ b/tests/test_governance_phase_toggle.py
@@ -111,7 +111,7 @@ def test_add_process_area_lists_scenario(monkeypatch):
 
     monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", capture_dialog)
     win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
-    win.add_process_area()
+    win.add_work_product()
 
     assert "Scenario" in captured["options"]
 

--- a/tests/test_governance_safety_management_process_area.py
+++ b/tests/test_governance_safety_management_process_area.py
@@ -31,7 +31,7 @@ def test_safety_management_process_area_available(monkeypatch):
 
     monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", DummyDialog)
 
-    win.add_process_area()
+    win.add_work_product()
 
     assert "Safety & Security Management" in captured["options"]
     assert len(captured["options"]) == len(set(captured["options"]))

--- a/tests/test_governance_spi_work_product.py
+++ b/tests/test_governance_spi_work_product.py
@@ -40,32 +40,31 @@ def test_governance_spi_work_product_enablement(monkeypatch):
 
     win.app = DummyApp()
 
-    class MissingWpDialog:
+    class FirstDialog:
         def __init__(self, parent, title, options):
-            captured["initial_wp_options"] = options
-            self.selection = ""
+            if title == "Add Process Area":
+                self.selection = "System Design (Item Definition)"
+            else:
+                captured["initial_wp_options"] = options
+                self.selection = ""
 
-    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", MissingWpDialog)
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", FirstDialog)
     win.add_work_product()
     assert "SPI Work Document" not in captured.get("initial_wp_options", [])
 
-    class AreaDialog:
+    class SecondDialog:
         def __init__(self, parent, title, options):
-            captured["area_options"] = options
-            self.selection = "Safety & Security Management"
+            if title == "Add Process Area":
+                captured["area_options"] = options
+                self.selection = "Safety & Security Management"
+            else:
+                captured["wp_options"] = options
+                self.selection = "SPI Work Document"
 
-    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", AreaDialog)
-    win.add_process_area()
-    assert "Safety & Security Management" in captured["area_options"]
-
-    class WorkProductDialog:
-        def __init__(self, parent, title, options):
-            captured["wp_options"] = options
-            self.selection = "SPI Work Document"
-
-    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", WorkProductDialog)
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", SecondDialog)
     win.add_work_product()
 
+    assert "Safety & Security Management" in captured["area_options"]
     assert "SPI Work Document" in captured["wp_options"]
     assert enable_calls == ["SPI Work Document"]
     assert any(wp.analysis == "SPI Work Document" for wp in toolbox.work_products)

--- a/tests/test_governance_work_product_enablement.py
+++ b/tests/test_governance_work_product_enablement.py
@@ -32,13 +32,10 @@ def test_governance_work_product_enablement(analysis, area_name, monkeypatch):
     prev_tb = _sm.ACTIVE_TOOLBOX
     toolbox = SafetyManagementToolbox()
 
-    # Required process area for the selected work product
-    area = SysMLObject(1, "System Boundary", 0, 0, properties={"name": area_name})
-
     win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
-    win.objects = [area]
+    win.objects = []
     win.connections = []
     win.zoom = 1.0
     win.sort_objects = lambda: None
@@ -59,8 +56,11 @@ def test_governance_work_product_enablement(analysis, area_name, monkeypatch):
 
     class DummyDialog:
         def __init__(self, parent, title, options):
-            captured["options"] = options
-            self.selection = analysis
+            if title == "Add Process Area":
+                self.selection = area_name
+            else:
+                captured["options"] = options
+                self.selection = analysis
 
     monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", DummyDialog)
 

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -1993,25 +1993,18 @@ def test_add_work_product_uses_half_width(monkeypatch):
     win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
-    win.objects = [
-        SysMLObject(
-            2,
-            "System Boundary",
-            0.0,
-            0.0,
-            width=200.0,
-            height=150.0,
-            properties={"name": "Hazard & Threat Analysis"},
-        )
-    ]
+    win.objects = []
     win.sort_objects = lambda: None
     win._sync_to_repository = lambda: None
     win.redraw = lambda: None
     win.app = types.SimpleNamespace(enable_work_product=lambda name, *, refresh=True: None)
 
     class FakeDialog:
-        def __init__(self, *args, **kwargs):
-            self.selection = "HAZOP"
+        def __init__(self, parent, title, options):
+            if title == "Add Process Area":
+                self.selection = "Hazard & Threat Analysis"
+            else:
+                self.selection = "HAZOP"
 
     monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", FakeDialog)
 

--- a/tests/test_work_product_process_area_containment.py
+++ b/tests/test_work_product_process_area_containment.py
@@ -1,0 +1,202 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_work_product_clamped_to_process_area():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.app = None
+
+    area = win._place_process_area("Risk Assessment", 0.0, 0.0)
+    wp = win._place_work_product("Risk Assessment", 0.0, 0.0, area=area)
+
+    wp.x = area.x + area.width
+    wp.y = area.y + area.height
+    win._constrain_to_parent(wp)
+
+    assert win.find_boundary_for_obj(wp) == area
+
+
+def test_add_work_product_existing_area_click():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.app = None
+
+    area = win._place_process_area("Risk Assessment", 10.0, 10.0)
+
+    class DummyCanvas:
+        def canvasx(self, x):
+            return x
+
+        def canvasy(self, y):
+            return y
+
+        def configure(self, **kwargs):
+            pass
+
+    win.canvas = DummyCanvas()
+
+    called = {"process": 0}
+
+    def _select_process_area():
+        called["process"] += 1
+        return "Risk Assessment"
+
+    def _select_wp(area_name):
+        assert area_name == "Risk Assessment"
+        return "Risk Assessment"
+
+    win._select_process_area = _select_process_area
+    win._select_work_product_for_area = _select_wp
+
+    win.add_work_product()
+
+    class Event:
+        x = 10
+        y = 10
+
+    win.on_left_press(Event())
+
+    assert called["process"] == 0
+    wps = [o for o in win.objects if o.obj_type == "Work Product"]
+    assert len(wps) == 1
+    assert wps[0].properties.get("parent") == str(area.obj_id)
+
+
+def test_right_click_process_area_adds_work_product():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.app = None
+
+    area = win._place_process_area("Risk Assessment", 5.0, 5.0)
+
+    class DummyCanvas:
+        def canvasx(self, x):
+            return x
+
+        def canvasy(self, y):
+            return y
+
+    win.canvas = DummyCanvas()
+    win.rc_dragged = False
+
+    def _select_wp(area_name):
+        assert area_name == "Risk Assessment"
+        return "Risk Assessment"
+
+    win._select_work_product_for_area = _select_wp
+
+    class Event:
+        x = 5
+        y = 5
+
+    win.on_rc_release(Event())
+
+    wps = [o for o in win.objects if o.obj_type == "Work Product"]
+    assert len(wps) == 1
+    assert wps[0].properties.get("parent") == str(area.obj_id)
+
+
+def test_process_area_drag_moves_work_product():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.app = None
+
+    area = win._place_process_area("Risk Assessment", 0.0, 0.0)
+    wp = win._place_work_product("Risk Assessment", 10.0, 0.0, area=area)
+
+    class DummyCanvas:
+        def canvasx(self, x):
+            return x
+
+        def canvasy(self, y):
+            return y
+
+        def configure(self, **kwargs):
+            pass
+
+    win.canvas = DummyCanvas()
+    win.current_tool = "Select"
+    win.start = None
+    win.select_rect_start = None
+    win.dragging_conn_mid = None
+    win.selected_conn = None
+    win.dragging_endpoint = None
+    win.dragging_point_index = None
+    win.resizing_obj = None
+    win.selected_obj = None
+    win.selected_objs = []
+
+    class Press:
+        x = 0
+        y = 60
+        state = 0
+
+    win.on_left_press(Press())
+
+    class Drag1:
+        x = 100
+        y = 110
+
+    win.on_left_drag(Drag1())
+
+    class Drag2:
+        x = 150
+        y = 140
+
+    win.on_left_drag(Drag2())
+
+    class Release:
+        x = 150
+        y = 140
+
+    win.on_left_release(Release())
+
+    assert win.find_boundary_for_obj(wp) == area
+    assert wp.x == area.x + 10
+    assert wp.y == area.y


### PR DESCRIPTION
## Summary
- rework Add Work Product workflow to place process area first and keep work products inside
- remove standalone Add Process Area button from Governance Core toolbox
- add tests for process area dialog options and work product containment
- allow adding work products to existing process areas via clicks or right-clicks
- clamp work products to their process area when the area is moved
- keep work products fixed relative to their process area when the area is dragged

## Testing
- `pytest tests/test_governance_core_actions.py tests/test_governance_work_product_enablement.py tests/test_safety_management.py::test_add_work_product_uses_half_width tests/test_governance_safety_management_process_area.py tests/test_governance_spi_work_product.py tests/test_governance_phase_toggle.py::test_add_process_area_lists_scenario tests/test_work_product_process_area_containment.py`

------
https://chatgpt.com/codex/tasks/task_b_68a3deec7d2c8327aa323e955618ec67