### PR TITLE
Add green-white glow to button hover images

### DIFF
--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -35,19 +35,6 @@ def set_uniform_button_width(widget: tk.Misc) -> None:
             btn.configure(width=max_width)
         except Exception:  # pragma: no cover - defensive
             pass
-
-
-def _lighten_color(color: str, factor: float = 1.2) -> str:
-    """Return *color* lightened by *factor* while clamping to valid range."""
-    r = int(color[1:3], 16)
-    g = int(color[3:5], 16)
-    b = int(color[5:7], 16)
-    r = min(int(r * factor), 255)
-    g = min(int(g * factor), 255)
-    b = min(int(b * factor), 255)
-    return f"#{r:02x}{g:02x}{b:02x}"
-
-
 def _lighten_image(
     img: tk.PhotoImage,
     factor: float = 1.2,
@@ -55,12 +42,12 @@ def _lighten_image(
     bottom_factor: float = 1.4,
     bottom_ratio: float = 0.3,
 ) -> tk.PhotoImage:
-    """Return a new image with all non-black pixels lightened.
+    """Return a new image with all non-black pixels lightened and tinted.
 
-    A subtle "lighting" effect is added to the lower portion of the image by
-    applying a stronger lightening factor to the bottom *bottom_ratio* of
-    pixels.  This creates the impression of a light source shining on the base
-    of the button when hovered.
+    Each pixel is brightened and then blended with white and a hint of light
+    green (``#ccffcc``) to give hover images a soft glow.  The lower portion of
+    the image receives an extra boost to suggest a light source shining from
+    below.
     """
     w, h = img.width(), img.height()
     new_img = tk.PhotoImage(width=w, height=h)
@@ -80,7 +67,17 @@ def _lighten_image(
                 new_img.put(pixel, (x, y))
             else:
                 lf = factor * bottom_factor if y >= highlight_start else factor
-                new_img.put(_lighten_color(pixel, lf), (x, y))
+                r = int(pixel[1:3], 16)
+                g = int(pixel[3:5], 16)
+                b = int(pixel[5:7], 16)
+                r = min(int(r * lf), 255)
+                g = min(int(g * lf), 255)
+                b = min(int(b * lf), 255)
+                # Blend with white (255,255,255) and light green (204,255,204)
+                r = int(r * 0.6 + 255 * 0.3 + 204 * 0.1)
+                g = int(g * 0.6 + 255 * 0.3 + 255 * 0.1)
+                b = int(b * 0.6 + 255 * 0.3 + 204 * 0.1)
+                new_img.put(f"#{r:02x}{g:02x}{b:02x}", (x, y))
     return new_img
 
 

--- a/tests/test_button_hover_highlight.py
+++ b/tests/test_button_hover_highlight.py
@@ -15,6 +15,12 @@ def _sum_rgb(value):
     return sum(int(value[i : i + 2], 16) for i in (1, 3, 5))
 
 
+def _rgb(value):
+    if isinstance(value, tuple):
+        return value[:3]
+    return tuple(int(value[i : i + 2], 16) for i in (1, 3, 5))
+
+
 def test_add_hover_highlight_swaps_to_lighter_image():
     try:
         root = tk.Tk()
@@ -34,4 +40,9 @@ def test_add_hover_highlight_swaps_to_lighter_image():
     assert _sum_rgb(hover_img.get(0, 0)) > _sum_rgb(img.get(0, 0))
     # Bottom pixels receive an extra boost creating a light glow
     assert _sum_rgb(hover_img.get(0, 1)) > _sum_rgb(hover_img.get(0, 0))
+    # The glow should introduce a slight green tint
+    r, g, b = _rgb(hover_img.get(0, 0))
+    assert g > r and g > b
+    r2, g2, b2 = _rgb(hover_img.get(0, 1))
+    assert g2 > r2 and g2 > b2
     root.destroy()


### PR DESCRIPTION
## Summary
- Give hover button images a soft glow by blending white and light green
- Test hover highlight for slight green tint in generated images

## Testing
- `pytest`
- `radon cc -j gui/button_utils.py tests/test_button_hover_highlight.py` *(fails: command not found)*
- `pip install radon` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a5cbdbde7083279561d30576c51017