### PR TITLE
Allow Role to develop Task

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -2486,6 +2486,7 @@
           "Plan",
           "Procedure",
           "Process",
+          "Task",
           "Model",
           "Test Suite",
           "Document",
@@ -3919,71 +3920,71 @@
       ],
       "subject": "Prototype team"
     },
-      "safety assessment workflow": {
-        "action": "assess and mitigate safety risks",
-        "relations": [
-          "Assesses",
-          "Uses",
-          "Mitigates",
-          "Develops",
-          "Verify",
-          "Produces"
-        ],
-        "subject": "Safety engineer"
-      },
-      "role safety issue triage": {
-        "action": "triage safety issue",
-        "relations": [
-          "Assesses",
-          "Triage"
-        ],
-        "subject": "Role"
-      },
-      "organization safety issue triage": {
-        "action": "triage safety issue",
-        "relations": [
-          "Assesses",
-          "Triage"
-        ],
-        "subject": "Organization"
-      },
-      "business unit safety issue triage": {
-        "action": "triage safety issue",
-        "relations": [
-          "Assesses",
-          "Triage"
-        ],
-        "subject": "Business Unit"
-      },
-      "role incident monitoring": {
-        "action": "monitor incident",
-        "relations": [
-          "Monitors",
-          "Assesses"
-        ],
-        "subject": "Role"
-      },
-      "organization incident monitoring": {
-        "action": "monitor incident",
-        "relations": [
-          "Monitors",
-          "Assesses"
-        ],
-        "subject": "Organization"
-      },
-      "business unit incident monitoring": {
-        "action": "monitor incident",
-        "relations": [
-          "Monitors",
-          "Assesses"
-        ],
-        "subject": "Business Unit"
-      },
-      "continuous improvement": {
-        "action": "improve deployed system",
-        "relations": [
-          "Monitors",
-          "Assesses",
+    "safety assessment workflow": {
+      "action": "assess and mitigate safety risks",
+      "relations": [
+        "Assesses",
+        "Uses",
+        "Mitigates",
+        "Develops",
+        "Verify",
+        "Produces"
+      ],
+      "subject": "Safety engineer"
+    },
+    "role safety issue triage": {
+      "action": "triage safety issue",
+      "relations": [
+        "Assesses",
+        "Triage"
+      ],
+      "subject": "Role"
+    },
+    "organization safety issue triage": {
+      "action": "triage safety issue",
+      "relations": [
+        "Assesses",
+        "Triage"
+      ],
+      "subject": "Organization"
+    },
+    "business unit safety issue triage": {
+      "action": "triage safety issue",
+      "relations": [
+        "Assesses",
+        "Triage"
+      ],
+      "subject": "Business Unit"
+    },
+    "role incident monitoring": {
+      "action": "monitor incident",
+      "relations": [
+        "Monitors",
+        "Assesses"
+      ],
+      "subject": "Role"
+    },
+    "organization incident monitoring": {
+      "action": "monitor incident",
+      "relations": [
+        "Monitors",
+        "Assesses"
+      ],
+      "subject": "Organization"
+    },
+    "business unit incident monitoring": {
+      "action": "monitor incident",
+      "relations": [
+        "Monitors",
+        "Assesses"
+      ],
+      "subject": "Business Unit"
+    },
+    "continuous improvement": {
+      "action": "improve deployed system",
+      "relations": [
+        "Monitors",
+        "Assesses",
         "Develops",
         "Produces"
       ],

--- a/tests/test_governance_role_develops_task_connection_rule.py
+++ b/tests/test_governance_role_develops_task_connection_rule.py
@@ -1,0 +1,17 @@
+import types
+from gui import architecture
+
+
+def test_role_develops_task_connection():
+    win = architecture.GovernanceDiagramWindow.__new__(
+        architecture.GovernanceDiagramWindow
+    )
+    win.repo = types.SimpleNamespace(diagrams={})
+    win.diagram_id = "d"
+    win.repo.diagrams["d"] = types.SimpleNamespace(diag_type="Governance Diagram")
+    src = architecture.SysMLObject(1, "Role", 0, 0)
+    dst = architecture.SysMLObject(2, "Task", 0, 0)
+    valid, _ = architecture.GovernanceDiagramWindow.validate_connection(
+        win, src, dst, "Develops"
+    )
+    assert valid


### PR DESCRIPTION
## Summary
- Permit `Develops` relationship from `Role` to `Task` in connection rules
- Add test ensuring Roles can develop Tasks in governance diagrams

## Testing
- `pytest`
- `pip install radon` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68a5223e7a388327a307b6a3dda56dd7