### PR TITLE
Allow role responsibility for system boundary

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -1555,7 +1555,8 @@
           "Activity",
           "Process",
           "Task",
-          "Work Product"
+          "Work Product",
+          "System Boundary"
         ],
         "Safety Compliance": [],
         "Safety Issue": [],

--- a/tests/test_governance_role_system_boundary_connection_rule.py
+++ b/tests/test_governance_role_system_boundary_connection_rule.py
@@ -1,0 +1,13 @@
+import types
+from gui import architecture
+
+
+def test_role_responsible_for_system_boundary_connection():
+    win = architecture.GovernanceDiagramWindow.__new__(architecture.GovernanceDiagramWindow)
+    win.repo = types.SimpleNamespace(diagrams={})
+    win.diagram_id = "d"
+    win.repo.diagrams["d"] = types.SimpleNamespace(diag_type="Governance Diagram")
+    src = architecture.SysMLObject(1, "Role", 0, 0)
+    dst = architecture.SysMLObject(2, "System Boundary", 0, 0)
+    valid, _ = architecture.GovernanceDiagramWindow.validate_connection(win, src, dst, "Responsible for")
+    assert valid


### PR DESCRIPTION
## Summary
- permit `Responsible for` connections from Role to System Boundary
- add regression test for Role responsible for System Boundary

## Testing
- `PYTHONPATH=. pytest`
- `python tools/metrics_generator.py --path analysis --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a52ce7db4883278e5adbc25e24b35b