### PR TITLE
Handle default option in CapsuleButton and add line chart variants

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -151,6 +151,11 @@ class CapsuleButton(tk.Canvas):
         kwargs.pop("style", None)
         kwargs.pop("image", None)
         kwargs.pop("compound", None)
+        # ``default`` is a standard ``Button`` option used by dialogs to mark
+        # the widget activated when the user presses Return.  ``Canvas`` does
+        # not recognise it, so silently drop the option to avoid a Tk error
+        # when our custom button is used as a stand-in for ``tk.Button``.
+        kwargs.pop("default", None)
         self._text = text
         self._image = image
         self._glow_cache: tk.PhotoImage | None = None

--- a/gui/metrics_tab.py
+++ b/gui/metrics_tab.py
@@ -13,20 +13,50 @@ class MetricsTab(tk.Frame):
             c.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.update_plots()
         
-    def _draw_line_chart(self, canvas: tk.Canvas, data):
+    # -- Line chart implementations -------------------------------------------------
+
+    @staticmethod
+    def _draw_line_chart_template(canvas: tk.Canvas, data, max_val: int) -> None:
+        """Render ``data`` on ``canvas`` scaling values by ``max_val``."""
         canvas.delete("all")
         h = int(canvas["height"])
         w = int(canvas["width"])
-        max_val = max(data) if data else 1
         step = w / max(1, len(data) - 1)
-        points = []
+        points: list[float] = []
         for i, val in enumerate(data):
             x = i * step
-            y = h - (val / max_val) * h
+            y = h - (val / max_val) * h if max_val else h
             points.extend([x, y])
         if len(points) > 3:
             canvas.create_line(*points, fill="blue")
         canvas.create_text(5, 5, anchor="nw", text="Requirements")
+
+    def _draw_line_chart_v1(self, canvas: tk.Canvas, data):
+        """Variant 1: treat all-zero input as a flat line."""
+        max_val = max(data) if any(data) else 1
+        MetricsTab._draw_line_chart_template(canvas, data, max_val)
+
+    def _draw_line_chart_v2(self, canvas: tk.Canvas, data):
+        """Variant 2: ``max`` with a default list element to avoid zero."""
+        max_val = max(list(data) + [1])
+        MetricsTab._draw_line_chart_template(canvas, data, max_val)
+
+    def _draw_line_chart_v3(self, canvas: tk.Canvas, data):
+        """Variant 3: use ``or`` to coerce zero to one."""
+        max_val = max(data) or 1
+        MetricsTab._draw_line_chart_template(canvas, data, max_val)
+
+    def _draw_line_chart_v4(self, canvas: tk.Canvas, data):
+        """Variant 4: early return when data empty or non-positive."""
+        if not data or max(data) <= 0:
+            MetricsTab._draw_line_chart_template(canvas, [0] * max(1, len(data)), 1)
+            return
+        max_val = max(data)
+        MetricsTab._draw_line_chart_template(canvas, data, max_val)
+
+    def _draw_line_chart(self, canvas: tk.Canvas, data):
+        """Default line chart implementation used by the application."""
+        self._draw_line_chart_v4(canvas, data)
 
     def _draw_bar_chart(self, canvas: tk.Canvas, data):
         canvas.delete("all")


### PR DESCRIPTION
## Summary
- Ignore unsupported `default` option in custom CapsuleButton to prevent Tk errors
- Add four line chart variants in MetricsTab to safely handle zero-valued data

## Testing
- `pytest -q`
- `python -m radon cc -j gui/capsule_button.py gui/metrics_tab.py` *(fails: No module named radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a64fad12188327bbf94718f3c25a5d