### PR TITLE
Add GLOBAL lifecycle phase for unassigned governance diagrams

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -4,6 +4,7 @@ from tkinter import ttk, simpledialog
 from functools import partial
 
 from analysis import SafetyManagementToolbox
+from analysis.safety_management import GLOBAL_PHASE
 from analysis.governance import GovernanceDiagram
 from analysis.models import (
     REQUIREMENT_TYPE_OPTIONS,
@@ -520,10 +521,7 @@ class SafetyManagementWindow(tk.Frame):
 
     def generate_lifecycle_requirements(self) -> None:
         """Generate requirements for diagrams outside of any phase."""
-        all_diags = set(self.toolbox.list_diagrams())
-        for phase in self.toolbox.list_modules():
-            all_diags -= self.toolbox.diagrams_for_module(phase)
-        diag_names = sorted(all_diags)
+        diag_names = sorted(self.toolbox.diagrams_for_module(GLOBAL_PHASE))
         if not diag_names:
             messagebox.showinfo(
                 "Requirements", "No lifecycle governance diagrams.")

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -7,6 +7,8 @@ import os
 import datetime
 import analysis.user_config as user_config
 
+GLOBAL_PHASE = "GLOBAL"
+
 
 def _diagram_type_abbreviation(diag_type: str | None) -> str:
     """Return an upper-case abbreviation for *diag_type*.
@@ -242,7 +244,7 @@ class SysMLRepository:
             author_email=user_config.CURRENT_USER_EMAIL,
             modified_by=user_config.CURRENT_USER_NAME,
             modified_by_email=user_config.CURRENT_USER_EMAIL,
-            phase=self.active_phase,
+            phase=None if self.active_phase == GLOBAL_PHASE else self.active_phase,
         )
         self.elements[elem_id] = elem
         try:
@@ -333,7 +335,7 @@ class SysMLRepository:
             author_email=user_config.CURRENT_USER_EMAIL,
             modified_by=user_config.CURRENT_USER_NAME,
             modified_by_email=user_config.CURRENT_USER_EMAIL,
-            phase=self.active_phase,
+            phase=None if self.active_phase == GLOBAL_PHASE else self.active_phase,
         )
         self.diagrams[diag_id] = diagram
         try:
@@ -509,7 +511,7 @@ class SysMLRepository:
             author_email=user_config.CURRENT_USER_EMAIL,
             modified_by=user_config.CURRENT_USER_NAME,
             modified_by_email=user_config.CURRENT_USER_EMAIL,
-            phase=self.active_phase,
+            phase=None if self.active_phase == GLOBAL_PHASE else self.active_phase,
         )
         self.relationships.append(rel)
         return rel
@@ -524,6 +526,8 @@ class SysMLRepository:
             return False
         if self.active_phase is None:
             return True
+        if self.active_phase == GLOBAL_PHASE:
+            return elem.phase is None
         if elem.phase is None:
             return False
         if elem.phase == self.active_phase or elem.phase in getattr(self, "reuse_phases", set()):
@@ -544,6 +548,8 @@ class SysMLRepository:
             return True
         if self.active_phase is None:
             return True
+        if self.active_phase == GLOBAL_PHASE:
+            return diag.phase is None
         if diag.diag_type == "Governance Diagram" and diag.phase is None:
             return True
         if diag.phase is None:
@@ -643,6 +649,8 @@ class SysMLRepository:
             return True
         if self.active_phase is None:
             return True
+        if self.active_phase == GLOBAL_PHASE:
+            return obj.get("phase") is None
         if diag and diag.diag_type == "Governance Diagram" and obj.get("phase") is None:
             return True
         if obj.get("phase") is None:
@@ -656,6 +664,8 @@ class SysMLRepository:
             return True
         if self.active_phase is None:
             return True
+        if self.active_phase == GLOBAL_PHASE:
+            return conn.get("phase") is None
         if diag and diag.diag_type == "Governance Diagram" and conn.get("phase") is None:
             return True
         if conn.get("phase") is None:

--- a/tests/test_phase_display_and_freeze.py
+++ b/tests/test_phase_display_and_freeze.py
@@ -38,6 +38,6 @@ def test_phase_freezes_after_work_product():
     assert "Gov" in tb.frozen_diagrams
     assert repo.diagram_read_only(diag_id)
     tb.rename_module("P1", "New")
-    assert tb.list_modules() == ["P1"]
+    assert tb.list_modules() == ["P1", "GLOBAL"]
     tb.rename_diagram("Gov", "Other")
     assert "Gov" in tb.diagrams

--- a/tests/test_phase_requirement_updates.py
+++ b/tests/test_phase_requirement_updates.py
@@ -21,9 +21,9 @@ def _setup_window(monkeypatch):
     win = SafetyManagementWindow.__new__(SafetyManagementWindow)
     toolbox = types.SimpleNamespace(
         diagrams={"D": "id1", "L": "id2"},
-        diagrams_for_module=lambda phase: {"D"} if phase == "Phase1" else set(),
-        list_modules=lambda: ["Phase1"],
-        module_for_diagram=lambda name: "Phase1" if name == "D" else None,
+        diagrams_for_module=lambda phase: {"D"} if phase == "Phase1" else {"L"} if phase == "GLOBAL" else set(),
+        list_modules=lambda: ["Phase1", "GLOBAL"],
+        module_for_diagram=lambda name: "Phase1" if name == "D" else "GLOBAL",
         list_diagrams=lambda: {"D", "L"},
     )
     win.toolbox = toolbox

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -2357,7 +2357,7 @@ def test_list_modules_includes_submodules():
     child = GovernanceModule("Child")
     parent = GovernanceModule("Parent", modules=[child])
     toolbox.modules = [parent]
-    assert set(toolbox.list_modules()) == {"Parent", "Child"}
+    assert set(toolbox.list_modules()) == {"Parent", "Child", "GLOBAL"}
 
 
 def test_enabled_products_only_active_module():

--- a/tests/test_unique_phase_names.py
+++ b/tests/test_unique_phase_names.py
@@ -10,6 +10,6 @@ def test_add_module_enforces_unique_names():
     child = tb.add_module("Phase", parent=parent)
     assert [m.name for m in tb.modules] == ["Phase", "Phase_1", "Parent"]
     assert child.name == "Phase_2"
-    assert tb.list_modules() == ["Phase", "Phase_1", "Parent", "Phase_2"]
-    assert len(set(tb.list_modules())) == 4
+    assert tb.list_modules() == ["Phase", "Phase_1", "Parent", "Phase_2", "GLOBAL"]
+    assert len(set(tb.list_modules())) == 5
     safety_management.ACTIVE_TOOLBOX = prev


### PR DESCRIPTION
## Summary
- Add `GLOBAL` lifecycle phase constant and include it when listing phases
- Treat diagrams without a phase as belonging to `GLOBAL` and generate lifecycle requirements from them
- Ensure repository visibility and creation logic respects the `GLOBAL` phase
- Update tests for new `GLOBAL` phase behavior

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_b_68a42275d7cc8327877f7515ac93ce4e