### PR TITLE
Fix duplicate argument in GUI treeview setup

### DIFF
--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -4217,7 +4217,6 @@ class RequirementsExplorerWindow(tk.Frame):
             edit_callback=self.on_cell_edit,
             multiline_columns={"Text"},
             height=10,
-            multiline_columns={"Text"},
         )
         for c in self.columns:
             self.tree.heading(c, text=c)

--- a/tests/test_toolboxes_syntax.py
+++ b/tests/test_toolboxes_syntax.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def compile_file(path: str) -> None:
+    source = Path(path).read_text(encoding="utf-8")
+    compile(source, path, "exec")
+
+
+def test_gui_toolboxes_compiles() -> None:
+    compile_file("gui/toolboxes.py")
+
+
+def test_safety_management_toolbox_compiles() -> None:
+    compile_file("gui/safety_management_toolbox.py")


### PR DESCRIPTION
## Summary
- remove repeated `multiline_columns` argument when constructing `EditableTreeview`
- add regression test ensuring `gui` modules compile without syntax errors

## Testing
- `python tools/metrics_generator.py --path gui --output /tmp/metrics.json && head -n 20 /tmp/metrics.json`
- `pytest tests/test_toolboxes_syntax.py -q`
- `pytest >/tmp/full.log && tail -n 20 /tmp/full.log`

------
https://chatgpt.com/codex/tasks/task_b_68a5fd72b1c08327af2fdc34a9fcc1e5