### PR TITLE
Make tooltips translucent and style buttons like macOS

### DIFF
--- a/gui/mac_button_style.py
+++ b/gui/mac_button_style.py
@@ -15,14 +15,14 @@ def apply_mac_button_style(style: ttk.Style | None = None) -> ttk.Style:
     style.configure(
         "TButton",
         padding=(10, 5),
-        relief="raised",
-        borderwidth=1,
+        relief="flat",
+        borderwidth=0,
         foreground="black",
-        background="#e1e1e1",
+        background="",
     )
     style.map(
         "TButton",
-        background=[("active", "#f5f5f5"), ("pressed", "#d9d9d9")],
-        relief=[("pressed", "sunken"), ("!pressed", "raised")],
+        background=[("active", ""), ("pressed", "")],
+        relief=[("pressed", "sunken"), ("!pressed", "flat")],
     )
     return style

--- a/gui/tooltip.py
+++ b/gui/tooltip.py
@@ -31,9 +31,10 @@ class ToolTip:
             y = self.widget.winfo_rooty() + self.widget.winfo_height() + 1
         self.tipwindow = tw = tk.Toplevel(self.widget)
         tw.wm_overrideredirect(True)
-        # Ensure the tooltip stays above other windows
+        # Ensure the tooltip stays above other windows and make it translucent
         try:
             tw.wm_attributes("-topmost", True)
+            tw.wm_attributes("-alpha", 0.9)
         except tk.TclError:
             pass
 
@@ -48,9 +49,10 @@ class ToolTip:
             tw,
             width=width,
             height=height,
-            background="#ffffe0",
-            relief="solid",
-            borderwidth=1,
+            background=tw.cget("background"),
+            relief="flat",
+            borderwidth=0,
+            highlightthickness=0,
             wrap="none",
         )
         vbar = ttk.Scrollbar(tw, orient="vertical", command=text.yview)


### PR DESCRIPTION
## Summary
- Make tooltips use translucent top-level windows and borderless text widgets
- Style ttk.Button widgets with flat, borderless configuration for macOS-like capsule buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a43668b41c832793d56a3e4234daeb