### PR TITLE
Enhance capsule button with glassy gradient and shadows

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -48,7 +48,7 @@ class CapsuleButton(tk.Canvas):
         command: Optional[Callable[[], None]] = None,
         width: int = 80,
         height: int = 26,
-        bg: str = "#e1e1e1",
+        bg: str = "#c3d7ff",
         hover_bg: Optional[str] = None,
         state: str | None = None,
         image: tk.PhotoImage | None = None,
@@ -59,10 +59,15 @@ class CapsuleButton(tk.Canvas):
             "height": height,
             "highlightthickness": 0,
         }
+        control_bg = _darken(bg, 0.9)
         try:
-            init_kwargs["bg"] = master.cget("background")
+            master.configure(bg=control_bg)
+            init_kwargs["bg"] = control_bg
         except tk.TclError:
-            pass
+            try:
+                init_kwargs["bg"] = master.cget("background")
+            except tk.TclError:
+                pass
         # ``style`` and ``state`` are ttk-specific options.  Strip them from
         # ``kwargs`` before forwarding to ``Canvas.__init__`` and track the
         # ``state`` value ourselves.  ``image`` and ``compound`` are also Tk
@@ -88,8 +93,8 @@ class CapsuleButton(tk.Canvas):
         self._current_color = self._normal_color
         self._radius = height // 2
         self._shape_items: list[int] = []
-        self._highlight_items: list[int] = []
         self._shade_items: list[int] = []
+        self._shine_items: list[int] = []
         # Border items are split into dark and light segments to create a
         # recessed "hole" effect around the button outline.  ``_border_outline``
         # draws a thin dark line between the button and its hole for an extra
@@ -99,6 +104,8 @@ class CapsuleButton(tk.Canvas):
         self._border_gap: list[int] = []
         self._text_item: Optional[int] = None
         self._image_item: Optional[int] = None
+        self._text_shadow_item: Optional[int] = None
+        self._icon_shadow_item: Optional[int] = None
         self._draw_button()
         self.bind("<Enter>", self._on_enter)
         self.bind("<Leave>", self._on_leave)
@@ -153,31 +160,17 @@ class CapsuleButton(tk.Canvas):
         self._draw_border(w, h)
 
     def _draw_highlight(self, w: int, h: int) -> None:
-        """Draw shiny highlight and shaded region to create a 3D capsule."""
+        """Draw shiny highlight to create a glassy lavender sheen."""
         r = self._radius
