### PR TITLE
Use transparent tooltips and mac-style capsule buttons

### DIFF
--- a/gui/mac_button_style.py
+++ b/gui/mac_button_style.py
@@ -15,14 +15,18 @@ def apply_mac_button_style(style: ttk.Style | None = None) -> ttk.Style:
     style.configure(
         "TButton",
         padding=(10, 5),
-        relief="raised",
+        relief="flat",
         borderwidth=1,
         foreground="black",
-        background="#e1e1e1",
+        background="",
     )
     style.map(
         "TButton",
-        background=[("active", "#f5f5f5"), ("pressed", "#d9d9d9")],
-        relief=[("pressed", "sunken"), ("!pressed", "raised")],
+        background=[
+            ("active", "#e0e0e0"),
+            ("pressed", "#d0d0d0"),
+            ("!active", ""),
+        ],
+        relief=[("pressed", "sunken"), ("!pressed", "flat")],
     )
     return style

--- a/gui/tooltip.py
+++ b/gui/tooltip.py
@@ -31,11 +31,13 @@ class ToolTip:
             y = self.widget.winfo_rooty() + self.widget.winfo_height() + 1
         self.tipwindow = tw = tk.Toplevel(self.widget)
         tw.wm_overrideredirect(True)
-        # Ensure the tooltip stays above other windows
+        # Ensure the tooltip stays above other windows and use a transparent background
         try:
             tw.wm_attributes("-topmost", True)
+            tw.wm_attributes("-transparentcolor", "#ffffe0")
         except tk.TclError:
             pass
+        tw.configure(background="#ffffe0")
 
         lines = self.text.split("\n")
         max_len = max((len(line) for line in lines), default=1)
@@ -49,8 +51,8 @@ class ToolTip:
             width=width,
             height=height,
             background="#ffffe0",
-            relief="solid",
-            borderwidth=1,
+            relief="flat",
+            borderwidth=0,
             wrap="none",
         )
         vbar = ttk.Scrollbar(tw, orient="vertical", command=text.yview)


### PR DESCRIPTION
## Summary
- Render tooltips with transparent backgrounds to blend with the interface
- Style ttk buttons like macOS capsules with flat relief and translucent hover states

## Testing
- `pytest tests/test_governance_tooltips.py tests/test_gui_classes.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a43668b41c832793d56a3e4234daeb