### PR TITLE
Allow Business Unit to Organization communication path

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -363,7 +363,8 @@
       "Communication Path": {
         "Activity": [],
         "Business Unit": [
-          "Business Unit"
+          "Business Unit",
+          "Organization"
         ],
         "Component": [],
         "Data": [],


### PR DESCRIPTION
## Summary
- permit Business Unit to Organization connections using Communication Path

## Testing
- `pytest`
- ⚠️ `pip install radon` (failed: Could not find a version that satisfies the requirement radon)


------
https://chatgpt.com/codex/tasks/task_b_68a4cceceb808327bd85a1a3f5e98b53