### PR TITLE
Ensure tabs detach when released outside notebook

### DIFF
--- a/gui/closable_notebook.py
+++ b/gui/closable_notebook.py
@@ -154,19 +154,26 @@ class ClosableNotebook(ttk.Notebook):
             return
 
         tab_index = self._drag_data["tab"]
-        if tab_index is not None and self._dragging:
-            try:
-                tab_id = self.tabs()[tab_index]
-            except IndexError:
-                self._reset_drag()
-                return
-            widget = self.winfo_containing(event.x_root, event.y_root)
-            while widget is not None and not isinstance(widget, ClosableNotebook):
-                widget = widget.master
-            if isinstance(widget, ClosableNotebook) and widget is not self:
-                self._move_tab(tab_id, widget)
-            else:
-                self._detach_tab(tab_id, event.x_root, event.y_root)
+        if tab_index is not None:
+            outside = (
+                event.x < 0
+                or event.y < 0
+                or event.x >= self.winfo_width()
+                or event.y >= self.winfo_height()
+            )
+            if self._dragging or outside:
+                try:
+                    tab_id = self.tabs()[tab_index]
+                except IndexError:
+                    self._reset_drag()
+                    return
+                widget = self.winfo_containing(event.x_root, event.y_root)
+                while widget is not None and not isinstance(widget, ClosableNotebook):
+                    widget = widget.master
+                if isinstance(widget, ClosableNotebook) and widget is not self:
+                    self._move_tab(tab_id, widget)
+                else:
+                    self._detach_tab(tab_id, event.x_root, event.y_root)
         self._reset_drag()
 
     def _move_tab(self, tab_id: str, target: "ClosableNotebook") -> bool:

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -43,3 +43,28 @@ def test_tab_detach_and_reattach():
     assert len(nb.tabs()) == 1
     assert frame.master is nb
     root.destroy()
+
+
+def test_tab_detach_without_motion():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    nb = ClosableNotebook(root)
+    frame = ttk.Frame(nb)
+    nb.add(frame, text="Tab1")
+    nb.update_idletasks()
+
+    class Event: ...
+
+    press = Event(); press.x = 5; press.y = 5
+    nb._on_tab_press(press)
+    release = Event()
+    release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+    release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+    release.x = nb.winfo_width() + 40
+    release.y = nb.winfo_height() + 40
+    nb._on_tab_release(release)
+
+    assert len(nb.tabs()) == 0
+    root.destroy()


### PR DESCRIPTION
## Summary
- Allow detaching tabs even when no drag motion event was received by checking release coordinates
- Cover tab detachment without motion in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3e8003a308327ad1c953bf895843e