### PR TITLE
Fix tab navigation button style

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2428,18 +2428,7 @@ class AutoMLApp:
             relief=[("pressed", "sunken"), ("!pressed", "raised")],
         )
         # Navigation buttons used to scroll document tabs
-        self.style.configure(
-            "Nav.TButton",
-            background="#e7edf5",
-            borderwidth=2,
-            relief="raised",
-            lightcolor="#ffffff",
-            darkcolor="#7a8a99",
-        )
-        self.style.map(
-            "Nav.TButton",
-            relief=[("pressed", "sunken"), ("!pressed", "raised")],
-        )
+        self._init_nav_button_style()
         # Increase notebook tab font/size so titles are fully visible
         self.style.configure(
             "TNotebook.Tab", font=("Arial", 10), padding=(10, 5), width=20
@@ -17997,6 +17986,22 @@ class AutoMLApp:
                             if hasattr(self, "lifecycle_var") and hasattr(self.lifecycle_var, "set"):
                                 self.lifecycle_var.set(module or "")
                     break
+
+    def _init_nav_button_style(self) -> None:
+        """Configure custom style for tab navigation buttons."""
+        self.style.configure(
+            "Nav.TButton",
+            background="#e7edf5",
+            borderwidth=2,
+            relief="raised",
+            lightcolor="#ffffff",
+            darkcolor="#7a8a99",
+        )
+        self.style.map(
+            "Nav.TButton",
+            background=[("active", "#f2f6fa"), ("pressed", "#dae2ea")],
+            relief=[("pressed", "sunken"), ("!pressed", "raised")],
+        )
 
     def _update_tool_tab_visibility(self) -> None:
         visible: list[str] = []

--- a/tests/test_navigation_buttons_style.py
+++ b/tests/test_navigation_buttons_style.py
@@ -1,0 +1,25 @@
+import types
+
+from AutoML import AutoMLApp
+
+
+class DummyStyle:
+    def __init__(self):
+        self.configured = {}
+        self.mapped = {}
+
+    def configure(self, style, **kwargs):
+        self.configured[style] = kwargs
+
+    def map(self, style, **kwargs):
+        self.mapped[style] = kwargs
+
+
+def test_nav_button_style_has_active_and_pressed_background():
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.style = DummyStyle()
+    AutoMLApp._init_nav_button_style(app)
+    mapping = app.style.mapped["Nav.TButton"]
+    assert ("active", "#f2f6fa") in mapping.get("background", [])
+    assert ("pressed", "#dae2ea") in mapping.get("background", [])
+


### PR DESCRIPTION
## Summary
- ensure tab navigation buttons use active and pressed colors for visual feedback
- cover navigation button style with tests

## Testing
- `pytest -q`
- `radon cc -s -j AutoML.py` *(fails: command not found: radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a48c34dfd48327a40490949f0a046d