### PR TITLE
feat: add transparent tooltip and mac-like buttons

### DIFF
--- a/gui/mac_button_style.py
+++ b/gui/mac_button_style.py
@@ -1,28 +1,37 @@
 from __future__ import annotations
 
 from tkinter import ttk
+import tkinter as tk
 
 
 def apply_mac_button_style(style: ttk.Style | None = None) -> ttk.Style:
-    """Configure ``ttk.Button`` widgets to mimic macOS capsule buttons.
+    """Configure ``ttk.Button`` widgets to mimic macOS transparent capsule buttons.
 
-    The function adjusts padding, border and relief to give buttons a rounded
-    3D appearance that resembles native macOS controls.  The style changes are
-    applied to the passed ``ttk.Style`` instance.  If no *style* is supplied a
-    new instance is created.
+    Padding, borders and relief are adjusted for a rounded capsule look while
+    using a transparent background so buttons blend with their surroundings.
+    The style changes are applied to the passed ``ttk.Style`` instance. If no
+    *style* is supplied a new instance is created.
     """
     style = style or ttk.Style()
     style.configure(
         "TButton",
         padding=(10, 5),
-        relief="raised",
+        relief="flat",
         borderwidth=1,
         foreground="black",
-        background="#e1e1e1",
     )
+
+    try:
+        style.configure("TButton", background="systemTransparent")
+        bg_map = [("active", "systemTransparent"), ("pressed", "systemTransparent")]
+    except tk.TclError:
+        # Fall back to default backgrounds if transparency isn't supported
+        style.configure("TButton", background="")
+        bg_map = [("active", ""), ("pressed", "")]
+
     style.map(
         "TButton",
-        background=[("active", "#f5f5f5"), ("pressed", "#d9d9d9")],
-        relief=[("pressed", "sunken"), ("!pressed", "raised")],
+        background=bg_map,
+        relief=[("pressed", "sunken"), ("!pressed", "flat")],
     )
     return style

--- a/gui/tooltip.py
+++ b/gui/tooltip.py
@@ -34,6 +34,8 @@ class ToolTip:
         # Ensure the tooltip stays above other windows
         try:
             tw.wm_attributes("-topmost", True)
+            # Make the tooltip semi-transparent for a subtle appearance
+            tw.wm_attributes("-alpha", 0.85)
         except tk.TclError:
             pass
 
@@ -48,9 +50,9 @@ class ToolTip:
             tw,
             width=width,
             height=height,
-            background="#ffffe0",
-            relief="solid",
-            borderwidth=1,
+            background="",
+            relief="flat",
+            borderwidth=0,
             wrap="none",
         )
         vbar = ttk.Scrollbar(tw, orient="vertical", command=text.yview)


### PR DESCRIPTION
## Summary
- make tooltip window semi-transparent and remove default background/border
- style ttk buttons as macOS-like transparent capsules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a43668b41c832793d56a3e4234daeb