### PR TITLE
Coalesce application undo states for drag movements

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -227,6 +227,7 @@ import math
 import sys
 import json
 import tkinter as tk
+from typing import Any, Optional
 from tkinter import ttk, filedialog, simpledialog, scrolledtext
 from gui.dialog_utils import askstring_fixed
 from gui import messagebox, logger, add_treeview_scrollbars
@@ -2119,6 +2120,8 @@ class DecompositionDialog(simpledialog.Dialog):
 class AutoMLApp:
     """Main application window for AutoML Analyzer."""
 
+    _instance: Optional["AutoMLApp"] = None
+
     #: Maximum number of characters displayed for a notebook tab title. Longer
     #: titles are truncated with an ellipsis to avoid giant tabs that overflow
     #: the working area.
@@ -2296,6 +2299,7 @@ class AutoMLApp:
         WORK_PRODUCT_PARENTS.setdefault(_wp, "Requirements")
 
     def __init__(self, root):
+        AutoMLApp._instance = self
         self.root = root
         self.top_events = []
         self.selected_node = None
@@ -10483,6 +10487,7 @@ class AutoMLApp:
                 break
         self.selected_node = clicked_node
         if clicked_node:
+            self.push_undo_state()
             self.dragging_node = clicked_node
             self.drag_offset_x = x - clicked_node.x
             self.drag_offset_y = y - clicked_node.y
@@ -10528,6 +10533,8 @@ class AutoMLApp:
         if self.dragging_node:
             self.dragging_node.x = round(self.dragging_node.x/self.grid_size)*self.grid_size
             self.dragging_node.y = round(self.dragging_node.y/self.grid_size)*self.grid_size
+            self.sync_nodes_by_id(self.dragging_node)
+            self.push_undo_state()
         self.dragging_node = None
         self.drag_offset_x = 0
         self.drag_offset_y = 0
@@ -12162,6 +12169,9 @@ class AutoMLApp:
         parent_node.children.append(new_node)
         new_node.parents.append(parent_node)
         self.update_views()
+        # Capture the post-addition state so future moves can be undone back
+        # to this initial location.
+        self.push_undo_state()
 
     def add_basic_event_from_fmea(self):
         self.push_undo_state()
@@ -19055,49 +19065,245 @@ class AutoMLApp:
         current_state = json.dumps(self.export_model_data(), sort_keys=True)
         return current_state != getattr(self, "last_saved_state", None)
 
-    def push_undo_state(self):
-        """Save the current model state for undo operations."""
-        self._undo_stack.append(self.export_model_data(include_versions=False))
-        if len(self._undo_stack) > 20:
-            self._undo_stack.pop(0)
-        self._redo_stack.clear()
+    # ------------------------------------------------------------
+    # Undo support
+    # ------------------------------------------------------------
+    def _strip_object_positions(self, data: dict) -> dict:
+        """Return a copy of *data* without concrete object positions."""
 
