### PR TITLE
Standardize toolbox button sizes across diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -22,6 +22,7 @@ from gui.drawing_helper import fta_drawing_helper
 from config import load_diagram_rules, load_json_with_comments
 import json
 from gui.icon_factory import create_icon
+from gui.button_utils import set_uniform_button_width
 
 from sysml.sysml_spec import SYSML_PROPERTIES
 from analysis.models import (
@@ -3805,6 +3806,7 @@ class SysMLDiagramWindow(tk.Frame):
                     _set_uniform_width(child)
 
         _set_uniform_width(self.toolbox)
+        set_uniform_button_width(self.toolbox)
 
         # Shrink the property view to match the button area so it does not force
         # the toolbox wider than needed. Allow the value column to stretch so it

--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -1,0 +1,33 @@
+"""Utility helpers for consistent button presentation across toolboxes."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+
+
+def set_uniform_button_width(widget: tk.Misc) -> None:
+    """Ensure all ``ttk.Button`` children of *widget* share the same width.
+
+    The width is based on the longest button label to avoid truncation and
+    provide a consistent appearance across diagram toolboxes.
+    """
+    widget.update_idletasks()
+    buttons: list[ttk.Button] = []
+    max_chars = 0
+
+    def _collect(w: tk.Misc) -> None:
+        nonlocal max_chars
+        for child in w.winfo_children():
+            if isinstance(child, ttk.Button):
+                buttons.append(child)
+                max_chars = max(max_chars, len(str(child.cget("text"))))
+            else:
+                _collect(child)
+
+    _collect(widget)
+    if not buttons:
+        return
+
+    max_chars += 2  # Account for padding inside the button
+    for btn in buttons:
+        btn.configure(width=max_chars)

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -10,6 +10,7 @@ from gui.tooltip import ToolTip
 from gui.drawing_helper import FTADrawingHelper
 from gui.style_manager import StyleManager
 from gui.icon_factory import create_icon as draw_icon
+from gui.button_utils import set_uniform_button_width
 
 
 class CausalBayesianNetworkWindow(tk.Frame):
@@ -72,7 +73,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
                 compound=tk.LEFT,
                 command=lambda t=name: self.select_tool(t),
             ).pack(fill=tk.X, padx=2, pady=2)
-        self._set_button_widths()
+        set_uniform_button_width(self.toolbox)
         # Pack then immediately hide so order relative to the canvas is preserved
         self.toolbox.pack(side=tk.LEFT, fill=tk.Y)
         self.toolbox.pack_forget()
@@ -123,17 +124,6 @@ class CausalBayesianNetworkWindow(tk.Frame):
         self._bind_shortcuts()
         self.focus_set()
 
-    def _set_button_widths(self) -> None:
-        self.toolbox.update_idletasks()
-        width = 0
-        for child in self.toolbox.winfo_children():
-            if isinstance(child, ttk.Button):
-                width = max(width, len(str(child.cget("text"))))
-        width += 2
-        for child in self.toolbox.winfo_children():
-            if isinstance(child, ttk.Button):
-                child.configure(width=width)
-
     # ------------------------------------------------------------------
     def refresh_docs(self) -> None:
         names = [doc.name for doc in getattr(self.app, "cbn_docs", [])]
@@ -177,6 +167,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
     def _fit_toolbox(self) -> None:
         """Ensure all toolbox buttons share the width of the longest."""
         self.toolbox.update_idletasks()
+        set_uniform_button_width(self.toolbox)
 
         def max_button_width(widget: tk.Misc) -> int:
             width = 0

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -17,6 +17,7 @@ from .gsn_connection_config import GSNConnectionConfig
 from . import messagebox
 from .style_manager import StyleManager
 from .icon_factory import create_icon
+from .button_utils import set_uniform_button_width
 
 
 class ModuleSelectDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
@@ -259,6 +260,7 @@ class GSNDiagramWindow(tk.Frame):
                     _set_uniform_width(child)
 
         _set_uniform_width(self.toolbox)
+        set_uniform_button_width(self.toolbox)
 
     # ------------------------------------------------------------------
     def refresh(self):  # pragma: no cover - requires tkinter

--- a/tests/test_toolbox_button_size.py
+++ b/tests/test_toolbox_button_size.py
@@ -1,0 +1,70 @@
+import os
+import tkinter as tk
+from tkinter import ttk
+from types import SimpleNamespace
+
+import pytest
+
+from gui.architecture import GovernanceDiagramWindow, BlockDiagramWindow
+from gui.gsn_diagram_window import GSNDiagramWindow
+from gui.causal_bayesian_network_window import CausalBayesianNetworkWindow
+from gsn import GSNDiagram
+from sysml.sysml_repository import SysMLRepository
+
+
+def _button_widths(widget):
+    widths = []
+    for child in widget.winfo_children():
+        if isinstance(child, ttk.Button):
+            widths.append(child.winfo_width())
+        else:
+            widths.extend(_button_widths(child))
+    return widths
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_governance_toolbox_buttons_same_width():
+    SysMLRepository.reset_instance()
+    root = tk.Tk()
+    root.withdraw()
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance", name="Gov")
+    win = GovernanceDiagramWindow(root, app=SimpleNamespace(), diagram_id=diag.diag_id)
+    root.update_idletasks()
+    widths = _button_widths(win.toolbox)
+    assert len(set(widths)) == 1
+    root.destroy()
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_block_toolbox_buttons_same_width():
+    SysMLRepository.reset_instance()
+    root = tk.Tk()
+    root.withdraw()
+    win = BlockDiagramWindow(root, app=SimpleNamespace())
+    root.update_idletasks()
+    widths = _button_widths(win.toolbox)
+    assert len(set(widths)) == 1
+    root.destroy()
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_gsn_toolbox_buttons_same_width():
+    root = tk.Tk()
+    root.withdraw()
+    win = GSNDiagramWindow(root, SimpleNamespace(), GSNDiagram("Test"))
+    root.update_idletasks()
+    widths = _button_widths(win.toolbox)
+    assert len(set(widths)) == 1
+    root.destroy()
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_cbn_toolbox_buttons_same_width():
+    root = tk.Tk()
+    root.withdraw()
+    win = CausalBayesianNetworkWindow(root, SimpleNamespace(cbn_docs=[]))
+    root.update_idletasks()
+    widths = _button_widths(win.toolbox)
+    assert len(set(widths)) == 1
+    root.destroy()


### PR DESCRIPTION
## Summary
- Add `set_uniform_button_width` utility and apply to governance, SysML, GSN, and Bayesian network diagram toolboxes
- Ensure consistent button width in all diagram toolboxes
- Add tests verifying uniform toolbox button sizing

## Testing
- `pytest -q`
- `radon cc -s -j gui/button_utils.py gui/gsn_diagram_window.py gui/causal_bayesian_network_window.py gui/architecture.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68a49039c2148327aebfe2d2edb00050