### PR TITLE
Fix line number scroll sync in Tkinter logger

### DIFF
--- a/gui/logger.py
+++ b/gui/logger.py
@@ -70,7 +70,7 @@ def init_log_window(root, height=8, dark_mode: bool = True):
         background=bg,
         foreground=fg,
         insertbackground=fg,
-        yscrollcommand=lambda *args: [scrollbar.set(*args), _line_widget.yview(*args)],
+        yscrollcommand=lambda first, last: [scrollbar.set(first, last), _line_widget.yview_moveto(first)],
     )
     log_widget.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
     scrollbar.config(command=lambda *args: [log_widget.yview(*args), _line_widget.yview(*args)])


### PR DESCRIPTION
## Summary
- ensure logger's line number widget uses yview_moveto when tracking scroll

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a441b625808327a10c79d7df27db40