-        color = self._current_color
-        top_highlight = _lighten(color, 1.4)
-        bottom_shade = _darken(color, 0.9)
-        self._highlight_items = [
+        self._shine_items = [
             self.create_oval(
                 1,
                 1,
                 w - 1,
                 h // 2,
                 outline="",
-                fill=top_highlight,
+                fill="#e6e6fa",
                 stipple="gray25",
-            )
-        ]
-        self._shade_items = [
-            self.create_oval(
-                1,
-                h // 2,
-                w - 1,
-                h - 1,
-                outline="",
-                fill=bottom_shade,
-                stipple="gray50",
             )
         ]
         small_r = max(r // 3, 2)
@@ -185,38 +178,51 @@ class CapsuleButton(tk.Canvas):
         for cx, cy in centers:
             for i in range(3):
                 rad = max(small_r - i * (small_r // 3), 1)
-                self._highlight_items.append(
+                self._shine_items.append(
                     self.create_oval(
                         cx - rad,
                         cy - rad,
                         cx + rad,
                         cy + rad,
                         outline="",
-                        fill=_lighten(color, 1.6 + 0.1 * i),
+                        fill="#f5f5ff",
                         stipple="gray25",
                     )
                 )
 
     def _draw_shade(self, w: int, h: int) -> None:
-        """Add a translucent shade to suggest the far side of the capsule."""
-        shade_color = _darken(self._current_color, 0.9)
+        """Add cool blue and aqua shades to suggest depth."""
         self._shade_items = [
+            # Bright medium sky blue
             self.create_oval(
                 1,
                 h // 2,
                 w - 1,
                 h - 1,
                 outline="",
-                fill=shade_color,
+                fill="#87ceeb",
+                stipple="gray50",
+            ),
+            # Fading light cyan/aqua
+            self.create_oval(
+                1,
+                (3 * h) // 4,
+                w - 1,
+                h - 1,
+                outline="",
+                fill="#e0ffff",
                 stipple="gray25",
-            )
+            ),
         ]
 
+
     def _draw_content(self, w: int, h: int) -> None:
-        """Render optional image and text within the button."""
+        """Render optional image and text within the button with center shadows."""
         cx, cy = w // 2, h // 2
         self._text_item = None
         self._image_item = None
+        self._text_shadow_item = None
+        self._icon_shadow_item = None
         if self._image and self._text and self._compound == tk.LEFT:
             font = tkfont.nametofont("TkDefaultFont")
             text_w = font.measure(self._text)
@@ -224,16 +230,44 @@ class CapsuleButton(tk.Canvas):
             spacing = 4
             total = text_w + img_w + spacing
             start = (w - total) // 2
-            self._image_item = self.create_image(start + img_w // 2, cy, image=self._image)
-            self._text_item = self.create_text(
-                start + img_w + spacing + text_w // 2,
-                cy,
-                text=self._text,
+            self._icon_shadow_item = self.create_oval(
+                start + 1,
+                cy - img_w // 2 + 1,
+                start + img_w + 1,
+                cy + img_w // 2 + 1,
+                outline="",
+                fill="#000000",
+                stipple="gray50",
             )
+            self._image_item = self.create_image(start + img_w // 2, cy, image=self._image)
+            text_x = start + img_w + spacing + text_w // 2
+            self._text_shadow_item = self.create_text(
+                text_x + 1,
+                cy + 1,
+                text=self._text,
+                fill="#000000",
+            )
+            self._text_item = self.create_text(text_x, cy, text=self._text)
         elif self._image:
+            self._icon_shadow_item = self.create_oval(
+                cx - self._image.width() // 2 + 1,
+                cy - self._image.height() // 2 + 1,
+                cx + self._image.width() // 2 + 1,
+                cy + self._image.height() // 2 + 1,
+                outline="",
+                fill="#000000",
+                stipple="gray50",
+            )
             self._image_item = self.create_image(cx, cy, image=self._image)
         else:
+            self._text_shadow_item = self.create_text(
+                cx + 1,
+                cy + 1,
+                text=self._text,
+                fill="#000000",
+            )
             self._text_item = self.create_text(cx, cy, text=self._text)
+
 
     def _draw_border(self, w: int, h: int) -> None:
         """Draw border and inner outline to mimic an inset capsule."""
@@ -276,12 +310,6 @@ class CapsuleButton(tk.Canvas):
     def _set_color(self, color: str) -> None:
         for item in self._shape_items:
             self.itemconfigure(item, fill=color)
-        highlight = _lighten(color, 1.4)
-        shade = _darken(color, 0.9)
-        for item in self._highlight_items:
-            self.itemconfigure(item, fill=highlight)
-        for item in self._shade_items:
-            self.itemconfigure(item, fill=shade)
         inner = _darken(color, 0.7)
         dark = _darken(color, 0.8)
         light = _lighten(color, 1.2)

--- a/tests/test_capsule_button_control_blend.py
+++ b/tests/test_capsule_button_control_blend.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+import tkinter as tk
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.capsule_button import CapsuleButton, _darken
+
+
+def test_capsule_button_tints_parent_background():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Blend", bg="#89aaff")
+    btn.pack()
+    root.update_idletasks()
+    expected_bg = _darken("#89aaff", 0.9)
+    assert root.cget("bg") == expected_bg
+    assert btn.cget("bg") == expected_bg
+    root.destroy()
+

--- a/tests/test_capsule_button_shadows.py
+++ b/tests/test_capsule_button_shadows.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import tkinter as tk
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.capsule_button import CapsuleButton
+
+
+def test_text_shadow_exists():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Test")
+    btn.pack()
+    root.update_idletasks()
+    assert getattr(btn, "_text_shadow_item", None) is not None
+    root.destroy()
+
+
+def test_icon_shadow_exists():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    img = tk.PhotoImage(width=10, height=10)
+    btn = CapsuleButton(root, image=img)
+    btn.pack()
+    root.update_idletasks()
+    assert getattr(btn, "_icon_shadow_item", None) is not None
+    root.destroy()


### PR DESCRIPTION
## Summary
- Darken parent controls to a bluish shade so capsule buttons visually blend with surrounding widgets
- Verify that parent widgets receive the tinted background when a capsule button is created

## Testing
- `pytest -q`
- `radon cc -s -j gui/capsule_button.py > complexity.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4de55c4f0832787f2b888ea4ed27b