### PR TITLE
Restrict GSN diagram visibility to safety cases

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -54,6 +54,7 @@ ALLOWED_ANALYSIS_USAGE: set[tuple[str, str]] = {
     ("Reliability Analysis", "FMEA"),
     ("Reliability Analysis", "FMEDA"),
     ("ODD", "Scenario Library"),
+    ("GSN Argumentation", "Safety & Security Case"),
 }
 
 # Work products that support governed inputs from other work products

--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -118,14 +118,33 @@ class SafetyCaseExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def _available_diagrams(self):
-        """Return a list of all GSN diagrams available in the application."""
+        """Return GSN diagrams visible to the safety case."""
         if not self.app:
             return []
+
         diagrams = list(getattr(self.app, "gsn_diagrams", []))
         for mod in getattr(self.app, "gsn_modules", []):
             diagrams.extend(self._collect_module_diagrams(mod))
         if not diagrams:
             diagrams = list(getattr(self.app, "all_gsn_diagrams", []))
+
+        toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+        if toolbox:
+            reviewed = getattr(getattr(self.app, "current_review", None), "reviewed", False)
+            approved = getattr(getattr(self.app, "current_review", None), "approved", False)
+            if toolbox.can_use_as_input(
+                "GSN Argumentation",
+                "Safety & Security Case",
+                reviewed=reviewed,
+                approved=approved,
+            ):
+                diagrams = [
+                    d
+                    for d in diagrams
+                    if toolbox.document_visible("GSN Argumentation", d.root.user_name)
+                ]
+            else:
+                diagrams = []
         return diagrams
 
     # ------------------------------------------------------------------

--- a/tests/test_safety_case_gsn_visibility.py
+++ b/tests/test_safety_case_gsn_visibility.py
@@ -1,0 +1,65 @@
+import types
+
+from gsn import GSNNode, GSNDiagram
+from gui.safety_case_explorer import SafetyCaseExplorer
+from gui.architecture import SysMLObject
+from analysis.safety_management import SafetyManagementToolbox, SafetyWorkProduct
+from sysml.sysml_repository import SysMLRepository
+
+
+def _setup(rel=None):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams = {"Gov": diag.diag_id}
+
+    e1 = repo.create_element("Block", name="E1")
+    e2 = repo.create_element("Block", name="E2")
+    repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+    repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+    o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "GSN Argumentation"})
+    o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "Safety & Security Case"})
+    diag.objects = [o1.__dict__, o2.__dict__]
+    diag.connections = [{"src": 1, "dst": 2, "conn_type": rel}] if rel else []
+
+    toolbox.work_products = [
+        SafetyWorkProduct("Gov", "GSN Argumentation", ""),
+        SafetyWorkProduct("Gov", "Safety & Security Case", ""),
+    ]
+    toolbox.doc_phases = {"GSN Argumentation": {"Diag": "P1"}}
+    toolbox.active_module = "P1"
+
+    root = GSNNode("Diag", "Goal")
+    gdiag = GSNDiagram(root)
+    app = types.SimpleNamespace(
+        safety_mgmt_toolbox=toolbox,
+        current_review=types.SimpleNamespace(reviewed=False, approved=False),
+        gsn_diagrams=[gdiag],
+        gsn_modules=[],
+        all_gsn_diagrams=[],
+    )
+    explorer = SafetyCaseExplorer.__new__(SafetyCaseExplorer)
+    explorer.app = app
+    return explorer, app
+
+
+def test_gsn_diagram_visibility_for_safety_case():
+    explorer, app = _setup()
+    assert explorer._available_diagrams() == []
+
+    explorer, app = _setup("Used By")
+    assert explorer._available_diagrams()
+
+    explorer, app = _setup("Used after Review")
+    assert explorer._available_diagrams() == []
+    app.current_review.reviewed = True
+    assert explorer._available_diagrams()
+
+    explorer, app = _setup("Used after Approval")
+    assert explorer._available_diagrams() == []
+    app.current_review.reviewed = True
+    assert explorer._available_diagrams() == []
+    app.current_review.approved = True
+    assert explorer._available_diagrams()


### PR DESCRIPTION
## Summary
- allow governance links from GSN Argumentation to Safety & Security Case
- hide GSN diagrams unless a valid Used By/Review/Approval link permits viewing
- test safety case access to GSN argumentation diagrams

## Testing
- `python tools/metrics_generator.py --path gui --output metrics.json`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a4bd0d7fd0832790cf8b0156ecf361