### PR TITLE
Use lightened image on CapsuleButton hover

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -449,10 +449,24 @@ class CapsuleButton(tk.Canvas):
         if inside:
             if self._current_color == self._normal_color:
                 self._set_color(self._hover_color)
+            if (
+                self._image_item
+                and self._hover_image
+                and self._current_image != self._hover_image
+            ):
+                self.itemconfigure(self._image_item, image=self._hover_image)
+                self._current_image = self._hover_image
             self._add_glow()
         else:
             if self._current_color != self._normal_color:
                 self._set_color(self._normal_color)
+            if (
+                self._image_item
+                and self._hover_image
+                and self._current_image != self._image
+            ):
+                self.itemconfigure(self._image_item, image=self._image)
+                self._current_image = self._image
             self._remove_glow()
 
     def _on_enter(self, _event: tk.Event) -> None:

--- a/tests/test_capsule_button_hover_icon.py
+++ b/tests/test_capsule_button_hover_icon.py
@@ -22,6 +22,13 @@ def test_capsule_button_lightens_icon_on_hover():
     assert btn._hover_image.get(0, 0) == _lighten("#808080")
     btn._on_enter(type("E", (), {})())
     assert btn.itemcget(btn._image_item, "image") == str(btn._hover_image)
+    # Motion inside maintains hover image, outside restores original
+    inside_evt = type("E", (), {"x": 0, "y": 0})()
+    outside_evt = type("E", (), {"x": btn.winfo_width() + 1, "y": btn.winfo_height() + 1})()
+    btn._on_motion(inside_evt)
+    assert btn.itemcget(btn._image_item, "image") == str(btn._hover_image)
+    btn._on_motion(outside_evt)
+    assert btn.itemcget(btn._image_item, "image") == str(btn._image)
     btn._on_leave(type("E", (), {})())
     assert btn.itemcget(btn._image_item, "image") == str(btn._image)
     root.destroy()


### PR DESCRIPTION
## Summary
- Ensure CapsuleButton swaps to a lightened hover image during cursor motion, restoring the original when leaving.
- Extend hover icon test to verify image updates on motion events.

## Testing
- `pytest`
- `python tools/metrics_generator.py --path gui --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a5c47f4bc88327b0d788c217a06165