### PR TITLE
Coalesce application undo states for drag movements

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -227,6 +227,7 @@ import math
 import sys
 import json
 import tkinter as tk
+from typing import Optional
 from tkinter import ttk, filedialog, simpledialog, scrolledtext
 from gui.dialog_utils import askstring_fixed
 from gui import messagebox, logger, add_treeview_scrollbars
@@ -2119,6 +2120,8 @@ class DecompositionDialog(simpledialog.Dialog):
 class AutoMLApp:
     """Main application window for AutoML Analyzer."""
 
+    _instance: Optional["AutoMLApp"] = None
+
     #: Maximum number of characters displayed for a notebook tab title. Longer
     #: titles are truncated with an ellipsis to avoid giant tabs that overflow
     #: the working area.
@@ -2296,6 +2299,7 @@ class AutoMLApp:
         WORK_PRODUCT_PARENTS.setdefault(_wp, "Requirements")
 
     def __init__(self, root):
+        AutoMLApp._instance = self
         self.root = root
         self.top_events = []
         self.selected_node = None
@@ -10483,6 +10487,7 @@ class AutoMLApp:
                 break
         self.selected_node = clicked_node
         if clicked_node:
+            self.push_undo_state()
             self.dragging_node = clicked_node
             self.drag_offset_x = x - clicked_node.x
             self.drag_offset_y = y - clicked_node.y
@@ -10528,6 +10533,8 @@ class AutoMLApp:
         if self.dragging_node:
             self.dragging_node.x = round(self.dragging_node.x/self.grid_size)*self.grid_size
             self.dragging_node.y = round(self.dragging_node.y/self.grid_size)*self.grid_size
+            self.sync_nodes_by_id(self.dragging_node)
+            self.push_undo_state()
         self.dragging_node = None
         self.drag_offset_x = 0
         self.drag_offset_y = 0
@@ -19055,49 +19062,253 @@ class AutoMLApp:
         current_state = json.dumps(self.export_model_data(), sort_keys=True)
         return current_state != getattr(self, "last_saved_state", None)
 
-    def push_undo_state(self):
-        """Save the current model state for undo operations."""
-        self._undo_stack.append(self.export_model_data(include_versions=False))
-        if len(self._undo_stack) > 20:
-            self._undo_stack.pop(0)
-        self._redo_stack.clear()
+    # ------------------------------------------------------------
+    # Undo support
+    # ------------------------------------------------------------
+    def _strip_object_positions(self, data: dict) -> dict:
+        """Return a copy of *data* without concrete object positions."""
 
