### PR TITLE
feat(gui): add gradient theme

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -228,7 +228,7 @@ import sys
 import json
 import tkinter as tk
 from tkinter import ttk, filedialog, simpledialog, scrolledtext
-from gui import messagebox, logger, add_treeview_scrollbars
+from gui import messagebox, logger, add_treeview_scrollbars, apply_gradient_theme
 from gui.tooltip import ToolTip
 from gui.style_manager import StyleManager
 from gui.review_toolbox import (
@@ -17660,7 +17660,7 @@ class AutoMLApp:
                 self._tab_right_btn.state(["!disabled"])
 
     def _make_doc_tab_visible(self, tab_id: str) -> None:
-        if tab_id not in self._doc_all_tabs:
+        if not hasattr(self, "_doc_all_tabs") or tab_id not in self._doc_all_tabs:
             return
         index = self._doc_all_tabs.index(tab_id)
         if index < self._doc_tab_offset:
@@ -21815,6 +21815,7 @@ class PageDiagram:
 
 def main():
     root = tk.Tk()
+    apply_gradient_theme(root)
     # Prevent the main window from being resized so small that
     # widgets and toolbars become unusable.
     root.minsize(1200, 700)

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 """Shared GUI helpers and widget customizations."""
 
+import tkinter as tk
 from tkinter import ttk
 
 
@@ -78,3 +79,49 @@ def _sortable_heading(self, column, option=None, **kw):
 
 
 ttk.Treeview.heading = _sortable_heading
+
+
+def _create_gradient_image(width: int = 200, height: int = 200) -> tk.PhotoImage:
+    """Return a vertical gradient image from light blue to white.
+
+    The bottom few pixels use a darker grey to create a subtle 3D effect.
+    """
+    top = (0xAD, 0xD8, 0xE6)  # light blue
+    img = tk.PhotoImage(width=width, height=height)
+    for y in range(height):
+        r = int(top[0] + (0xFF - top[0]) * y / (height - 1))
+        g = int(top[1] + (0xFF - top[1]) * y / (height - 1))
+        b = int(top[2] + (0xFF - top[2]) * y / (height - 1))
+        if y > height * 0.95:
+            r = g = b = 0xA0  # thin dark band at the bottom
+        img.put(f"#{r:02x}{g:02x}{b:02x}", to=(0, y, width, y + 1))
+    return img
+
+
+def apply_gradient_theme(root: tk.Misc) -> None:
+    """Apply a light-blue gradient theme to common ttk widgets."""
+    style = ttk.Style(root)
+    try:
+        style.theme_use("clam")
+    except tk.TclError:
+        pass
+    gradient = _create_gradient_image(400, 200)
+    style.element_create("Gradient", "image", gradient, border=0, sticky="nsew")
+    style.layout("TFrame", [("Gradient", {"sticky": "nsew"})])
+    style.layout(
+        "TButton",
+        [
+            (
+                "Gradient",
+                {
+                    "sticky": "nsew",
+                    "children": [
+                        ("Button.focus", {"sticky": "nsew", "children": [("Button.label", {"sticky": "nsew"})]})
+                    ],
+                },
+            )
+        ],
+    )
+    style.configure("TButton", padding=5, relief="flat")
+    # Keep a reference to prevent the image from being garbage collected
+    root._gradient_image = gradient


### PR DESCRIPTION
## Summary
- apply a light blue to white gradient background across ttk widgets
- initialize gradient styling during application start
- guard document tab visibility logic against missing tab lists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a4277c3ef4832786dbf7189872e409