### PR TITLE
Ensure log toggle button visible with pinned explorer

### DIFF
--- a/gui/logger.py
+++ b/gui/logger.py
@@ -117,6 +117,10 @@ def show_log():
     log_frame.pack(side=tk.BOTTOM, fill=tk.X, before=_toggle_button)
     if _toggle_button:
         _toggle_button.config(text="Hide Logs")
+        # Ensure the toggle button remains visible when other panels
+        # (such as a pinned explorer) might overlap it by raising it
+        # to the top of the stacking order.
+        _toggle_button.lift()
     if _auto_hide_id:
         log_frame.after_cancel(_auto_hide_id)
         _auto_hide_id = None
@@ -149,6 +153,7 @@ def hide_log(animate=False):
         log_frame.configure(height=_default_height)
         if _toggle_button:
             _toggle_button.config(text="Show Logs")
+            _toggle_button.lift()
 
 
 def toggle_log():

--- a/tests/test_log_button_visibility.py
+++ b/tests/test_log_button_visibility.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pytest
+import tkinter as tk
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from AutoML import AutoMLApp
+
+
+def test_log_toggle_button_visible_with_pinned_explorer():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    app = AutoMLApp(root)
+    app.show_explorer()
+    app.toggle_explorer_pin()  # pin the explorer
+    app.toggle_logs()  # show logs
+    root.update()
+    # The toggle button should remain managed and visible
+    assert app.toggle_log_button.winfo_manager() == "pack"
+    app.toggle_logs()  # hide logs
+    root.destroy()


### PR DESCRIPTION
## Summary
- raise log toggle button in stacking order so it's accessible when explorer is pinned
- add regression test covering log toggle button visibility

## Testing
- `pytest`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a48c5e529483278ff3e181353b3d6a