### PR TITLE
Add green-tinted hover glow for buttons

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import tkinter as tk
 from tkinter import ttk
 
-from .capsule_button import CapsuleButton, _interpolate_color  # noqa: F401
+from .capsule_button import CapsuleButton, _interpolate_color, _lighten  # noqa: F401
 
 
 class _StyledButton(CapsuleButton):
@@ -40,8 +40,8 @@ class TranslucidButton(_StyledButton):
     """Capsule button with a subtle translucent palette."""
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("bg", "#ffffff")
-        kwargs.setdefault("hover_bg", "#f5f5f5")
+        bg = kwargs.setdefault("bg", "#ffffff")
+        kwargs.setdefault("hover_bg", _lighten(bg))
         kwargs.setdefault("gradient", ["#ffffff", "#f7f7f7", "#ececec"])
         super().__init__(*args, **kwargs)
 
@@ -50,8 +50,8 @@ class PurpleButton(_StyledButton):
     """Capsule button variant with a translucent purple theme for dialogs."""
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("bg", "#f3eaff")
-        kwargs.setdefault("hover_bg", "#e6d9ff")
+        bg = kwargs.setdefault("bg", "#f3eaff")
+        kwargs.setdefault("hover_bg", _lighten(bg))
         kwargs.setdefault("gradient", ["#f8f6ff", "#e7ddff", "#d9c2ff", "#f3eaff"])
         super().__init__(*args, **kwargs)
 

--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -16,11 +16,22 @@ def _rgb_to_hex(rgb: tuple[int, int, int]) -> str:
 
 
 def _lighten(color: str, factor: float = 1.2) -> str:
+    """Return a brighter, lightly green-tinted version of ``color``.
+
+    The original RGB channels are scaled by *factor* and then blended with a
+    hint of white and pastel green to create a subtle glow used for hover
+    effects.
+    """
+
     r, g, b = _hex_to_rgb(color)
     r = min(int(r * factor), 255)
     g = min(int(g * factor), 255)
     b = min(int(b * factor), 255)
-    return _rgb_to_hex((r, g, b))
+    # Blend with white and a touch of light green (#ccffcc)
+    r = int(r * 0.6 + 255 * 0.3 + 204 * 0.1)
+    g = int(g * 0.6 + 255 * 0.3 + 255 * 0.1)
+    b = int(b * 0.6 + 255 * 0.3 + 204 * 0.1)
+    return _rgb_to_hex((min(r, 255), min(g, 255), min(b, 255)))
 
 
 def _darken(color: str, factor: float = 0.8) -> str:
@@ -57,7 +68,11 @@ def _lighten_image(img: tk.PhotoImage, factor: float = 1.2) -> tk.PhotoImage:
         r, g, b, a = pil_img.split()
         rgb = Image.merge("RGB", (r, g, b))
         bright = ImageEnhance.Brightness(rgb).enhance(factor)
-        light = Image.merge("RGBA", (*bright.split(), a))
+        white = Image.new("RGB", bright.size, (255, 255, 255))
+        green = Image.new("RGB", bright.size, (204, 255, 204))
+        blended = Image.blend(bright, white, 0.3)
+        blended = Image.blend(blended, green, 0.1)
+        light = Image.merge("RGBA", (*blended.split(), a))
         return ImageTk.PhotoImage(light)
     except Exception:  # pragma: no cover - Pillow may be unavailable
         w, h = img.width(), img.height()

--- a/tests/test_capsule_button_glow.py
+++ b/tests/test_capsule_button_glow.py
@@ -1,0 +1,8 @@
+from gui.capsule_button import _lighten, _hex_to_rgb
+
+
+def test_lighten_adds_white_and_green():
+    color = "#0000ff"
+    light = _lighten(color, 1.2)
+    r, g, b = _hex_to_rgb(light)
+    assert r > 0 and g > 0


### PR DESCRIPTION
## Summary
- Tint button hover colors with white and light green for a glowing effect
- Use tinted hover backgrounds for translucent and purple capsule buttons
- Test color lightening to ensure green-tinted glow

## Testing
- `pytest`
- `radon cc -s -j gui/capsule_button.py gui/__init__.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68a5c71f770c8327b0c742d30fcb9acc