-    def undo(self):
+        cleaned = json.loads(json.dumps(data))
+        for diag in cleaned.get("diagrams", []):
+            for obj in diag.get("objects", []):
+                obj.pop("x", None)
+                obj.pop("y", None)
+        return cleaned
+
+    def push_undo_state(self, strategy: str = "v4", sync_repo: bool = True) -> None:
+        """Save the current model state for undo operations."""
+        repo = SysMLRepository.get_instance()
+        if sync_repo:
+            repo.push_undo_state(strategy=strategy, sync_app=False)
+
+        state = self.export_model_data(include_versions=False)
+        stripped = self._strip_object_positions(state)
+
+        if strategy == "v1":
+            changed = self._push_undo_state_v1(state, stripped)
+        elif strategy == "v2":
+            changed = self._push_undo_state_v2(state, stripped)
+        elif strategy == "v3":
+            changed = self._push_undo_state_v3(state, stripped)
+        else:  # v4
+            changed = self._push_undo_state_v4(state, stripped)
+
+        if changed and len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        if changed:
+            self._redo_stack.clear()
+
+    # Variants for push_undo_state
+    def _push_undo_state_v1(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack:
+            last = self._undo_stack[-1]
+            if last == state:
+                return False
+            if self._strip_object_positions(last) == stripped:
+                if (
+                    len(self._undo_stack) >= 2
+                    and self._strip_object_positions(self._undo_stack[-2]) == stripped
+                ):
+                    self._undo_stack[-1] = state
+                    return True
+                self._undo_stack.append(state)
+                return True
+        else:
+            self._undo_stack.append(state)
+            return True
+
+        self._undo_stack.append(state)
+        return True
+
+    def _push_undo_state_v2(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack and self._undo_stack[-1] == state:
+            return False
+        if self._undo_stack and self._strip_object_positions(self._undo_stack[-1]) == stripped:
+            if getattr(self, "_last_move_base", None) == stripped:
+                self._undo_stack[-1] = state
+            else:
+                self._undo_stack.append(state)
+                self._last_move_base = stripped
+            return True
+        self._last_move_base = None
+        self._undo_stack.append(state)
+        return True
+
+    def _push_undo_state_v3(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack and self._undo_stack[-1] == state:
+            return False
+        if self._undo_stack and self._strip_object_positions(self._undo_stack[-1]) == stripped:
+            if getattr(self, "_move_run_length", 0):
+                self._undo_stack[-1] = state
+            else:
+                self._undo_stack.append(state)
+            self._move_run_length = getattr(self, "_move_run_length", 0) + 1
+            return True
+        self._move_run_length = 0
+        self._undo_stack.append(state)
+        return True
+
+    def _push_undo_state_v4(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack and self._undo_stack[-1] == state:
+            return False
+        self._undo_stack.append(state)
+        if len(self._undo_stack) >= 3:
+            s1 = self._strip_object_positions(self._undo_stack[-3])
+            s2 = self._strip_object_positions(self._undo_stack[-2])
+            if s1 == s2 == stripped:
+                self._undo_stack.pop(-2)
+        return True
+
+    def undo(self, strategy: str = "v4"):
         """Revert the repository and model data to the previous state."""
         repo = SysMLRepository.get_instance()
-        # Only perform undo if there is a corresponding application state
-        if not self._undo_stack:
+        if strategy == "v1":
+            changed = self._undo_v1(repo)
+        elif strategy == "v2":
+            changed = self._undo_v2(repo)
+        elif strategy == "v3":
+            changed = self._undo_v3(repo)
+        else:
+            changed = self._undo_v4(repo)
+        if not changed:
             return
+        for tab in getattr(self, "diagram_tabs", {}).values():
+            for child in tab.winfo_children():
+                if hasattr(child, "refresh_from_repository"):
+                    child.refresh_from_repository()
+        self.refresh_all()
+
+    def redo(self, strategy: str = "v4"):
+        """Restore the next state from the redo stack."""
+        repo = SysMLRepository.get_instance()
+        if strategy == "v1":
+            changed = self._redo_v1(repo)
+        elif strategy == "v2":
+            changed = self._redo_v2(repo)
+        elif strategy == "v3":
+            changed = self._redo_v3(repo)
+        else:
+            changed = self._redo_v4(repo)
+        if not changed:
+            return
+        for tab in getattr(self, "diagram_tabs", {}).values():
+            for child in tab.winfo_children():
+                if hasattr(child, "refresh_from_repository"):
+                    child.refresh_from_repository()
+        self.refresh_all()
+
+    # Undo/redo variants
+    def _undo_v1(self, repo):
+        if not self._undo_stack:
+            return False
         current = self.export_model_data(include_versions=False)
-        # Repository may or may not have an accompanying undo state
-        repo.undo()
+        repo.undo(strategy="v1")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
         state = self._undo_stack.pop()
         self._redo_stack.append(current)
         if len(self._redo_stack) > 20:
             self._redo_stack.pop(0)
         self.apply_model_data(state)
-        for tab in getattr(self, "diagram_tabs", {}).values():
-            for child in tab.winfo_children():
-                if hasattr(child, "refresh_from_repository"):
-                    child.refresh_from_repository()
-        self.refresh_all()
+        return True
 
-    def redo(self):
-        """Restore the next state from the redo stack."""
-        repo = SysMLRepository.get_instance()
+    def _undo_v2(self, repo):
+        if not self._undo_stack:
+            return False
         current = self.export_model_data(include_versions=False)
-        repo.redo()
-        if self._redo_stack:
-            state = self._redo_stack.pop()
-            self._undo_stack.append(current)
-            if len(self._undo_stack) > 20:
-                self._undo_stack.pop(0)
-            self.apply_model_data(state)
-        for tab in getattr(self, "diagram_tabs", {}).values():
-            for child in tab.winfo_children():
-                if hasattr(child, "refresh_from_repository"):
-                    child.refresh_from_repository()
-        self.refresh_all()
+        repo.undo(strategy="v2")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 20:
+            self._redo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _undo_v3(self, repo):
+        if not self._undo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.undo(strategy="v3")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 20:
+            self._redo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _undo_v4(self, repo):
+        if not self._undo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.undo(strategy="v4")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 20:
+            self._redo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _redo_v1(self, repo):
+        if not self._redo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.redo(strategy="v1")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _redo_v2(self, repo):
+        if not self._redo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.redo(strategy="v2")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _redo_v3(self, repo):
+        if not self._redo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.redo(strategy="v3")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _redo_v4(self, repo):
+        if not self._redo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.redo(strategy="v4")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
 
     def confirm_close(self):
         """Prompt to save if there are unsaved changes before closing."""
@@ -22233,6 +22444,7 @@ class PageDiagram:
         self.selected_node = clicked_node
         self.app.selected_node = clicked_node
         if clicked_node and clicked_node is not self.root_node:
+            self.app.push_undo_state()
             self.dragging_node = clicked_node
             self.drag_offset_x = x - clicked_node.x
             self.drag_offset_y = y - clicked_node.y
@@ -22273,6 +22485,8 @@ class PageDiagram:
         if self.dragging_node:
             self.dragging_node.x = round(self.dragging_node.x/self.grid_size)*self.grid_size
             self.dragging_node.y = round(self.dragging_node.y/self.grid_size)*self.grid_size
+            self.app.sync_nodes_by_id(self.dragging_node)
+            self.app.push_undo_state()
         self.dragging_node = None
         self.drag_offset_x = 0
         self.drag_offset_y = 0

--- a/tests/test_app_drag_undo_redo.py
+++ b/tests/test_app_drag_undo_redo.py
@@ -1,0 +1,58 @@
+import types
+
+from AutoML import AutoMLApp
+
+
+class DummyEvent:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+def test_drag_records_only_endpoints_and_undo_redo():
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.zoom = 1.0
+    app.grid_size = 1
+    node = types.SimpleNamespace(
+        x=0.0,
+        y=0.0,
+        node_type="Block",
+        children=[],
+        is_primary_instance=True,
+    )
+    app.root_node = node
+    app.get_all_nodes = lambda root: [node]
+    app.move_subtree = lambda n, dx, dy: None
+    app.sync_nodes_by_id = lambda n: None
+    app.redraw_canvas = lambda: None
+    app._undo_stack = []
+    app._redo_stack = []
+    app.export_model_data = lambda include_versions=False: {
+        "diagrams": [{"objects": [{"x": node.x, "y": node.y}]}]
+    }
+    app.apply_model_data = lambda data: (
+        setattr(node, "x", data["diagrams"][0]["objects"][0]["x"]),
+        setattr(node, "y", data["diagrams"][0]["objects"][0]["y"]),
+    )
+    app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+    app.undo = AutoMLApp.undo.__get__(app)
+    app.redo = AutoMLApp.redo.__get__(app)
+    app.on_canvas_click = AutoMLApp.on_canvas_click.__get__(app)
+    app.on_canvas_drag = AutoMLApp.on_canvas_drag.__get__(app)
+    app.on_canvas_release = AutoMLApp.on_canvas_release.__get__(app)
+    app.canvas = types.SimpleNamespace(canvasx=lambda x: x, canvasy=lambda y: y)
+    app.diagram_tabs = {}
+    app.refresh_all = lambda: None
+
+    app.on_canvas_click(DummyEvent(0, 0))
+    app.on_canvas_drag(DummyEvent(10, 10))
+    app.on_canvas_release(DummyEvent(10, 10))
+
+    assert node.x == 10.0 and node.y == 10.0
+    assert len(app._undo_stack) == 2
+
+    app.undo()
+    assert node.x == 0.0 and node.y == 0.0
+
+    app.redo()
+    assert node.x == 10.0 and node.y == 10.0

--- a/tests/test_app_undo_move_coalesce.py
+++ b/tests/test_app_undo_move_coalesce.py
@@ -1,0 +1,72 @@
+import unittest
+import json
+
+from AutoML import AutoMLApp
+
+
+class AppUndoMoveCoalesceTests(unittest.TestCase):
+    def _make_app(self):
+        app = AutoMLApp.__new__(AutoMLApp)
+        app._undo_stack = []
+        app._redo_stack = []
+        state = {"diagrams": [{"objects": [{"x": 0.0, "y": 0.0}]}]}
+        app._state = state
+
+        def export_model_data(include_versions: bool = False):
+            return json.loads(json.dumps(app._state))
+
+        app.export_model_data = export_model_data
+        app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+        return app
+
+    def test_strategies_only_store_first_and_last(self):
+        for strat in ("v1", "v2", "v3", "v4"):
+            with self.subTest(strategy=strat):
+                app = self._make_app()
+                base_len = len(app._undo_stack)
+                app.push_undo_state(strategy=strat)
+                for i in range(1, 5):
+                    app._state["diagrams"][0]["objects"][0]["x"] = float(i)
+                    app._state["diagrams"][0]["objects"][0]["y"] = float(i)
+                    app.push_undo_state(strategy=strat)
+                self.assertEqual(len(app._undo_stack), base_len + 2)
+
+    def test_undo_redo_restore_endpoints(self):
+        from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+        for strat in ("v1", "v2", "v3", "v4"):
+            with self.subTest(strategy=strat):
+                SysMLRepository.reset_instance()
+                repo = SysMLRepository.get_instance()
+                diag = SysMLDiagram(diag_id="d", diag_type="Use Case Diagram")
+                repo.diagrams[diag.diag_id] = diag
+                diag.objects.append({"obj_id": 1, "obj_type": "Block", "x": 0.0, "y": 0.0})
+
+                app = AutoMLApp.__new__(AutoMLApp)
+                app._undo_stack = []
+                app._redo_stack = []
+                app.export_model_data = lambda include_versions=False: repo.to_dict()
+                app.apply_model_data = lambda data: repo.from_dict(data)
+                app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+                app.undo = AutoMLApp.undo.__get__(app)
+                app.redo = AutoMLApp.redo.__get__(app)
+                app.diagram_tabs = {}
+                app.refresh_all = lambda: None
+
+                app.push_undo_state(strategy=strat)
+                for i in range(1, 5):
+                    diag.objects[0]["x"] = float(i)
+                    diag.objects[0]["y"] = float(i)
+                    app.push_undo_state(strategy=strat)
+
+                app.undo(strategy=strat)
+                self.assertEqual(repo.diagrams[diag.diag_id].objects[0]["x"], 0.0)
+                self.assertEqual(repo.diagrams[diag.diag_id].objects[0]["y"], 0.0)
+
+                app.redo(strategy=strat)
+                self.assertEqual(repo.diagrams[diag.diag_id].objects[0]["x"], 4.0)
+                self.assertEqual(repo.diagrams[diag.diag_id].objects[0]["y"], 4.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_app_undo_task_lifecycle.py
+++ b/tests/test_app_undo_task_lifecycle.py
@@ -1,0 +1,104 @@
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from sysml.sysml_repository import SysMLRepository
+
+
+class AppUndoTaskLifecycleTests(unittest.TestCase):
+    def _make_app_repo(self):
+        SysMLRepository.reset_instance()
+        repo = SysMLRepository.get_instance()
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        app = AutoMLApp.__new__(AutoMLApp)
+        app._undo_stack = []
+        app._redo_stack = []
+        app.export_model_data = lambda include_versions=False: repo.to_dict()
+        app.apply_model_data = lambda data: repo.from_dict(data)
+        app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+        app.undo = AutoMLApp.undo.__get__(app)
+        app.redo = AutoMLApp.redo.__get__(app)
+        app.diagram_tabs = {}
+        app.refresh_all = lambda: None
+        return app, repo, diag
+
+    def test_task_add_move_rename_resize_undo_redo(self):
+        for strat in ("v1", "v2", "v3", "v4"):
+            with self.subTest(strategy=strat):
+                app, repo, diag = self._make_app_repo()
+
+                # Baseline before adding the task
+                app.push_undo_state(strategy=strat)
+
+                # Add task
+                obj = {
+                    "obj_id": 1,
+                    "obj_type": "Task",
+                    "user_name": "T1",
+                    "x": 1.0,
+                    "y": 1.0,
+                    "width": 10.0,
+                    "height": 10.0,
+                }
+                diag.objects.append(obj)
+
+                # Prepare to move
+                app.push_undo_state(strategy=strat)
+                obj["x"], obj["y"] = 5.0, 5.0
+
+                # Prepare to rename
+                app.push_undo_state(strategy=strat)
+                obj["user_name"] = "Renamed"
+
+                # Prepare to resize
+                app.push_undo_state(strategy=strat)
+                obj["width"], obj["height"] = 20.0, 20.0
+
+                # Undo size
+                app.undo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual((obj["width"], obj["height"]), (10.0, 10.0))
+
+                # Undo rename
+                app.undo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual(obj["user_name"], "T1")
+
+                # Undo move
+                app.undo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual((obj["x"], obj["y"]), (1.0, 1.0))
+
+                # Undo addition
+                app.undo(strategy=strat)
+                self.assertEqual(len(repo.diagrams[diag.diag_id].objects), 0)
+
+                # Redo addition
+                app.redo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual((obj["x"], obj["y"]), (1.0, 1.0))
+                self.assertEqual((obj["width"], obj["height"]), (10.0, 10.0))
+                self.assertEqual(obj["user_name"], "T1")
+
+                # Redo move
+                app.redo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual((obj["x"], obj["y"]), (5.0, 5.0))
+
+                # Redo rename
+                app.redo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual(obj["user_name"], "Renamed")
+
+                # Redo resize
+                app.redo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual((obj["width"], obj["height"]), (20.0, 20.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Record undo snapshots at the beginning and end of drag gestures so diagrams can revert to their original and final positions
- Add regression test exercising a full click-drag-release cycle and verifying undo/redo restore the endpoints only

## Testing
- `pytest -q`
- `radon cc AutoML.py sysml/sysml_repository.py -s -j` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a71c9cdf088327b192271e8563c397