### PR TITLE
Add toggle to freeze governance diagrams

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -216,6 +216,25 @@ class SafetyManagementToolbox:
         return bool(mod and getattr(mod, "frozen", False))
 
     # ------------------------------------------------------------------
+    def set_diagram_frozen(self, name: str, frozen: bool) -> None:
+        """Toggle immutability of a governance diagram."""
+        diag_id = self.diagrams.get(name)
+        if not diag_id:
+            return
+        repo = SysMLRepository.get_instance()
+        if frozen:
+            repo.freeze_diagram(diag_id)
+            self.frozen_diagrams.add(name)
+        else:
+            repo.unfreeze_diagram(diag_id)
+            self.frozen_diagrams.discard(name)
+
+    # ------------------------------------------------------------------
+    def diagram_frozen(self, name: str) -> bool:
+        """Return ``True`` if the named diagram is frozen."""
+        return name in self.frozen_diagrams
+
+    # ------------------------------------------------------------------
     def freeze_active_phase(self) -> None:
         """Mark the currently active module as frozen and lock its diagrams."""
         if not self.active_module or self.module_frozen(self.active_module):

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -12663,6 +12663,7 @@ class DiagramPropertiesDialog(simpledialog.Dialog):
         super().__init__(master, title="Diagram Properties")
 
     def body(self, master):
+        self.resizable(False, False)
         ttk.Label(master, text="Name:").grid(row=0, column=0, sticky="e", padx=4, pady=2)
         self.name_var = tk.StringVar(value=self.diagram.name)
         ttk.Entry(master, textvariable=self.name_var).grid(row=0, column=1, padx=4, pady=2)
@@ -12672,17 +12673,26 @@ class DiagramPropertiesDialog(simpledialog.Dialog):
         ttk.Label(master, text="Color:").grid(row=2, column=0, sticky="e", padx=4, pady=2)
         self.color_var = tk.StringVar(value=getattr(self.diagram, "color", "#FFFFFF"))
         ttk.Entry(master, textvariable=self.color_var).grid(row=2, column=1, padx=4, pady=2)
-        if self.diagram.diag_type == "Internal Block Diagram":
+        row = 3
+        if self.diagram.diag_type == "Governance Diagram":
+            app = getattr(self.master, "app", None)
+            toolbox = getattr(app, "safety_mgmt_toolbox", None)
+            frozen = toolbox.diagram_frozen(self.diagram.name) if toolbox else False
+            self.freeze_var = tk.BooleanVar(value=frozen)
+            ttk.Checkbutton(master, text="Frozen", variable=self.freeze_var).grid(
+                row=row, column=0, columnspan=2, sticky="w", padx=4, pady=2
+            )
+        elif self.diagram.diag_type == "Internal Block Diagram":
             repo = SysMLRepository.get_instance()
             blocks = [e for e in repo.elements.values() if e.elem_type == "Block"]
             idmap = {b.name or b.elem_id: b.elem_id for b in blocks}
-            ttk.Label(master, text="Father:").grid(row=3, column=0, sticky="e", padx=4, pady=2)
+            ttk.Label(master, text="Father:").grid(row=row, column=0, sticky="e", padx=4, pady=2)
             self.father_map = idmap
             cur_id = getattr(self.diagram, "father", "")
             cur_name = next((n for n, i in idmap.items() if i == cur_id), "")
             self.father_var = tk.StringVar(value=cur_name)
             ttk.Combobox(master, textvariable=self.father_var, values=list(idmap.keys())).grid(
-                row=3, column=1, padx=4, pady=2
+                row=row, column=1, padx=4, pady=2
             )
         else:
             self.father_map = {}
@@ -12692,7 +12702,12 @@ class DiagramPropertiesDialog(simpledialog.Dialog):
         self.diagram.name = self.name_var.get()
         self.diagram.description = self.desc_var.get()
         self.diagram.color = self.color_var.get()
