### PR TITLE
Handle missing background option for capsule buttons

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -41,14 +41,17 @@ class CapsuleButton(tk.Canvas):
         hover_bg: Optional[str] = None,
         **kwargs,
     ) -> None:
-        super().__init__(
-            master,
-            width=width,
-            height=height,
-            highlightthickness=0,
-            bg=master.cget("background"),
-            **kwargs,
-        )
+        init_kwargs = {
+            "width": width,
+            "height": height,
+            "highlightthickness": 0,
+        }
+        try:
+            init_kwargs["bg"] = master.cget("background")
+        except tk.TclError:
+            pass
+        init_kwargs.update(kwargs)
+        super().__init__(master, **init_kwargs)
         self._command = command
         self._text = text
         self._normal_color = bg


### PR DESCRIPTION
## Summary
- Prevent CapsuleButton from failing when its master widget lacks a `background` option by gracefully handling `TclError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a479ecf8b483279a5e82eefc440428