### PR TITLE
Fix undo/redo for governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3815,6 +3815,7 @@ class SysMLDiagramWindow(tk.Frame):
         self.bind("<Control-v>", self.paste_selected)
         if self.app:
             self.bind("<Control-z>", lambda e: self.app.undo())
+            self.bind("<Control-y>", lambda e: self.app.redo())
         self.bind("<Delete>", self.delete_selected)
         # Refresh from the repository whenever the window gains focus
         self.bind("<FocusIn>", self.refresh_from_repository)
@@ -9639,6 +9640,9 @@ class SysMLDiagramWindow(tk.Frame):
     def _sync_to_repository(self) -> None:
         """Persist current objects and connections back to the repository."""
         self.repo.push_undo_state()
+        undo = getattr(self.app, "push_undo_state", None)
+        if undo:
+            undo()
         diag = self.repo.diagrams.get(self.diagram_id)
         if diag:
             existing_objs = getattr(diag, "objects", [])

--- a/tests/test_governance_undo.py
+++ b/tests/test_governance_undo.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import types
+
+# Ensure repository root is on the Python path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+
+from AutoML import AutoMLApp
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_governance_diagram_undo_redo_work_product():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.export_model_data = lambda include_versions=False: {}
+    app.apply_model_data = lambda data: None
+    app.refresh_all = lambda: None
+    app.diagram_tabs = {}
+    app._undo_stack = []
+    app._redo_stack = []
+    app.enable_work_product = lambda *a, **k: None
+    app.refresh_tool_enablement = lambda *a, **k: None
+    app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+    app.undo = AutoMLApp.undo.__get__(app)
+    app.redo = AutoMLApp.redo.__get__(app)
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.app = app
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.sort_objects = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+
+    win._place_work_product("WP1", 10.0, 20.0)
+    assert len(repo.diagrams[diag.diag_id].objects) == 1
+
+    app.undo()
+    assert len(repo.diagrams[diag.diag_id].objects) == 0
+
+    app.redo()
+    assert len(repo.diagrams[diag.diag_id].objects) == 1


### PR DESCRIPTION
## Summary
- ensure governance diagrams push application undo state
- bind Control-Y to redo in all SysML diagram windows
- cover governance undo/redo with regression test

## Testing
- `pytest tests/test_governance_undo.py::test_governance_diagram_undo_redo_work_product -q`
- `pytest -q`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a732c2814c8327bdfa07670d027ba6