### PR TITLE
Apply translucid button style to toolboxes

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -16,6 +16,7 @@ from gui import messagebox, add_treeview_scrollbars
 from gui.icon_factory import create_icon
 from sysml.sysml_repository import SysMLRepository
 from gui.toolboxes import configure_table_style, _wrap_val
+from gui.mac_button_style import apply_translucid_button_style
 
 
 class SafetyManagementWindow(tk.Frame):
@@ -34,6 +35,7 @@ class SafetyManagementWindow(tk.Frame):
         show_diagrams: bool = True,
     ):
         super().__init__(master)
+        apply_translucid_button_style()
         self.app = app
         self.toolbox = toolbox or SafetyManagementToolbox()
         self._auto_show_diagram = show_diagrams

--- a/gui/search_toolbox.py
+++ b/gui/search_toolbox.py
@@ -6,6 +6,7 @@ import tkinter as tk
 from tkinter import ttk
 
 from gui import messagebox
+from gui.mac_button_style import apply_translucid_button_style
 
 # Additional model sections that can be searched.  Each tuple contains a
 # human-readable category name, the name of a method on the ``app`` object
@@ -48,6 +49,7 @@ class SearchToolbox(ttk.Frame):
 
     def __init__(self, master, app):
         super().__init__(master)
+        apply_translucid_button_style()
         self.app = app
 
         self.search_var = tk.StringVar()


### PR DESCRIPTION
## Summary
- ensure toolbox widgets use translucid button style via mac-style helper
- confirm message dialogs employ purple-themed buttons

## Testing
- `pytest`
- `radon cc -s -j gui/search_toolbox.py gui/safety_management_toolbox.py gui/messagebox.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68a4fcdb73fc8327ad4d55f6166dff0a