### PR TITLE
fix: use tkraise for canvas-based toggle

### DIFF
--- a/gui/logger.py
+++ b/gui/logger.py
@@ -125,7 +125,7 @@ def show_log():
         # Ensure the toggle button remains visible when other panels
         # (such as a pinned explorer) might overlap it by raising it
         # to the top of the stacking order.
-        _toggle_button.lift()
+        _toggle_button.tkraise()
     if _auto_hide_id:
         log_frame.after_cancel(_auto_hide_id)
         _auto_hide_id = None
@@ -158,7 +158,7 @@ def hide_log(animate=False):
         log_frame.configure(height=_default_height)
         if _toggle_button:
             _toggle_button.config(text="Show Logs")
-            _toggle_button.lift()
+            _toggle_button.tkraise()
 
 
 def toggle_log():


### PR DESCRIPTION
## Summary
- prevent TclError in logger by using `tkraise` with canvas-based toggle button

## Testing
- `pytest`
- `python tools/metrics_generator.py --path gui --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a497d1ba188327a77c3892fda82155