### PR TITLE
Allow operations to execute requirement work products

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -777,7 +777,8 @@
         "Model": [],
         "Operation": [
           "Procedure",
-          "Process"
+          "Process",
+          "Work Product"
         ],
         "Organization": [],
         "Plan": [],

--- a/tests/test_governance_element_connection_rules.py
+++ b/tests/test_governance_element_connection_rules.py
@@ -11,7 +11,11 @@ def test_governance_element_connection_rules():
     rules = cfg["connection_rules"]["Governance Diagram"]
     assert set(rules["Approves"]["Role"]) == {"Document", "Policy", "Procedure", "Record"}
     assert set(rules["Uses"]["Role"]) == {"Document", "Data", "Record", "Work Product"}
-    assert set(rules["Executes"]["Operation"]) == {"Procedure", "Process"}
+    assert set(rules["Executes"]["Operation"]) == {
+        "Procedure",
+        "Process",
+        "Work Product",
+    }
     assert set(rules["Uses"]["Operation"]) == {"Data", "Document", "Record"}
     assert set(rules["Used By"]["Guideline"]) == {"Lifecycle Phase"}
     assert set(rules["Used By"]["Policy"]) == {"Lifecycle Phase"}

--- a/tests/test_operation_executes_work_product_connection_rule.py
+++ b/tests/test_operation_executes_work_product_connection_rule.py
@@ -1,0 +1,18 @@
+import types
+from gui import architecture
+
+
+def test_operation_executes_work_product_connection():
+    win = architecture.GovernanceDiagramWindow.__new__(
+        architecture.GovernanceDiagramWindow
+    )
+    win.repo = types.SimpleNamespace(diagrams={})
+    win.diagram_id = "d"
+    win.repo.diagrams["d"] = types.SimpleNamespace(diag_type="Governance Diagram")
+    src = architecture.SysMLObject(1, "Operation", 0, 0)
+    dst = architecture.SysMLObject(2, "Work Product", 0, 0)
+    dst.name = "Operational Requirement Specification"
+    valid, _ = architecture.GovernanceDiagramWindow.validate_connection(
+        win, src, dst, "Executes"
+    )
+    assert valid


### PR DESCRIPTION
## Summary
- Permit Operation shapes to connect to Work Product via `Executes`
- Document governance rule allowing operations to execute requirement work products
- Add regression test for Operation executing an Operational Requirement Specification work product

## Testing
- `pytest`
- `pip install radon` *(failed: Could not connect to proxy and no matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_b_68a51f55113483278ab828e26d974bac