### PR TITLE
fix: smooth explorer animation

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -10413,7 +10413,14 @@ class AutoMLApp:
             self._cancel_explorer_hide()
             return
         self._explorer_tab.pack_forget()
-        self.main_pane.add(self.explorer_nb, width=0, before=self.doc_frame)
+        # Adding the pane with ``width=0`` often results in Tk briefly
+        # allocating a large default width before our animation kicks in.
+        # This caused a distracting flash of a full-sized panel prior to the
+        # slide-out effect.  To ensure a smooth animation, add the explorer
+        # pane first and immediately force its width to zero before scheduling
+        # the animation.
+        self.main_pane.add(self.explorer_nb, before=self.doc_frame)
+        self.main_pane.paneconfig(self.explorer_nb, width=0)
         if animate:
             self._animate_explorer_show(0)
         else:


### PR DESCRIPTION
## Summary
- ensure explorer pane width is set to zero before animation to avoid flash

## Testing
- `pytest`
- `radon cc AutoML.py -j` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a48191f8e883279406ff981d27e4ef