### PR TITLE
feat: display tool version in help menu

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2885,6 +2885,7 @@ class AutoMLApp:
         menubar.entryconfig(idx, state=tk.DISABLED)
         menubar.add_cascade(label="Review", menu=review_menu)
         help_menu = tk.Menu(menubar, tearoff=0)
+        help_menu.add_command(label="Version", command=self.show_version)
         help_menu.add_command(label="About", command=self.show_about)
         menubar.add_cascade(label="Help", menu=help_menu)
 
@@ -18967,6 +18968,10 @@ class AutoMLApp:
             f"Version: {self.version}"
         )
         messagebox.showinfo("About AutoML", message)
+
+    def show_version(self):
+        """Display the tool version."""
+        messagebox.showinfo("Version", f"AutoML version {self.version}")
 
     def export_model_data(self, include_versions=True):
         # Ensure aggregated ODD elements are up to date


### PR DESCRIPTION
## Summary
- add Version entry in the Help menu
- show AutoML version in a dedicated dialog

## Testing
- `pytest`
- `python tools/metrics_generator.py --path . --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a5ec026fc88327b6b37d332810d0c3