### PR TITLE
Fix accidental deletion of loaded project files

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -18925,12 +18925,9 @@ class AutoMLApp:
                 return
             if result:
                 self.save_model()
-        for path in getattr(self, "_loaded_model_paths", []):
-            try:
-                if os.path.exists(path):
-                    os.remove(path)
-            except OSError:
-                pass
+        # Previously, any loaded model paths were deleted on close, which could
+        # remove user data. Avoid deleting files that were explicitly opened by
+        # the user so their project files remain intact.
         # Ensure the Tk event loop terminates and all windows are destroyed
         self.root.quit()
         self.root.destroy()

--- a/tests/test_confirm_close_preserves_loaded_files.py
+++ b/tests/test_confirm_close_preserves_loaded_files.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+from AutoML import AutoMLApp
+
+
+class DummyRoot:
+    def __init__(self):
+        self.quit = MagicMock()
+        self.destroy = MagicMock()
+
+
+def test_confirm_close_preserves_loaded_files():
+    fd, path = tempfile.mkstemp(suffix=".autml")
+    os.close(fd)
+    try:
+        app = AutoMLApp.__new__(AutoMLApp)
+        app.root = DummyRoot()
+        app.has_unsaved_changes = lambda: False
+        app._loaded_model_paths = [path]
+
+        app.confirm_close()
+
+        assert os.path.exists(path)
+        app.root.quit.assert_called()
+        app.root.destroy.assert_called()
+    finally:
+        if os.path.exists(path):
+            os.remove(path)


### PR DESCRIPTION
## Summary
- Ensure closing the application no longer deletes user `.autml` files
- Add regression test verifying confirm_close preserves loaded files

## Testing
- `pytest -q`
- Unable to install radon for cyclomatic complexity metrics due to network restrictions


------
https://chatgpt.com/codex/tasks/task_b_68a4fd0b2c788327a2ad22f2768906d9