### PR TITLE
Use shared image lightening for button hover

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -4,6 +4,8 @@ import tkinter as tk
 import tkinter.font as tkfont
 from typing import Callable, Optional
 
+from .button_utils import _lighten_image
+
 
 def _hex_to_rgb(value: str) -> tuple[int, int, int]:
     value = value.lstrip('#')
@@ -38,42 +40,6 @@ def _interpolate_color(c1: str, c2: str, t: float) -> str:
     g = int(g1 + (g2 - g1) * t)
     b = int(b1 + (b2 - b1) * t)
     return _rgb_to_hex((r, g, b))
-
-
-def _lighten_image(img: tk.PhotoImage, factor: float = 1.2) -> tk.PhotoImage:
-    """Return a lightened copy of ``img`` while preserving transparency.
-
-    ``tk.PhotoImage`` provides no direct access to per-pixel alpha values, so
-    when Pillow is available the image is converted to an ``RGBA`` bitmap where
-    the colour channels are brightened and the original alpha channel is
-    reapplied.  If Pillow cannot be imported we fall back to a pure Tk based
-    implementation that skips pixels reported as transparent.
-    """
-
-    try:  # Prefer Pillow for correct alpha handling
-        from PIL import Image, ImageEnhance, ImageTk  # type: ignore
-
-        pil_img = ImageTk.getimage(img).convert("RGBA")
-        r, g, b, a = pil_img.split()
-        rgb = Image.merge("RGB", (r, g, b))
-        bright = ImageEnhance.Brightness(rgb).enhance(factor)
-        light = Image.merge("RGBA", (*bright.split(), a))
-        return ImageTk.PhotoImage(light)
-    except Exception:  # pragma: no cover - Pillow may be unavailable
-        w, h = img.width(), img.height()
-        new = tk.PhotoImage(width=w, height=h)
-        for x in range(w):
-            for y in range(h):
-                pixel = img.get(x, y)
-                if pixel in ("", "{}", None):
-                    # Leave fully transparent pixels untouched
-                    continue
-                if isinstance(pixel, tuple):
-                    color = _rgb_to_hex(pixel[:3])
-                else:
-                    color = pixel
-                new.put(_lighten(color, factor), (x, y))
-        return new
 
 
 class CapsuleButton(tk.Canvas):

--- a/tests/test_capsule_button_hover_icon.py
+++ b/tests/test_capsule_button_hover_icon.py
@@ -5,7 +5,13 @@ import tkinter as tk
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from gui.capsule_button import CapsuleButton, _lighten
+from gui.capsule_button import CapsuleButton
+
+
+def _sum_rgb(value):
+    if isinstance(value, tuple):
+        return sum(value[:3])
+    return sum(int(value[i : i + 2], 16) for i in (1, 3, 5))
 
 
 def test_capsule_button_lightens_icon_on_hover():
@@ -13,13 +19,15 @@ def test_capsule_button_lightens_icon_on_hover():
         root = tk.Tk()
     except tk.TclError:
         pytest.skip("Tk not available")
-    img = tk.PhotoImage(width=1, height=1)
-    img.put("#808080", to=(0, 0, 1, 1))
+    img = tk.PhotoImage(width=2, height=2)
+    img.put("#808080", to=(0, 0, 2, 2))
     btn = CapsuleButton(root, image=img)
     btn.pack()
     root.update_idletasks()
-    # hover image should be a lighter tone of original
-    assert btn._hover_image.get(0, 0) == _lighten("#808080")
+    top = btn._hover_image.get(0, 0)
+    bottom = btn._hover_image.get(0, 1)
+    assert _sum_rgb(top) > _sum_rgb(img.get(0, 0))
+    assert _sum_rgb(bottom) > _sum_rgb(top)
     btn._on_enter(type("E", (), {})())
     assert btn.itemcget(btn._image_item, "image") == str(btn._hover_image)
     btn._on_leave(type("E", (), {})())


### PR DESCRIPTION
## Summary
- Reuse button utility `_lighten_image` to create glowing hover icons in `CapsuleButton`
- Test hover behaviour ensures bottom pixels glow brighter than top ones

## Testing
- `pytest`
- ⚠️ `pip install radon` (failed: Could not find a version that satisfies the requirement)


------
https://chatgpt.com/codex/tasks/task_b_68a5c47f4bc88327b0d788c217a06165