### PR TITLE
style: update window and toolbox colors

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2234,6 +2234,65 @@ class AutoMLApp:
         except tk.TclError:
             pass
         self.style.configure("Treeview", font=("Arial", 10))
+        # ------------------------------------------------------------------
+        # Global color theme inspired by Windows classic / Windows 7
+        # ------------------------------------------------------------------
+        # Overall workspace background
+        root.configure(background="#f0f0f0")
+        # Toolbox/LabelFrame titles
+        self.style.configure(
+            "Toolbox.TLabelframe",
+            background="#fef9e7",
+            bordercolor="#888888",
+            borderwidth=1,
+            relief="solid",
+        )
+        self.style.configure(
+            "Toolbox.TLabelframe.Label",
+            background="#f8e27c",
+            foreground="black",
+            font=("Segoe UI", 10, "bold"),
+            padding=(4, 0, 0, 0),
+            anchor="w",
+        )
+        self.style.map(
+            "Toolbox.TLabelframe.Label",
+            background=[("active", "#e0c95c"), ("!active", "#f8e27c")],
+        )
+        # Notebook (ribbon-like) title bars
+        self.style.configure(
+            "TNotebook",
+            background="#c0d4eb",
+            borderwidth=1,
+            relief="ridge",
+        )
+        self.style.configure(
+            "TNotebook.Tab",
+            background="#b5bdc9",
+            foreground="#555555",
+        )
+        self.style.map(
+            "TNotebook.Tab",
+            background=[("selected", "#4a6ea9"), ("!selected", "#b5bdc9")],
+            foreground=[("selected", "white"), ("!selected", "#555555")],
+        )
+        # Closable notebook shares the same appearance
+        self.style.configure(
+            "ClosableNotebook",
+            background="#c0d4eb",
+            borderwidth=1,
+            relief="ridge",
+        )
+        self.style.configure(
+            "ClosableNotebook.Tab",
+            background="#b5bdc9",
+            foreground="#555555",
+        )
+        self.style.map(
+            "ClosableNotebook.Tab",
+            background=[("selected", "#4a6ea9"), ("!selected", "#b5bdc9")],
+            foreground=[("selected", "white"), ("!selected", "#555555")],
+        )
         # Increase notebook tab font/size so titles are fully visible
         self.style.configure(
             "TNotebook.Tab", font=("Arial", 10), padding=(10, 5), width=20
@@ -2734,7 +2793,9 @@ class AutoMLApp:
         self.explorer_nb.add(self.analysis_tab, text="File Explorer")
 
         # --- Analyses Group ---
-        self.analysis_group = ttk.LabelFrame(self.analysis_tab, text="Analyses & Architecture")
+        self.analysis_group = ttk.LabelFrame(
+            self.analysis_tab, text="Analyses & Architecture", style="Toolbox.TLabelframe"
+        )
         self.analysis_group.pack(fill=tk.BOTH, expand=True)
 
         tree_frame = ttk.Frame(self.analysis_group)
@@ -2756,7 +2817,9 @@ class AutoMLApp:
         self.treeview = self.analysis_tree
 
         # --- Tools Section ---
-        self.tools_group = ttk.LabelFrame(self.analysis_tab, text="Tools")
+        self.tools_group = ttk.LabelFrame(
+            self.analysis_tab, text="Tools", style="Toolbox.TLabelframe"
+        )
         self.tools_group.pack(fill=tk.BOTH, expand=False, pady=5)
         top = ttk.Frame(self.tools_group)
         top.pack(side=tk.TOP, fill=tk.X)
@@ -17660,13 +17723,15 @@ class AutoMLApp:
                 self._tab_right_btn.state(["!disabled"])
 
     def _make_doc_tab_visible(self, tab_id: str) -> None:
-        if tab_id not in self._doc_all_tabs:
+        all_tabs = getattr(self, "_doc_all_tabs", [])
+        if tab_id not in all_tabs:
             return
-        index = self._doc_all_tabs.index(tab_id)
-        if index < self._doc_tab_offset:
+        index = all_tabs.index(tab_id)
+        offset = getattr(self, "_doc_tab_offset", 0)
+        if index < offset:
             self._doc_tab_offset = index
             self._update_doc_tab_visibility()
-        elif index >= self._doc_tab_offset + self.MAX_VISIBLE_TABS:
+        elif index >= offset + self.MAX_VISIBLE_TABS:
             self._doc_tab_offset = index - self.MAX_VISIBLE_TABS + 1
             self._update_doc_tab_visibility()
 


### PR DESCRIPTION
## Summary
- Apply Windows classic inspired color palette to toolboxes and window title bars
- Style label frames for docked panels and notebooks with blue and golden hues
- Harden document tab visibility logic against missing attributes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a42a43a10c832787aeb29990baac3d