### PR TITLE
Add auto-sizing icon buttons

### DIFF
--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -1,0 +1,38 @@
+import tkinter as tk
+from tkinter import ttk
+import tkinter.font as tkfont
+from typing import Optional
+
+
+def create_tool_button(master, text: str, command=None, icon: Optional[tk.PhotoImage] = None) -> ttk.Button:
+    """Return a ttk.Button that sizes itself to fit *text* and icon.
+
+    The button ensures its width and height are at least large enough to
+    display both the icon and the text without clipping. A square shape is used
+    as a minimum so icon-only buttons appear circular.
+    """
+    btn = ttk.Button(master, text=text, command=command)
+    if icon is not None:
+        btn.configure(image=icon, compound=tk.LEFT)
+
+    def _resize() -> None:
+        # Determine the pixel width/height the button requests
+        btn.update_idletasks()
+        req_w = btn.winfo_reqwidth()
+        req_h = btn.winfo_reqheight()
+        size = max(req_w, req_h)
+
+        # Convert pixel dimensions to character units expected by ttk.Button
+        try:
+            font = tkfont.nametofont(btn.cget("font"))
+            char_width = font.measure("0") or 1
+            line_height = font.metrics("linespace") or 1
+        except Exception:
+            char_width = 7
+            line_height = 15
+
+        btn.configure(width=int((size / char_width) + 1))
+        btn.configure(height=int((size / line_height) + 1))
+
+    btn.after(0, _resize)
+    return btn

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -10,6 +10,7 @@ from gui.tooltip import ToolTip
 from gui.drawing_helper import FTADrawingHelper
 from gui.style_manager import StyleManager
 from gui.icon_factory import create_icon as draw_icon
+from gui.button_utils import create_tool_button
 
 
 class CausalBayesianNetworkWindow(tk.Frame):
@@ -65,12 +66,11 @@ class CausalBayesianNetworkWindow(tk.Frame):
             "Existing Malfunction",
             "Relationship",
         ):
-            ttk.Button(
+            create_tool_button(
                 self.toolbox,
                 text=name,
-                image=self._icons.get(name),
-                compound=tk.LEFT,
                 command=lambda t=name: self.select_tool(t),
+                icon=self._icons.get(name),
             ).pack(fill=tk.X, padx=2, pady=2)
         # Pack then immediately hide so order relative to the canvas is preserved
         self.toolbox.pack(side=tk.LEFT, fill=tk.Y)

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -17,6 +17,7 @@ from .gsn_connection_config import GSNConnectionConfig
 from . import messagebox
 from .style_manager import StyleManager
 from .icon_factory import create_icon
+from .button_utils import create_tool_button
 
 
 class ModuleSelectDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
@@ -139,12 +140,11 @@ class GSNDiagramWindow(tk.Frame):
             )
         node_frame.pack(side=tk.TOP, fill=tk.X)
         for name, cmd in node_cmds:
-            ttk.Button(
+            create_tool_button(
                 node_frame,
                 text=name,
                 command=cmd,
-                image=self._icons.get(name),
-                compound=tk.LEFT,
+                icon=self._icons.get(name),
             ).pack(fill=tk.X, padx=2, pady=2)
 
         rel_cmds = [
@@ -164,12 +164,11 @@ class GSNDiagramWindow(tk.Frame):
             )
         rel_frame.pack(side=tk.TOP, fill=tk.X)
         for name, cmd in rel_cmds:
-            ttk.Button(
+            create_tool_button(
                 rel_frame,
                 text=name,
                 command=cmd,
-                image=self._icons.get(name),
-                compound=tk.LEFT,
+                icon=self._icons.get(name),
             ).pack(fill=tk.X, padx=2, pady=2)
 
         util_cmds = [
@@ -180,12 +179,11 @@ class GSNDiagramWindow(tk.Frame):
         util_frame = ttk.Frame(self.toolbox)
         util_frame.pack(side=tk.TOP, fill=tk.X)
         for name, cmd in util_cmds:
-            ttk.Button(
+            create_tool_button(
                 util_frame,
                 text=name,
                 command=cmd,
-                image=self._icons.get(name),
-                compound=tk.LEFT,
+                icon=self._icons.get(name),
             ).pack(fill=tk.X, padx=2, pady=2)
 
         # Ensure the toolbox is wide enough to display button text

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -15,6 +15,8 @@ from gui.architecture import GovernanceDiagramWindow
 from gui import messagebox, add_treeview_scrollbars
 from sysml.sysml_repository import SysMLRepository
 from gui.toolboxes import configure_table_style, _wrap_val
+from gui.icon_factory import create_icon
+from gui.button_utils import create_tool_button
 
 
 class SafetyManagementWindow(tk.Frame):
@@ -58,25 +60,42 @@ class SafetyManagementWindow(tk.Frame):
         self.diag_cb.pack(side=tk.LEFT, padx=2)
         self.diag_cb.bind("<<ComboboxSelected>>", self.select_diagram)
 
-        ttk.Button(top, text="New", command=self.new_diagram).pack(side=tk.LEFT)
-        ttk.Button(top, text="Rename", command=self.rename_diagram).pack(side=tk.LEFT)
-        ttk.Button(top, text="Delete", command=self.delete_diagram).pack(side=tk.LEFT)
-        ttk.Button(top, text="Requirements", command=self.generate_requirements).pack(
-            side=tk.LEFT
-        )
+        self._icons = {
+            "New": create_icon("plus", "black"),
+            "Rename": create_icon("gear", "black"),
+            "Delete": create_icon("cross", "black"),
+            "Requirements": create_icon("clipboard", "black"),
+            "Lifecycle Requirements": create_icon("clipboard", "black"),
+            "Delete Obsolete": create_icon("minus", "black"),
+        }
+        create_tool_button(top, "New", self.new_diagram, self._icons["New"]).pack(side=tk.LEFT)
+        create_tool_button(
+            top, "Rename", self.rename_diagram, self._icons["Rename"]
+        ).pack(side=tk.LEFT)
+        create_tool_button(
+            top, "Delete", self.delete_diagram, self._icons["Delete"]
+        ).pack(side=tk.LEFT)
+        create_tool_button(
+            top,
+            "Requirements",
+            self.generate_requirements,
+            self._icons["Requirements"],
+        ).pack(side=tk.LEFT)
         self.phase_menu_btn = ttk.Menubutton(top, text="Phase Requirements")
         self.phase_menu = tk.Menu(self.phase_menu_btn, tearoff=False)
         self.phase_menu_btn.configure(menu=self.phase_menu)
         self.phase_menu_btn.pack(side=tk.LEFT)
-        ttk.Button(
+        create_tool_button(
             top,
-            text="Lifecycle Requirements",
-            command=self.generate_lifecycle_requirements,
+            "Lifecycle Requirements",
+            self.generate_lifecycle_requirements,
+            self._icons["Lifecycle Requirements"],
         ).pack(side=tk.LEFT)
-        ttk.Button(
+        create_tool_button(
             top,
-            text="Delete Obsolete",
-            command=self.delete_obsolete_requirements,
+            "Delete Obsolete",
+            self.delete_obsolete_requirements,
+            self._icons["Delete Obsolete"],
         ).pack(side=tk.LEFT)
 
         self.diagram_frame = ttk.Frame(self)


### PR DESCRIPTION
## Summary
- provide helper to create auto-sized toolbar buttons with optional icons
- use new helper in GSN and Bayesian network toolboxes
- add icons to Safety Management toolbox controls

## Testing
- `pytest`
- `pip install radon` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a489582b608327bbf3c8fb9a2b0dde