### PR TITLE
Enable STPA governance links to architecture diagrams

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -100,6 +100,7 @@ ALLOWED_USAGE.update(
         ("Reliability Analysis", "FMEA"),
         ("Reliability Analysis", "FMEDA"),
         ("GSN Argumentation", "Safety & Security Case"),
+        ("STPA", "Architecture Diagram"),
     }
 )
 
@@ -869,6 +870,8 @@ class SafetyManagementToolbox:
                     sname = id_to_name.get(conn.get("src"))
                     tname = id_to_name.get(conn.get("dst"))
                     if sname and tname:
+                        if sname == "STPA" and tname == "Architecture Diagram":
+                            sname, tname = tname, sname
                         if (
                             sname in SAFETY_ANALYSIS_WORK_PRODUCTS
                             and tname in SAFETY_ANALYSIS_WORK_PRODUCTS

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4220,9 +4220,9 @@ class SysMLDiagramWindow(tk.Frame):
                         return False, (
                             "No metamodel dependency between these work products"
                         )
-                    if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS and not (
-                        sname == "ODD" and dname == "Scenario Library"
-                    ):
+                    if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS and (
+                        sname, dname
+                    ) not in ALLOWED_USAGE:
                         return False, f"{conn_type} links must target a safety analysis work product"
                     if (
                         sname in SAFETY_ANALYSIS_WORK_PRODUCTS

--- a/tests/test_analysis_input_visibility.py
+++ b/tests/test_analysis_input_visibility.py
@@ -153,6 +153,82 @@ def test_used_after_approval_input_visibility(analysis):
     assert toolbox.analysis_inputs(analysis, approved=True) == {"Architecture Diagram"}
 
 
+def test_stpa_to_architecture_used_by_input_visibility():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams = {"Gov": diag.diag_id}
+    e1 = repo.create_element("Block", name="E1")
+    e2 = repo.create_element("Block", name="E2")
+    repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+    repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+    o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "STPA"})
+    o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "Architecture Diagram"})
+    diag.objects = [o1.__dict__, o2.__dict__]
+    win = _create_window(repo, "Used By", o1, o2, diag)
+    GovernanceDiagramWindow.on_left_press(win, types.SimpleNamespace(x=0, y=0, state=0))
+    GovernanceDiagramWindow.on_left_press(win, types.SimpleNamespace(x=0, y=100, state=0))
+    diag.connections = [c.__dict__ for c in win.connections]
+    toolbox.work_products = [
+        SafetyWorkProduct("Gov", "Architecture Diagram", ""),
+        SafetyWorkProduct("Gov", "STPA", ""),
+    ]
+    assert toolbox.analysis_inputs("STPA") == {"Architecture Diagram"}
+
+
+def test_stpa_to_architecture_used_after_review_input_visibility():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams = {"Gov": diag.diag_id}
+    e1 = repo.create_element("Block", name="E1")
+    e2 = repo.create_element("Block", name="E2")
+    repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+    repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+    o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "STPA"})
+    o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "Architecture Diagram"})
+    diag.objects = [o1.__dict__, o2.__dict__]
+    win = _create_window(repo, "Used after Review", o1, o2, diag)
+    GovernanceDiagramWindow.on_left_press(win, types.SimpleNamespace(x=0, y=0, state=0))
+    GovernanceDiagramWindow.on_left_press(win, types.SimpleNamespace(x=0, y=100, state=0))
+    diag.connections = [c.__dict__ for c in win.connections]
+    toolbox.work_products = [
+        SafetyWorkProduct("Gov", "Architecture Diagram", ""),
+        SafetyWorkProduct("Gov", "STPA", ""),
+    ]
+    assert toolbox.analysis_inputs("STPA") == set()
+    assert toolbox.analysis_inputs("STPA", reviewed=True) == {"Architecture Diagram"}
+    assert toolbox.analysis_inputs("STPA", approved=True) == {"Architecture Diagram"}
+
+
+def test_stpa_to_architecture_used_after_approval_input_visibility():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams = {"Gov": diag.diag_id}
+    e1 = repo.create_element("Block", name="E1")
+    e2 = repo.create_element("Block", name="E2")
+    repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+    repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+    o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "STPA"})
+    o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "Architecture Diagram"})
+    diag.objects = [o1.__dict__, o2.__dict__]
+    win = _create_window(repo, "Used after Approval", o1, o2, diag)
+    GovernanceDiagramWindow.on_left_press(win, types.SimpleNamespace(x=0, y=0, state=0))
+    GovernanceDiagramWindow.on_left_press(win, types.SimpleNamespace(x=0, y=100, state=0))
+    diag.connections = [c.__dict__ for c in win.connections]
+    toolbox.work_products = [
+        SafetyWorkProduct("Gov", "Architecture Diagram", ""),
+        SafetyWorkProduct("Gov", "STPA", ""),
+    ]
+    assert toolbox.analysis_inputs("STPA") == set()
+    assert toolbox.analysis_inputs("STPA", reviewed=True) == set()
+    assert toolbox.analysis_inputs("STPA", approved=True) == {"Architecture Diagram"}
+
+
 @pytest.mark.parametrize("analysis", ["FI2TC", "TC2FI"])
 def test_analysis_inputs_respect_phase(analysis):
     SysMLRepository.reset_instance()

--- a/tests/test_governance_relationship_stereotype.py
+++ b/tests/test_governance_relationship_stereotype.py
@@ -221,6 +221,39 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             GovernanceDiagramWindow.on_left_press(win, event2)
             self.assertEqual(repo.relationships, [])
 
+    def test_stpa_to_architecture_used_relationships(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "STPA"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "Architecture Diagram"},
+        )
+        diag.objects = [o1.__dict__, o2.__dict__]
+        for rel in ["Used By", "Used after Review", "Used after Approval"]:
+            repo.relationships.clear()
+            win = self._create_window(rel, o1, o2, diag)
+            event1 = types.SimpleNamespace(x=0, y=0, state=0)
+            GovernanceDiagramWindow.on_left_press(win, event1)
+            event2 = types.SimpleNamespace(x=0, y=100, state=0)
+            GovernanceDiagramWindow.on_left_press(win, event2)
+            self.assertEqual(repo.relationships[0].stereotype, rel.lower())
+
     def test_used_relationship_validation(self):
         repo = self.repo
         diag = repo.create_diagram("Governance Diagram", name="Gov")


### PR DESCRIPTION
## Summary
- allow STPA work products to relate to architecture diagrams via Used By/After Review/After Approval links
- include STPA→Architecture relationships when computing allowed inputs
- add tests for STPA as a source for governance relationships

## Testing
- `pytest -q`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a51d6f0bf08327b66722b2c775504d