-        if self.diagram.diag_type == "Internal Block Diagram":
+        if self.diagram.diag_type == "Governance Diagram":
+            app = getattr(self.master, "app", None)
+            toolbox = getattr(app, "safety_mgmt_toolbox", None)
+            if toolbox and hasattr(self, "freeze_var"):
+                toolbox.set_diagram_frozen(self.diagram.name, bool(self.freeze_var.get()))
+        elif self.diagram.diag_type == "Internal Block Diagram":
             father_id = self.father_map.get(self.father_var.get())
             repo = SysMLRepository.get_instance()
             self.added_parts = set_ibd_father(
@@ -12709,6 +12724,7 @@ class PackagePropertiesDialog(simpledialog.Dialog):
         super().__init__(master, title="Package Properties")
 
     def body(self, master):
+        self.resizable(False, False)
         ttk.Label(master, text="Name:").grid(row=0, column=0, sticky="e", padx=4, pady=2)
         self.name_var = tk.StringVar(value=self.package.name)
         ttk.Entry(master, textvariable=self.name_var).grid(row=0, column=1, padx=4, pady=2)
@@ -12725,6 +12741,7 @@ class ElementPropertiesDialog(simpledialog.Dialog):
         super().__init__(master, title=f"{element.elem_type} Properties")
 
     def body(self, master):
+        self.resizable(False, False)
         ttk.Label(master, text="Name:").grid(row=0, column=0, sticky="e", padx=4, pady=2)
         self.name_var = tk.StringVar(value=self.element.name)
         ttk.Entry(master, textvariable=self.name_var).grid(row=0, column=1, padx=4, pady=2)

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -90,6 +90,12 @@ class SafetyManagementWindow(tk.Frame):
             compound=tk.LEFT,
             command=self.delete_diagram,
         ).pack(side=tk.LEFT)
+        self.freeze_btn = ttk.Button(
+            top,
+            text="Freeze",
+            command=self.toggle_freeze,
+        )
+        self.freeze_btn.pack(side=tk.LEFT)
         ttk.Button(
             top,
             text="Requirements",
@@ -154,6 +160,7 @@ class SafetyManagementWindow(tk.Frame):
         elif self._auto_show_diagram:
             self.diag_var.set("")
             self.open_diagram(None)
+        self.update_freeze_button()
 
     def refresh_phases(self):
         phases = ["All"] + sorted(self.toolbox.list_modules())
@@ -238,6 +245,24 @@ class SafetyManagementWindow(tk.Frame):
             return
         self.current_window = GovernanceDiagramWindow(self.diagram_frame, self.app, diagram_id=diag_id)
         self.current_window.pack(fill=tk.BOTH, expand=True)
+        self.update_freeze_button()
+
+    def toggle_freeze(self):
+        name = self.diag_var.get()
+        if not name:
+            return
+        frozen = self.toolbox.diagram_frozen(name)
+        self.toolbox.set_diagram_frozen(name, not frozen)
+        self.update_freeze_button()
+
+    def update_freeze_button(self):
+        name = self.diag_var.get()
+        if not name:
+            self.freeze_btn.configure(state=tk.DISABLED, text="Freeze")
+            return
+        self.freeze_btn.configure(state=tk.NORMAL)
+        text = "Unfreeze" if self.toolbox.diagram_frozen(name) else "Freeze"
+        self.freeze_btn.configure(text=text)
 
     # ------------------------------------------------------------------
     def _add_requirement(

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -591,6 +591,17 @@ class SysMLRepository:
     def freeze_diagram(self, diag_id: str) -> None:
         """Mark a diagram as immutable."""
         self.frozen_diagrams.add(diag_id)
+        diag = self.diagrams.get(diag_id)
+        if diag:
+            diag.locked = True
+
+    # ------------------------------------------------------------
+    def unfreeze_diagram(self, diag_id: str) -> None:
+        """Allow modifications to a previously frozen diagram."""
+        self.frozen_diagrams.discard(diag_id)
+        diag = self.diagrams.get(diag_id)
+        if diag:
+            diag.locked = False
 
     # ------------------------------------------------------------
     def rename_phase(self, old: str, new: str) -> None:

--- a/tests/test_governance_diagram_freeze_toggle.py
+++ b/tests/test_governance_diagram_freeze_toggle.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.safety_management import SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_manual_freeze_persists_across_save():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    tb = SafetyManagementToolbox()
+    diag_id = tb.create_diagram("Gov1")
+    tb.set_diagram_frozen("Gov1", True)
+    assert repo.diagram_read_only(diag_id)
+
+    repo_data = repo.to_dict()
+    tb_data = tb.to_dict()
+
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    repo.from_dict(repo_data)
+    tb2 = SafetyManagementToolbox.from_dict(tb_data)
+    diag_id2 = tb2.diagrams["Gov1"]
+    assert repo.diagram_read_only(diag_id2)
+
+    tb2.set_diagram_frozen("Gov1", False)
+    assert not repo.diagram_read_only(diag_id2)


### PR DESCRIPTION
## Summary
- allow locking/unlocking governance diagrams and persist their state
- expose Freeze/Unfreeze control in Safety Management window
- add regression test for freeze persistence
- add Frozen checkbox to diagram properties and fix properties dialog sizes

## Testing
- `pytest`
- `python tools/metrics_generator.py --path . --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a4d69d76bc83278f774f628e189523