### PR TITLE
Ensure version appears in Help > About dialog

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -436,10 +436,20 @@ def format_requirement(req, include_id=True):
     return " ".join(parts)
 
 
+from pathlib import Path
+
+
 def get_version() -> str:
-    """Read the tool version from the first line of README.md."""
+    """Read the tool version from the first line of README.md.
+
+    The README is located alongside this file so we resolve the path relative
+    to ``__file__``.  This avoids returning ``"Unknown"`` when the current
+    working directory is different (e.g. when launching from another folder or
+    from an installed package).
+    """
     try:
-        with open("README.md", "r", encoding="utf-8") as f:
+        readme = Path(__file__).resolve().parent / "README.md"
+        with readme.open("r", encoding="utf-8") as f:
             first_line = f.readline().strip()
             if first_line.lower().startswith("version:"):
                 return first_line.split(":", 1)[1].strip()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.1.5
+version: 0.1.6
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1602,6 +1602,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.1.6 - Fixed version display in Help → About and splash screen.
 - 0.1.5 - Added a pastel style with peach actions and steel-blue nodes.
 - 0.1.4 - Initial diagram style support documented.
 - 0.1.3 - Added context menu actions to remove parts from a diagram or from the model.


### PR DESCRIPTION
## Summary
- read tool version from README using path relative to `AutoML.py` so Help/About no longer shows "Unknown"
- document new version number and note fix in version history

## Testing
- `pytest`
- `python - <<'PY'
import AutoML
print(AutoML.VERSION)
PY`


------
https://chatgpt.com/codex/tasks/task_b_68a46fda4f7c832783272a836dd46a1c