### PR TITLE
Allow Role to execute Operation

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -789,7 +789,8 @@
         "Record": [],
         "Role": [
           "Procedure",
-          "Process"
+          "Process",
+          "Operation"
         ],
         "Safety Compliance": [],
         "Safety Issue": [],

--- a/tests/test_governance_element_connection_rules.py
+++ b/tests/test_governance_element_connection_rules.py
@@ -16,6 +16,11 @@ def test_governance_element_connection_rules():
         "Process",
         "Work Product",
     }
+    assert set(rules["Executes"]["Role"]) == {
+        "Procedure",
+        "Process",
+        "Operation",
+    }
     assert set(rules["Uses"]["Operation"]) == {"Data", "Document", "Record"}
     assert set(rules["Used By"]["Guideline"]) == {"Lifecycle Phase"}
     assert set(rules["Used By"]["Policy"]) == {"Lifecycle Phase"}

--- a/tests/test_role_executes_operation_connection_rule.py
+++ b/tests/test_role_executes_operation_connection_rule.py
@@ -1,0 +1,17 @@
+import types
+from gui import architecture
+
+
+def test_role_executes_operation_connection():
+    win = architecture.GovernanceDiagramWindow.__new__(
+        architecture.GovernanceDiagramWindow
+    )
+    win.repo = types.SimpleNamespace(diagrams={})
+    win.diagram_id = "d"
+    win.repo.diagrams["d"] = types.SimpleNamespace(diag_type="Governance Diagram")
+    src = architecture.SysMLObject(1, "Role", 0, 0)
+    dst = architecture.SysMLObject(2, "Operation", 0, 0)
+    valid, _ = architecture.GovernanceDiagramWindow.validate_connection(
+        win, src, dst, "Executes"
+    )
+    assert valid


### PR DESCRIPTION
## Summary
- permit `Executes` connections from `Role` to `Operation`
- cover new rule with unit tests

## Testing
- `pytest`
- `python tools/metrics_generator.py --path gui --output /tmp/metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a521d6a70083278b8c4b857368df48