### PR TITLE
Highlight active lifecycle phase for users

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2993,6 +2993,10 @@ class AutoMLApp:
         )
         self.lifecycle_cb.pack(side=tk.LEFT, fill=tk.X, expand=True)
         self.lifecycle_cb.bind("<<ComboboxSelected>>", self.on_lifecycle_selected)
+        self.active_phase_lbl = ttk.Label(
+            top, text="Active phase: None", foreground="blue"
+        )
+        self.active_phase_lbl.pack(side=tk.LEFT, padx=5)
 
         # Container holding navigation buttons and the tools notebook
         nb_container = ttk.Frame(self.tools_group)
@@ -9866,6 +9870,10 @@ class AutoMLApp:
 
     def on_lifecycle_selected(self, _event=None) -> None:
         phase = self.lifecycle_var.get()
+        if hasattr(self, "active_phase_lbl"):
+            self.active_phase_lbl.config(
+                text=f"Active phase: {phase or 'None'}"
+            )
         if not phase:
             self.safety_mgmt_toolbox.set_active_module(None)
         else:

--- a/tests/test_active_phase_label.py
+++ b/tests/test_active_phase_label.py
@@ -1,0 +1,45 @@
+import types
+
+from AutoML import AutoMLApp
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, value):
+        self.value = value
+
+
+class DummyLabel:
+    def __init__(self):
+        self.text = ""
+
+    def config(self, **kwargs):
+        self.text = kwargs.get("text", self.text)
+
+
+class DummyToolbox:
+    def __init__(self):
+        self.phase = None
+
+    def set_active_module(self, phase):
+        self.phase = phase
+
+
+def test_active_phase_label_updates():
+    app = types.SimpleNamespace(
+        lifecycle_var=DummyVar(),
+        safety_mgmt_toolbox=DummyToolbox(),
+        update_views=lambda: None,
+        active_phase_lbl=DummyLabel(),
+    )
+    app.on_lifecycle_selected = AutoMLApp.on_lifecycle_selected.__get__(app, AutoMLApp)
+
+    app.lifecycle_var.set("Phase1")
+    app.on_lifecycle_selected()
+
+    assert app.active_phase_lbl.text == "Active phase: Phase1"


### PR DESCRIPTION
## Summary
- Display the active lifecycle phase next to the phase selector in the Tools section, highlighting it for visibility
- Update lifecycle selection handler to refresh the highlighted label
- Add unit test verifying the label updates with the selected phase

## Testing
- `pytest`
- `radon cc AutoML.py -j` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68a4cee9f16883278ef6edba8850a367