### PR TITLE
Format governance tooltips as table for readability

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -370,11 +370,25 @@ def _gov_connection_text(node_type: str) -> str:
                 incoming.setdefault(rel, []).append(src)
     if not outgoing and not incoming:
         return ""
-    lines = ["To Others | From Others"]
+
+    rows: list[tuple[str, str, str]] = []
     for rel in sorted(set(outgoing) | set(incoming)):
         outs = ", ".join(outgoing.get(rel, []))
         ins = ", ".join(sorted(incoming.get(rel, [])))
-        lines.append(f"{rel}: {outs} | {ins}")
+        rows.append((rel, outs, ins))
+
+    headers = ("Relation", "To Others", "From Others")
+    col_widths = [
+        max(len(row[i]) for row in rows + [headers]) for i in range(3)
+    ]
+    lines = [
+        " | ".join(h.ljust(col_widths[i]) for i, h in enumerate(headers)),
+        "-+-".join("-" * col_widths[i] for i in range(3)),
+    ]
+    for row in rows:
+        lines.append(
+            " | ".join(row[i].ljust(col_widths[i]) for i in range(3))
+        )
     return "\n".join(lines)
 
 # Node type aliases used when validating governance diagram connections.

--- a/tests/test_governance_tooltips.py
+++ b/tests/test_governance_tooltips.py
@@ -44,11 +44,25 @@ def _expected_text(cfg, node_type: str) -> str:
                 incoming.setdefault(rel, []).append(src)
     if not outgoing and not incoming:
         return ""
-    lines = ["To Others | From Others"]
+
+    rows = []
     for rel in sorted(set(outgoing) | set(incoming)):
         outs = ", ".join(outgoing.get(rel, []))
         ins = ", ".join(sorted(incoming.get(rel, [])))
-        lines.append(f"{rel}: {outs} | {ins}")
+        rows.append((rel, outs, ins))
+
+    headers = ("Relation", "To Others", "From Others")
+    col_widths = [
+        max(len(row[i]) for row in rows + [headers]) for i in range(3)
+    ]
+    lines = [
+        " | ".join(h.ljust(col_widths[i]) for i, h in enumerate(headers)),
+        "-+-".join("-" * col_widths[i] for i in range(3)),
+    ]
+    for row in rows:
+        lines.append(
+            " | ".join(row[i].ljust(col_widths[i]) for i in range(3))
+        )
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary
- Display governance element connection info in a column-aligned table
- Update governance tooltip tests to match new formatting

## Testing
- `pytest tests/test_governance_tooltips.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3ed93317c8327a1281eb17b09ddc4