-    def undo(self):
+        cleaned = json.loads(json.dumps(data))
+
+        def scrub(obj: Any) -> None:
+            if isinstance(obj, dict):
+                for field in ("x", "y", "modified", "modified_by", "modified_by_email"):
+                    obj.pop(field, None)
+                for value in obj.values():
+                    scrub(value)
+            elif isinstance(obj, list):
+                for item in obj:
+                    scrub(item)
+
+        scrub(cleaned)
+        return cleaned
+
+    def push_undo_state(self, strategy: str = "v4", sync_repo: bool = True) -> None:
+        """Save the current model state for undo operations."""
+        repo = SysMLRepository.get_instance()
+        if sync_repo:
+            repo.push_undo_state(strategy=strategy, sync_app=False)
+
+        state = self.export_model_data(include_versions=False)
+        stripped = self._strip_object_positions(state)
+
+        handler = getattr(
+            self, f"_push_undo_state_{strategy}", self._push_undo_state_v1
+        )
+        changed = handler(state, stripped)
+
+        if changed and len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        if changed:
+            self._redo_stack.clear()
+
+    # Variants for push_undo_state
+    def _push_undo_state_v1(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack:
+            last = self._undo_stack[-1]
+            if last == state:
+                return False
+            if self._strip_object_positions(last) == stripped:
+                if (
+                    len(self._undo_stack) >= 2
+                    and self._strip_object_positions(self._undo_stack[-2]) == stripped
+                ):
+                    self._undo_stack[-1] = state
+                    return True
+                self._undo_stack.append(state)
+                return True
+        else:
+            self._undo_stack.append(state)
+            return True
+
+        self._undo_stack.append(state)
+        return True
+
+    def _push_undo_state_v2(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack and self._undo_stack[-1] == state:
+            return False
+        if self._undo_stack and self._strip_object_positions(self._undo_stack[-1]) == stripped:
+            if getattr(self, "_last_move_base", None) == stripped:
+                self._undo_stack[-1] = state
+            else:
+                self._undo_stack.append(state)
+                self._last_move_base = stripped
+            return True
+        self._last_move_base = None
+        self._undo_stack.append(state)
+        return True
+
+    def _push_undo_state_v3(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack and self._undo_stack[-1] == state:
+            return False
+        if self._undo_stack and self._strip_object_positions(self._undo_stack[-1]) == stripped:
+            if getattr(self, "_move_run_length", 0):
+                self._undo_stack[-1] = state
+            else:
+                self._undo_stack.append(state)
+            self._move_run_length = getattr(self, "_move_run_length", 0) + 1
+            return True
+        self._move_run_length = 0
+        self._undo_stack.append(state)
+        return True
+
+    def _push_undo_state_v4(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack and self._undo_stack[-1] == state:
+            return False
+        self._undo_stack.append(state)
+        if len(self._undo_stack) >= 3:
+            s1 = self._strip_object_positions(self._undo_stack[-3])
+            s2 = self._strip_object_positions(self._undo_stack[-2])
+            if s1 == s2 == stripped:
+                self._undo_stack.pop(-2)
+        return True
+
+    def undo(self, strategy: str = "v4"):
         """Revert the repository and model data to the previous state."""
         repo = SysMLRepository.get_instance()
-        # Only perform undo if there is a corresponding application state
-        if not self._undo_stack:
+        handler = getattr(self, f"_undo_{strategy}", self._undo_v1)
+        changed = handler(repo)
+        if not changed:
             return
+        for tab in getattr(self, "diagram_tabs", {}).values():
+            for child in tab.winfo_children():
+                if hasattr(child, "refresh_from_repository"):
+                    child.refresh_from_repository()
+        self.refresh_all()
+
+    def redo(self, strategy: str = "v4"):
+        """Restore the next state from the redo stack."""
+        repo = SysMLRepository.get_instance()
+        handler = getattr(self, f"_redo_{strategy}", self._redo_v1)
+        changed = handler(repo)
+        if not changed:
+            return
+        for tab in getattr(self, "diagram_tabs", {}).values():
+            for child in tab.winfo_children():
+                if hasattr(child, "refresh_from_repository"):
+                    child.refresh_from_repository()
+        self.refresh_all()
+
+    # Undo/redo variants
+    def _undo_v1(self, repo):
+        if not self._undo_stack:
+            return False
         current = self.export_model_data(include_versions=False)
-        # Repository may or may not have an accompanying undo state
-        repo.undo()
+        repo.undo(strategy="v1")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
         state = self._undo_stack.pop()
         self._redo_stack.append(current)
         if len(self._redo_stack) > 20:
             self._redo_stack.pop(0)
         self.apply_model_data(state)
-        for tab in getattr(self, "diagram_tabs", {}).values():
-            for child in tab.winfo_children():
-                if hasattr(child, "refresh_from_repository"):
-                    child.refresh_from_repository()
-        self.refresh_all()
+        return True
 
-    def redo(self):
-        """Restore the next state from the redo stack."""
-        repo = SysMLRepository.get_instance()
+    def _undo_v2(self, repo):
+        if not self._undo_stack:
+            return False
         current = self.export_model_data(include_versions=False)
-        repo.redo()
-        if self._redo_stack:
-            state = self._redo_stack.pop()
-            self._undo_stack.append(current)
-            if len(self._undo_stack) > 20:
-                self._undo_stack.pop(0)
-            self.apply_model_data(state)
-        for tab in getattr(self, "diagram_tabs", {}).values():
-            for child in tab.winfo_children():
-                if hasattr(child, "refresh_from_repository"):
-                    child.refresh_from_repository()
-        self.refresh_all()
+        repo.undo(strategy="v2")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 20:
+            self._redo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _undo_v3(self, repo):
+        if not self._undo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.undo(strategy="v3")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 20:
+            self._redo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _undo_v4(self, repo):
+        if not self._undo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.undo(strategy="v4")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 20:
+            self._redo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _redo_v1(self, repo):
+        if not self._redo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.redo(strategy="v1")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _redo_v2(self, repo):
+        if not self._redo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.redo(strategy="v2")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _redo_v3(self, repo):
+        if not self._redo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.redo(strategy="v3")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
+
+    def _redo_v4(self, repo):
+        if not self._redo_stack:
+            return False
+        current = self.export_model_data(include_versions=False)
+        repo.redo(strategy="v4")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.apply_model_data(state)
+        return True
 
     def confirm_close(self):
         """Prompt to save if there are unsaved changes before closing."""
@@ -22233,6 +22439,7 @@ class PageDiagram:
         self.selected_node = clicked_node
         self.app.selected_node = clicked_node
         if clicked_node and clicked_node is not self.root_node:
+            self.app.push_undo_state()
             self.dragging_node = clicked_node
             self.drag_offset_x = x - clicked_node.x
             self.drag_offset_y = y - clicked_node.y
@@ -22273,6 +22480,8 @@ class PageDiagram:
         if self.dragging_node:
             self.dragging_node.x = round(self.dragging_node.x/self.grid_size)*self.grid_size
             self.dragging_node.y = round(self.dragging_node.y/self.grid_size)*self.grid_size
+            self.app.sync_nodes_by_id(self.dragging_node)
+            self.app.push_undo_state()
         self.dragging_node = None
         self.drag_offset_x = 0
         self.drag_offset_y = 0

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -13422,6 +13422,8 @@ class ArchitectureManagerDialog(tk.Frame):
                     properties=props,
                 )
                 diagram.objects.append(obj.__dict__)
+                if getattr(self, "app", None) and hasattr(self.app, "push_undo_state"):
+                    self.app.push_undo_state()
                 return
             if (
                 src_diag
@@ -13441,6 +13443,8 @@ class ArchitectureManagerDialog(tk.Frame):
                     properties=props,
                 )
                 diagram.objects.append(obj.__dict__)
+                if getattr(self, "app", None) and hasattr(self.app, "push_undo_state"):
+                    self.app.push_undo_state()
                 return
             messagebox.showerror("Drop Error", "This item cannot be dropped on that diagram.")
             return
@@ -13451,6 +13455,8 @@ class ArchitectureManagerDialog(tk.Frame):
             repo.add_element_to_diagram(diagram.diag_id, block.elem_id)
             obj = SysMLObject(_get_next_id(), "Block", 50.0, 50.0, element_id=block.elem_id)
             diagram.objects.append(obj.__dict__)
+            if getattr(self, "app", None) and hasattr(self.app, "push_undo_state"):
+                self.app.push_undo_state()
         else:
             messagebox.showerror("Drop Error", "This item cannot be dropped on that diagram.")
 

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -2,7 +2,7 @@
 import json
 import uuid
 from dataclasses import dataclass, field, asdict
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 import os
 import datetime
 import analysis.user_config as user_config
@@ -161,13 +161,21 @@ class SysMLRepository:
         """
 
         cleaned = json.loads(json.dumps(data))
-        for diag in cleaned.get("diagrams", []):
-            for obj in diag.get("objects", []):
-                obj.pop("x", None)
-                obj.pop("y", None)
+
+        def scrub(obj: Any) -> None:
+            if isinstance(obj, dict):
+                for field in ("x", "y", "modified", "modified_by", "modified_by_email"):
+                    obj.pop(field, None)
+                for value in obj.values():
+                    scrub(value)
+            elif isinstance(obj, list):
+                for item in obj:
+                    scrub(item)
+
+        scrub(cleaned)
         return cleaned
 
-    def push_undo_state(self, strategy: str = "v4") -> None:
+    def push_undo_state(self, strategy: str = "v4", sync_app: bool = True) -> None:
         """Save the current repository state for undo.
 
         Four alternative strategies are provided and can be selected via the
@@ -178,21 +186,25 @@ class SysMLRepository:
 
         state = self.to_dict()
         stripped = self._strip_object_positions(state)
-        changed = False
 
-        if strategy == "v1":
-            changed = self._push_undo_state_v1(state, stripped)
-        elif strategy == "v2":
-            changed = self._push_undo_state_v2(state, stripped)
-        elif strategy == "v3":
-            changed = self._push_undo_state_v3(state, stripped)
-        else:  # v4
-            changed = self._push_undo_state_v4(state, stripped)
+        handler = getattr(
+            self, f"_push_undo_state_{strategy}", self._push_undo_state_v1
+        )
+        changed = handler(state, stripped)
 
         if changed:
             if len(self._undo_stack) > 50:
                 self._undo_stack.pop(0)
             self._redo_stack.clear()
+            if sync_app:
+                try:
+                    from AutoML import AutoMLApp
+
+                    app = getattr(AutoMLApp, "_instance", None)
+                    if app:
+                        app.push_undo_state(strategy=strategy, sync_repo=False)
+                except Exception:
+                    pass
 
     # ------------------------------------------------------------
     # Variants for push_undo_state
@@ -257,11 +269,25 @@ class SysMLRepository:
                 self._undo_stack.pop(-2)
         return True
 
-    def undo(self) -> bool:
+    def undo(self, strategy: str = "v4") -> bool:
         """Revert to the most recent saved state."""
+        handler = getattr(self, f"_undo_{strategy}", self._undo_v1)
+        return handler()
+
+    def redo(self, strategy: str = "v4") -> bool:
+        """Restore the next state from the redo stack."""
+        handler = getattr(self, f"_redo_{strategy}", self._redo_v1)
+        return handler()
+
+    # Undo/redo variants
+    def _undo_v1(self) -> bool:
         if not self._undo_stack:
             return False
         current = self.to_dict()
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
         state = self._undo_stack.pop()
         self._redo_stack.append(current)
         if len(self._redo_stack) > 50:
@@ -269,8 +295,85 @@ class SysMLRepository:
         self.from_dict(state)
         return True
 
-    def redo(self) -> bool:
-        """Restore the next state from the redo stack."""
+    def _undo_v2(self) -> bool:
+        if not self._undo_stack:
+            return False
+        current = self.to_dict()
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 50:
+            self._redo_stack.pop(0)
+        self.from_dict(state)
+        return True
+
+    def _undo_v3(self) -> bool:
+        if not self._undo_stack:
+            return False
+        current = self.to_dict()
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 50:
+            self._redo_stack.pop(0)
+        self.from_dict(state)
+        return True
+
+    def _undo_v4(self) -> bool:
+        if not self._undo_stack:
+            return False
+        current = self.to_dict()
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 50:
+            self._redo_stack.pop(0)
+        self.from_dict(state)
+        return True
+
+    def _redo_v1(self) -> bool:
+        if not self._redo_stack:
+            return False
+        current = self.to_dict()
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 50:
+            self._undo_stack.pop(0)
+        self.from_dict(state)
+        return True
+
+    def _redo_v2(self) -> bool:
+        if not self._redo_stack:
+            return False
+        current = self.to_dict()
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 50:
+            self._undo_stack.pop(0)
+        self.from_dict(state)
+        return True
+
+    def _redo_v3(self) -> bool:
+        if not self._redo_stack:
+            return False
+        current = self.to_dict()
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 50:
+            self._undo_stack.pop(0)
+        self.from_dict(state)
+        return True
+
+    def _redo_v4(self) -> bool:
         if not self._redo_stack:
             return False
         current = self.to_dict()

--- a/tests/test_app_drag_undo_redo.py
+++ b/tests/test_app_drag_undo_redo.py
@@ -1,0 +1,58 @@
+import types
+
+from AutoML import AutoMLApp
+
+
+class DummyEvent:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+def test_drag_records_only_endpoints_and_undo_redo():
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.zoom = 1.0
+    app.grid_size = 1
+    node = types.SimpleNamespace(
+        x=0.0,
+        y=0.0,
+        node_type="Block",
+        children=[],
+        is_primary_instance=True,
+    )
+    app.root_node = node
+    app.get_all_nodes = lambda root: [node]
+    app.move_subtree = lambda n, dx, dy: None
+    app.sync_nodes_by_id = lambda n: None
+    app.redraw_canvas = lambda: None
+    app._undo_stack = []
+    app._redo_stack = []
+    app.export_model_data = lambda include_versions=False: {
+        "diagrams": [{"objects": [{"x": node.x, "y": node.y}]}]
+    }
+    app.apply_model_data = lambda data: (
+        setattr(node, "x", data["diagrams"][0]["objects"][0]["x"]),
+        setattr(node, "y", data["diagrams"][0]["objects"][0]["y"]),
+    )
+    app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+    app.undo = AutoMLApp.undo.__get__(app)
+    app.redo = AutoMLApp.redo.__get__(app)
+    app.on_canvas_click = AutoMLApp.on_canvas_click.__get__(app)
+    app.on_canvas_drag = AutoMLApp.on_canvas_drag.__get__(app)
+    app.on_canvas_release = AutoMLApp.on_canvas_release.__get__(app)
+    app.canvas = types.SimpleNamespace(canvasx=lambda x: x, canvasy=lambda y: y)
+    app.diagram_tabs = {}
+    app.refresh_all = lambda: None
+
+    app.on_canvas_click(DummyEvent(0, 0))
+    app.on_canvas_drag(DummyEvent(10, 10))
+    app.on_canvas_release(DummyEvent(10, 10))
+
+    assert node.x == 10.0 and node.y == 10.0
+    assert len(app._undo_stack) == 2
+
+    app.undo()
+    assert node.x == 0.0 and node.y == 0.0
+
+    app.redo()
+    assert node.x == 10.0 and node.y == 10.0

--- a/tests/test_app_undo_move_coalesce.py
+++ b/tests/test_app_undo_move_coalesce.py
@@ -1,0 +1,72 @@
+import unittest
+import json
+
+from AutoML import AutoMLApp
+
+
+class AppUndoMoveCoalesceTests(unittest.TestCase):
+    def _make_app(self):
+        app = AutoMLApp.__new__(AutoMLApp)
+        app._undo_stack = []
+        app._redo_stack = []
+        state = {"diagrams": [{"objects": [{"x": 0.0, "y": 0.0}]}]}
+        app._state = state
+
+        def export_model_data(include_versions: bool = False):
+            return json.loads(json.dumps(app._state))
+
+        app.export_model_data = export_model_data
+        app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+        return app
+
+    def test_strategies_only_store_first_and_last(self):
+        for strat in ("v1", "v2", "v3", "v4"):
+            with self.subTest(strategy=strat):
+                app = self._make_app()
+                base_len = len(app._undo_stack)
+                app.push_undo_state(strategy=strat)
+                for i in range(1, 5):
+                    app._state["diagrams"][0]["objects"][0]["x"] = float(i)
+                    app._state["diagrams"][0]["objects"][0]["y"] = float(i)
+                    app.push_undo_state(strategy=strat)
+                self.assertEqual(len(app._undo_stack), base_len + 2)
+
+    def test_undo_redo_restore_endpoints(self):
+        from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+        for strat in ("v1", "v2", "v3", "v4"):
+            with self.subTest(strategy=strat):
+                SysMLRepository.reset_instance()
+                repo = SysMLRepository.get_instance()
+                diag = SysMLDiagram(diag_id="d", diag_type="Use Case Diagram")
+                repo.diagrams[diag.diag_id] = diag
+                diag.objects.append({"obj_id": 1, "obj_type": "Block", "x": 0.0, "y": 0.0})
+
+                app = AutoMLApp.__new__(AutoMLApp)
+                app._undo_stack = []
+                app._redo_stack = []
+                app.export_model_data = lambda include_versions=False: repo.to_dict()
+                app.apply_model_data = lambda data: repo.from_dict(data)
+                app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+                app.undo = AutoMLApp.undo.__get__(app)
+                app.redo = AutoMLApp.redo.__get__(app)
+                app.diagram_tabs = {}
+                app.refresh_all = lambda: None
+
+                app.push_undo_state(strategy=strat)
+                for i in range(1, 5):
+                    diag.objects[0]["x"] = float(i)
+                    diag.objects[0]["y"] = float(i)
+                    app.push_undo_state(strategy=strat)
+
+                app.undo(strategy=strat)
+                self.assertEqual(repo.diagrams[diag.diag_id].objects[0]["x"], 0.0)
+                self.assertEqual(repo.diagrams[diag.diag_id].objects[0]["y"], 0.0)
+
+                app.redo(strategy=strat)
+                self.assertEqual(repo.diagrams[diag.diag_id].objects[0]["x"], 4.0)
+                self.assertEqual(repo.diagrams[diag.diag_id].objects[0]["y"], 4.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_app_undo_move_creation.py
+++ b/tests/test_app_undo_move_creation.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from sysml.sysml_repository import SysMLRepository
+
+
+class AppUndoMoveCreationTests(unittest.TestCase):
+    def _make_app_repo(self):
+        SysMLRepository.reset_instance()
+        repo = SysMLRepository.get_instance()
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        app = AutoMLApp.__new__(AutoMLApp)
+        app._undo_stack = []
+        app._redo_stack = []
+        app.export_model_data = lambda include_versions=False: repo.to_dict()
+        app.apply_model_data = lambda data: repo.from_dict(data)
+        app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+        app.undo = AutoMLApp.undo.__get__(app)
+        app.diagram_tabs = {}
+        app.refresh_all = lambda: None
+        return app, repo, diag
+
+    def test_move_undo_restores_creation_position(self):
+        for strat in ("v1", "v2", "v3", "v4"):
+            with self.subTest(strategy=strat):
+                app, repo, diag = self._make_app_repo()
+                # Baseline before adding
+                app.push_undo_state(strategy=strat)
+                obj = {
+                    "obj_id": 1,
+                    "obj_type": "Task",
+                    "user_name": "T1",
+                    "x": 2.0,
+                    "y": 3.0,
+                    "width": 10.0,
+                    "height": 10.0,
+                }
+                diag.objects.append(obj)
+                # Record the addition state
+                app.push_undo_state(strategy=strat)
+                # Move the task
+                obj["x"], obj["y"] = 8.0, 9.0
+                app.push_undo_state(strategy=strat)
+                # Undo the move
+                app.undo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual((obj["x"], obj["y"]), (2.0, 3.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_app_undo_task_lifecycle.py
+++ b/tests/test_app_undo_task_lifecycle.py
@@ -1,0 +1,104 @@
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from sysml.sysml_repository import SysMLRepository
+
+
+class AppUndoTaskLifecycleTests(unittest.TestCase):
+    def _make_app_repo(self):
+        SysMLRepository.reset_instance()
+        repo = SysMLRepository.get_instance()
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        app = AutoMLApp.__new__(AutoMLApp)
+        app._undo_stack = []
+        app._redo_stack = []
+        app.export_model_data = lambda include_versions=False: repo.to_dict()
+        app.apply_model_data = lambda data: repo.from_dict(data)
+        app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+        app.undo = AutoMLApp.undo.__get__(app)
+        app.redo = AutoMLApp.redo.__get__(app)
+        app.diagram_tabs = {}
+        app.refresh_all = lambda: None
+        return app, repo, diag
+
+    def test_task_add_move_rename_resize_undo_redo(self):
+        for strat in ("v1", "v2", "v3", "v4"):
+            with self.subTest(strategy=strat):
+                app, repo, diag = self._make_app_repo()
+
+                # Baseline before adding the task
+                app.push_undo_state(strategy=strat)
+
+                # Add task
+                obj = {
+                    "obj_id": 1,
+                    "obj_type": "Task",
+                    "user_name": "T1",
+                    "x": 1.0,
+                    "y": 1.0,
+                    "width": 10.0,
+                    "height": 10.0,
+                }
+                diag.objects.append(obj)
+
+                # Prepare to move
+                app.push_undo_state(strategy=strat)
+                obj["x"], obj["y"] = 5.0, 5.0
+
+                # Prepare to rename
+                app.push_undo_state(strategy=strat)
+                obj["user_name"] = "Renamed"
+
+                # Prepare to resize
+                app.push_undo_state(strategy=strat)
+                obj["width"], obj["height"] = 20.0, 20.0
+
+                # Undo size
+                app.undo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual((obj["width"], obj["height"]), (10.0, 10.0))
+
+                # Undo rename
+                app.undo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual(obj["user_name"], "T1")
+
+                # Undo move
+                app.undo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual((obj["x"], obj["y"]), (1.0, 1.0))
+
+                # Undo addition
+                app.undo(strategy=strat)
+                self.assertEqual(len(repo.diagrams[diag.diag_id].objects), 0)
+
+                # Redo addition
+                app.redo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual((obj["x"], obj["y"]), (1.0, 1.0))
+                self.assertEqual((obj["width"], obj["height"]), (10.0, 10.0))
+                self.assertEqual(obj["user_name"], "T1")
+
+                # Redo move
+                app.redo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual((obj["x"], obj["y"]), (5.0, 5.0))
+
+                # Redo rename
+                app.redo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual(obj["user_name"], "Renamed")
+
+                # Redo resize
+                app.redo(strategy=strat)
+                obj = repo.diagrams[diag.diag_id].objects[0]
+                self.assertEqual((obj["width"], obj["height"]), (20.0, 20.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repo_push_undo_fallback.py
+++ b/tests/test_repo_push_undo_fallback.py
@@ -1,0 +1,16 @@
+import pytest
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_push_undo_state_falls_back_when_strategy_missing():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    base_len = len(repo._undo_stack)
+
+    original = SysMLRepository._push_undo_state_v4
+    del SysMLRepository._push_undo_state_v4
+    try:
+        repo.push_undo_state("v4")
+        assert len(repo._undo_stack) == base_len + 1
+    finally:
+        SysMLRepository._push_undo_state_v4 = original

--- a/tests/test_undo_move_ignore_modified.py
+++ b/tests/test_undo_move_ignore_modified.py
@@ -1,0 +1,30 @@
+import unittest
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+
+class UndoMoveIgnoreModifiedTests(unittest.TestCase):
+    def _prepare_repo(self):
+        SysMLRepository.reset_instance()
+        repo = SysMLRepository.get_instance()
+        diag = SysMLDiagram(diag_id="d", diag_type="Use Case Diagram")
+        repo.diagrams[diag.diag_id] = diag
+        diag.objects.append({"obj_id": 1, "obj_type": "Block", "x": 0.0, "y": 0.0, "modified": "t0"})
+        return repo, diag
+
+    def test_modified_fields_do_not_create_extra_states(self):
+        for strat in ("v1", "v2", "v3", "v4"):
+            with self.subTest(strategy=strat):
+                repo, diag = self._prepare_repo()
+                base_len = len(repo._undo_stack)
+                # initial state
+                repo.push_undo_state(strategy=strat)
+                for i in range(1, 5):
+                    diag.objects[0]["x"] = float(i)
+                    diag.objects[0]["y"] = float(i)
+                    diag.objects[0]["modified"] = f"t{i}"
+                    repo.push_undo_state(strategy=strat)
+                self.assertEqual(len(repo._undo_stack), base_len + 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Record undo snapshots after adding new nodes so moves can be undone back to the original drop location
- Sync diagram drop operations with the application's undo stack to retain the element's first placement
- Add regression test confirming undoing a move restores the task's creation coordinates across all strategies

## Testing
- `python -m pytest tests/test_app_undo_move_creation.py -q`
- `python -m pytest -q`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*
- `radon cc AutoML.py sysml/sysml_repository.py -s -j` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a71c9cdf088327b192271e8563c397