### PR TITLE
Allow GSN safety case usage

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -54,6 +54,7 @@ ALLOWED_ANALYSIS_USAGE: set[tuple[str, str]] = {
     ("Reliability Analysis", "FMEA"),
     ("Reliability Analysis", "FMEDA"),
     ("ODD", "Scenario Library"),
+    ("GSN Argumentation", "Safety & Security Case"),
 }
 
 # Work products that support governed inputs from other work products
@@ -96,6 +97,7 @@ ALLOWED_USAGE.update(
         ("ODD", "Scenario Library"),
         ("Reliability Analysis", "FMEA"),
         ("Reliability Analysis", "FMEDA"),
+        ("GSN Argumentation", "Safety & Security Case"),
     }
 )
 

--- a/gsn/governance.py
+++ b/gsn/governance.py
@@ -1,0 +1,21 @@
+"""Governance rules for Safety & Security Case visibility of GSN diagrams."""
+from dataclasses import dataclass
+
+@dataclass
+class RelationshipStatus:
+    """Status of relationships between GSN argumentation and Safety & Security Case.
+
+    A diagram is visible only when all relationships are satisfied.
+    """
+    used_by: bool = False
+    used_after_review: bool = False
+    used_after_approval: bool = False
+
+
+def can_view_gsn_argumentation(rel: RelationshipStatus) -> bool:
+    """Return True if the Safety & Security Case may view GSN diagrams.
+
+    The rule requires the GSN argumentation to be used by the case and
+    to have passed both review and approval.
+    """
+    return rel.used_by and rel.used_after_review and rel.used_after_approval

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -1,0 +1,26 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from gsn.governance import RelationshipStatus, can_view_gsn_argumentation
+from analysis.safety_management import ALLOWED_USAGE, ALLOWED_ANALYSIS_USAGE
+
+
+def test_visibility_requires_all_relationships():
+    rel = RelationshipStatus(used_by=True, used_after_review=True, used_after_approval=True)
+    assert can_view_gsn_argumentation(rel)
+
+
+def test_visibility_fails_if_any_relationship_missing():
+    rel = RelationshipStatus(used_by=True, used_after_review=False, used_after_approval=True)
+    assert not can_view_gsn_argumentation(rel)
+    rel = RelationshipStatus(used_by=True, used_after_review=True, used_after_approval=False)
+    assert not can_view_gsn_argumentation(rel)
+    rel = RelationshipStatus(used_by=False, used_after_review=True, used_after_approval=True)
+    assert not can_view_gsn_argumentation(rel)
+
+
+def test_gsn_safety_case_dependency_allowed():
+    pair = ("GSN Argumentation", "Safety & Security Case")
+    assert pair in ALLOWED_USAGE
+    assert pair in ALLOWED_ANALYSIS_USAGE


### PR DESCRIPTION
## Summary
- allow GSN Argumentation to depend on Safety & Security Case via Used relationships
- test that dependency is registered in governance constants

## Testing
- `pytest -q`
- `radon cc -j gsn/governance.py analysis/safety_management.py > cc.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4bd0d7fd0832790cf8b0156ecf361