### PR TITLE
Fix askstring dialog resizing issue

### DIFF
--- a/gui/dialog_utils.py
+++ b/gui/dialog_utils.py
@@ -15,9 +15,11 @@ def askstring_fixed(sd_module: simpledialog.__class__, title: str, prompt: str, 
     original = sd_module._QueryString
 
     class FixedQueryString(sd_module._QueryString):  # type: ignore[attr-defined]
-        def __init__(self, *a, **k):
-            super().__init__(*a, **k)
+        """Query dialog variant that disables window resizing."""
+
+        def body(self, master):  # type: ignore[override]
             self.resizable(False, False)
+            return super().body(master)
 
     sd_module._QueryString = FixedQueryString  # type: ignore[attr-defined]
     try:


### PR DESCRIPTION
## Summary
- prevent _tkinter.TclError in askstring dialogs by setting window non-resizable during body creation

## Testing
- `pytest`
- `python tools/metrics_generator.py --path . --output /tmp/metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a5f52d12ec8327a3d77a6c998f92e7