### PR TITLE
Improve diagram clipboard handling, undo logic, and hotkeys

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -348,6 +348,7 @@ from gui.architecture import (
     unlink_requirement_from_object,
     link_requirements,
     unlink_requirements,
+    ARCH_WINDOWS,
 )
 from sysml.sysml_repository import SysMLRepository
 from analysis.fmeda_utils import compute_fmeda_metrics
@@ -2522,6 +2523,9 @@ class AutoMLApp:
             "Control Flow Diagram": self._create_icon("activity_diag", _color("Control Flow Diagram", "red")),
         }
         self.clipboard_node = None
+        self.diagram_clipboard = None
+        self.diagram_clipboard_type = None
+        self.active_arch_window = None
         self.cut_mode = False
         self.page_history = []
         self.project_properties = {
@@ -2976,9 +2980,9 @@ class AutoMLApp:
         root.bind("<Control-Shift-b>", lambda event: self.add_node_of_type("Basic Event"))
         root.bind("<Control-Shift-t>", lambda event: self.add_node_of_type("Triggering Condition"))
         root.bind("<Control-Shift-f>", lambda event: self.add_node_of_type("Functional Insufficiency"))
-        root.bind("<Control-c>", lambda event: self.copy_node())
-        root.bind("<Control-x>", lambda event: self.cut_node())
-        root.bind("<Control-v>", lambda event: self.paste_node())
+        root.bind_all("<Control-c>", lambda event: self.copy_node(), add="+")
+        root.bind_all("<Control-x>", lambda event: self.cut_node(), add="+")
+        root.bind_all("<Control-v>", lambda event: self.paste_node(), add="+")
         root.bind("<Control-p>", lambda event: self.save_diagram_png())
         root.bind_all("<Control-z>", self._undo_hotkey, add="+")
         root.bind_all("<Control-y>", self._redo_hotkey, add="+")
@@ -18651,8 +18655,19 @@ class AutoMLApp:
             self.clipboard_node = node
             self.selected_node = node
             self.cut_mode = False
-        else:
-            messagebox.showwarning("Copy", "Select a non-root node to copy.")
+            return
+        win = getattr(self, "active_arch_window", None)
+        if win and getattr(win, "selected_obj", None):
+            if getattr(win, "copy_selected", None):
+                win.copy_selected()
+                return
+        for ref in list(ARCH_WINDOWS):
+            win = ref()
+            if win and getattr(win, "selected_obj", None):
+                if getattr(win, "copy_selected", None):
+                    win.copy_selected()
+                return
+        messagebox.showwarning("Copy", "Select a non-root node to copy.")
 
     def cut_node(self):
         """Store the currently selected node for a cut & paste operation."""
@@ -18667,104 +18682,98 @@ class AutoMLApp:
             self.clipboard_node = node
             self.selected_node = node
             self.cut_mode = True
-        else:
-            messagebox.showwarning("Cut", "Select a non-root node to cut.")
+            return
+        win = getattr(self, "active_arch_window", None)
+        if win and getattr(win, "selected_obj", None):
+            if getattr(win, "cut_selected", None):
+                win.cut_selected()
+                return
+        for ref in list(ARCH_WINDOWS):
+            win = ref()
+            if win and getattr(win, "selected_obj", None):
+                if getattr(win, "cut_selected", None):
+                    win.cut_selected()
+                return
+        if getattr(self, "active_arch_window", None) or ARCH_WINDOWS:
+            return
+        messagebox.showwarning("Cut", "Select a non-root node to cut.")
 
     def paste_node(self):
-        # 1) Ensure clipboard is not empty.
-        if not self.clipboard_node:
-            messagebox.showwarning("Paste", "Clipboard is empty.")
-            return
-
-        # 2) Determine target from selection or current selected node.
-        target = None
-        sel = self.analysis_tree.selection()
-        if sel:
-            tags = self.analysis_tree.item(sel[0], "tags")
-            if tags:
-                target = self.find_node_by_id(self.root_node, int(tags[0]))
-        if not target:
-            target = self.selected_node
-        if not target:
-            messagebox.showwarning("Paste", "Select a target node to paste into.")
-            return
-
-        # 3) Do not allow pasting into base events.
-        if target.node_type.upper() in ["CONFIDENCE LEVEL", "ROBUSTNESS SCORE"]:
-            messagebox.showwarning("Paste", "Cannot paste into a base event.")
-            return
-
-        # 4) Always use the primary instance of target.
-        if not target.is_primary_instance:
-            target = target.original
-
-        # 5) Prevent self-pasting.
-        if target.unique_id == self.clipboard_node.unique_id:
-            messagebox.showwarning("Paste", "Cannot paste a node onto itself.")
-            return
-        for child in target.children:
-            if child.unique_id == self.clipboard_node.unique_id:
-                messagebox.showwarning("Paste", "This node is already a child of the target.")
+        if self.clipboard_node:
+            target = None
+            sel = self.analysis_tree.selection()
+            if sel:
+                tags = self.analysis_tree.item(sel[0], "tags")
+                if tags:
+                    target = self.find_node_by_id(self.root_node, int(tags[0]))
+            if not target:
+                target = self.selected_node
+            if not target:
+                messagebox.showwarning("Paste", "Select a target node to paste into.")
                 return
-
-        # 6) If in cut mode, update parent's pointer, remove from top_events, and update coordinates.
-        if self.cut_mode:
-            if self.clipboard_node in self.top_events:
-                self.top_events.remove(self.clipboard_node)
-            for p in list(self.clipboard_node.parents):
-                if self.clipboard_node in p.children:
-                    p.children.remove(self.clipboard_node)
-            self.clipboard_node.parents = []
-            if self.clipboard_node.node_type.upper() == "TOP EVENT":
-                # Demote top events so they no longer show in the tree.
-                self.clipboard_node.node_type = "RIGOR LEVEL"
-                self.clipboard_node.severity = None
-                self.clipboard_node.is_page = False
-                self.clipboard_node.input_subtype = "Failure"
-            self.clipboard_node.is_primary_instance = True
-            target.children.append(self.clipboard_node)
-            self.clipboard_node.parents.append(target)
-            # Ensure the moved GSN node is registered with the target's diagram
-            # (and removed from its previous one if necessary).
-            if isinstance(self.clipboard_node, GSNNode):
-                old_diag = self._find_gsn_diagram(self.clipboard_node)
-                new_diag = self._find_gsn_diagram(target)
-                if old_diag and old_diag is not new_diag and self.clipboard_node in old_diag.nodes:
-                    old_diag.nodes.remove(self.clipboard_node)
-                if new_diag and self.clipboard_node not in new_diag.nodes:
-                    new_diag.add_node(self.clipboard_node)
-            # Update its position so it is offset relative to the new parent.
-            self.clipboard_node.x = target.x + 100
-            self.clipboard_node.y = target.y + 100
-            # (Optional: remove any clone marker from its label.)
-            self.clipboard_node.display_label = self.clipboard_node.display_label.replace(" (clone)", "")
-            self.clipboard_node = None
-            self.cut_mode = False
-            messagebox.showinfo("Paste", "Node moved successfully (cut & pasted).")
-        else:
-            # 7) Copy branch: create a clone and attach it.
-            cloned_node = self.clone_node_preserving_id(self.clipboard_node)
-            target.children.append(cloned_node)
-            cloned_node.parents.append(target)
-            # Ensure the cloned node is registered with its GSN diagram so it
-            # will be drawn instead of just the connection.  Without this the
-            # relationship line appears but the pasted node itself is missing.
-            if isinstance(cloned_node, GSNNode):
-                diag = self._find_gsn_diagram(target)
-                if diag:
-                    diag.add_node(cloned_node)
-            # Offset the cloned node relative to the target so it does not
-            # overlap the original selection.
-            cloned_node.x = target.x + 100
-            cloned_node.y = target.y + 100
-            messagebox.showinfo("Paste", "Node pasted successfully (copied).")
-
-        # 8) Recalculate and update views.
-        AutoML_Helper.calculate_assurance_recursive(
-            self.root_node,
-            self.top_events,
-        )
-        self.update_views()
+            if target.node_type.upper() in ["CONFIDENCE LEVEL", "ROBUSTNESS SCORE"]:
+                messagebox.showwarning("Paste", "Cannot paste into a base event.")
+                return
+            if not target.is_primary_instance:
+                target = target.original
+            if target.unique_id == self.clipboard_node.unique_id:
+                messagebox.showwarning("Paste", "Cannot paste a node onto itself.")
+                return
+            for child in target.children:
+                if child.unique_id == self.clipboard_node.unique_id:
+                    messagebox.showwarning("Paste", "This node is already a child of the target.")
+                    return
+            if self.cut_mode:
+                if self.clipboard_node in self.top_events:
+                    self.top_events.remove(self.clipboard_node)
+                for p in list(self.clipboard_node.parents):
+                    if self.clipboard_node in p.children:
+                        p.children.remove(self.clipboard_node)
+                self.clipboard_node.parents = []
+                if self.clipboard_node.node_type.upper() == "TOP EVENT":
+                    self.clipboard_node.node_type = "RIGOR LEVEL"
+                    self.clipboard_node.severity = None
+                    self.clipboard_node.is_page = False
+                    self.clipboard_node.input_subtype = "Failure"
+                self.clipboard_node.is_primary_instance = True
+                target.children.append(self.clipboard_node)
+                self.clipboard_node.parents.append(target)
+                if isinstance(self.clipboard_node, GSNNode):
+                    old_diag = self._find_gsn_diagram(self.clipboard_node)
+                    new_diag = self._find_gsn_diagram(target)
+                    if old_diag and old_diag is not new_diag and self.clipboard_node in old_diag.nodes:
+                        old_diag.nodes.remove(self.clipboard_node)
+                    if new_diag and self.clipboard_node not in new_diag.nodes:
+                        new_diag.add_node(self.clipboard_node)
+                self.clipboard_node.x = target.x + 100
+                self.clipboard_node.y = target.y + 100
+                self.clipboard_node.display_label = self.clipboard_node.display_label.replace(" (clone)", "")
+                self.clipboard_node = None
+                self.cut_mode = False
+                messagebox.showinfo("Paste", "Node moved successfully (cut & pasted).")
+            else:
+                cloned_node = self.clone_node_preserving_id(self.clipboard_node)
+                target.children.append(cloned_node)
+                cloned_node.parents.append(target)
+                if isinstance(cloned_node, GSNNode):
+                    diag = self._find_gsn_diagram(target)
+                    if diag:
+                        diag.add_node(cloned_node)
+                cloned_node.x = target.x + 100
+                cloned_node.y = target.y + 100
+                messagebox.showinfo("Paste", "Node pasted successfully (copied).")
+            AutoML_Helper.calculate_assurance_recursive(
+                self.root_node,
+                self.top_events,
+            )
+            self.update_views()
+            return
+        win = getattr(self, "active_arch_window", None)
+        if win and getattr(self, "diagram_clipboard", None):
+            if getattr(win, "paste_selected", None):
+                win.paste_selected()
+                return
+        messagebox.showwarning("Paste", "Clipboard is empty.")
  
     def clone_node_preserving_id(self, node):
         """Return a clone of *node* with a new unique ID.
@@ -19259,7 +19268,10 @@ class AutoMLApp:
         if self._undo_stack and self._undo_stack[-1] == current:
             self._undo_stack.pop()
             if not self._undo_stack:
-                return False
+                self._redo_stack.append(current)
+                if len(self._redo_stack) > 20:
+                    self._redo_stack.pop(0)
+                return True
         state = self._undo_stack.pop()
         self._redo_stack.append(current)
         if len(self._redo_stack) > 20:

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3635,7 +3635,6 @@ class SysMLDiagramWindow(tk.Frame):
         self.conn_drag_offset: tuple[float, float] | None = None
         self.dragging_conn_mid: tuple[float, float] | None = None
         self.dragging_conn_vec: tuple[float, float] | None = None
-        self.clipboard: SysMLObject | None = None
         self.resizing_obj: SysMLObject | None = None
         self.resize_edge: str | None = None
         self.select_rect_start: tuple[float, float] | None = None
@@ -3818,13 +3817,18 @@ class SysMLDiagramWindow(tk.Frame):
             self.bind("<Control-y>", lambda e: self.app.redo())
         self.bind("<Delete>", self.delete_selected)
         # Refresh from the repository whenever the window gains focus
-        self.bind("<FocusIn>", self.refresh_from_repository)
+        self.bind("<FocusIn>", self._on_focus_in)
 
         self.after_idle(self._fit_toolbox)
         self.redraw()
         self.update_property_view()
         if not isinstance(self.master, tk.Toplevel):
             self.pack(fill=tk.BOTH, expand=True)
+
+    def _on_focus_in(self, event=None):
+        if self.app:
+            self.app.active_arch_window = self
+        self.refresh_from_repository(event)
 
     def _fit_toolbox(self) -> None:
         """Resize the toolbox to the smallest width that shows all button text."""
@@ -9290,18 +9294,22 @@ class SysMLDiagramWindow(tk.Frame):
     # Clipboard operations
     # ------------------------------------------------------------
     def copy_selected(self, _event=None):
-        if self.selected_obj:
+        if self.selected_obj and self.app:
             import copy
 
-            self.clipboard = copy.deepcopy(self.selected_obj)
+            diag = self.repo.diagrams.get(self.diagram_id)
+            self.app.diagram_clipboard = copy.deepcopy(self.selected_obj)
+            self.app.diagram_clipboard_type = diag.diag_type if diag else None
 
     def cut_selected(self, _event=None):
         if self.repo.diagram_read_only(self.diagram_id):
             return
-        if self.selected_obj:
+        if self.selected_obj and self.app:
             import copy
 
-            self.clipboard = copy.deepcopy(self.selected_obj)
+            diag = self.repo.diagrams.get(self.diagram_id)
+            self.app.diagram_clipboard = copy.deepcopy(self.selected_obj)
+            self.app.diagram_clipboard_type = diag.diag_type if diag else None
             self.remove_object(self.selected_obj)
             self.selected_obj = None
             self._sync_to_repository()
@@ -9311,10 +9319,18 @@ class SysMLDiagramWindow(tk.Frame):
     def paste_selected(self, _event=None):
         if self.repo.diagram_read_only(self.diagram_id):
             return
-        if self.clipboard:
+        if self.app and getattr(self.app, "diagram_clipboard", None):
+            if self.app.diagram_clipboard_type:
+                diag = self.repo.diagrams.get(self.diagram_id)
+                if diag and diag.diag_type != self.app.diagram_clipboard_type:
+                    messagebox.showwarning(
+                        "Paste",
+                        "Clipboard contains incompatible diagram element.",
+                    )
+                    return
             import copy
 
-            new_obj = copy.deepcopy(self.clipboard)
+            new_obj = copy.deepcopy(self.app.diagram_clipboard)
             new_obj.obj_id = _get_next_id()
             new_obj.x += 20
             new_obj.y += 20
@@ -9639,10 +9655,10 @@ class SysMLDiagramWindow(tk.Frame):
 
     def _sync_to_repository(self) -> None:
         """Persist current objects and connections back to the repository."""
-        self.repo.push_undo_state()
+        self.repo.push_undo_state(sync_app=False)
         undo = getattr(self.app, "push_undo_state", None)
         if undo:
-            undo()
+            undo(sync_repo=False)
         diag = self.repo.diagrams.get(self.diagram_id)
         if diag:
             existing_objs = getattr(diag, "objects", [])

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -247,13 +247,28 @@ class SysMLRepository:
 
     def _push_undo_state_v3(self, state: dict, stripped: dict) -> bool:
         if self._undo_stack and self._undo_stack[-1] == state:
-            return
-
+            return False
         self._undo_stack.append(state)
-        # limit history to 50 states to avoid excessive memory use
+        if len(self._undo_stack) >= 3:
+            s1 = self._strip_object_positions(self._undo_stack[-3])
+            s2 = self._strip_object_positions(self._undo_stack[-2])
+            if s1 == s2 == stripped:
+                self._undo_stack.pop(-2)
         if len(self._undo_stack) > 50:
             self._undo_stack.pop(0)
         self._redo_stack.clear()
+        return True
+
+    def _push_undo_state_v4(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack and self._undo_stack[-1] == state:
+            return False
+        self._undo_stack.append(state)
+        if len(self._undo_stack) >= 3:
+            s1 = self._strip_object_positions(self._undo_stack[-3])
+            s2 = self._strip_object_positions(self._undo_stack[-2])
+            if s1 == s2 == stripped:
+                self._undo_stack.pop(-2)
+        return True
 
     def undo(self, strategy: str = "v4") -> bool:
         """Revert to the most recent saved state."""

--- a/tests/test_cross_diagram_clipboard.py
+++ b/tests/test_cross_diagram_clipboard.py
@@ -1,0 +1,70 @@
+import types
+
+
+from AutoML import AutoMLApp
+from gui.architecture import SysMLDiagramWindow, _get_next_id
+
+
+class DummyRepo:
+    def __init__(self, diag1_type, diag2_type):
+        self.diagrams = {
+            1: types.SimpleNamespace(diag_type=diag1_type, elements=[]),
+            2: types.SimpleNamespace(diag_type=diag2_type, elements=[]),
+        }
+
+    def diagram_read_only(self, _id):
+        return False
+
+
+def make_window(app, repo, diagram_id):
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.app = app
+    win.repo = repo
+    win.diagram_id = diagram_id
+    win.selected_obj = None
+    win.objects = []
+    win.remove_object = lambda o: win.objects.remove(o)
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    win.sort_objects = lambda: None
+    return win
+
+
+def test_copy_paste_between_same_type_diagrams():
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.active_arch_window = None
+
+    repo = DummyRepo("Governance Diagram", "Governance Diagram")
+
+    obj = types.SimpleNamespace(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        width=80,
+        height=40,
+        element_id=None,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.selected_obj = obj
+    win1.objects = [obj]
+
+    win2 = make_window(app, repo, 2)
+
+    app.active_arch_window = win1
+    SysMLDiagramWindow.copy_selected(win1)
+    assert app.diagram_clipboard is not None
+
+    app.active_arch_window = win2
+    SysMLDiagramWindow.paste_selected(win2)
+    assert len(win2.objects) == 1
+    assert win2.objects[0] is not obj


### PR DESCRIPTION
## Summary
- share diagram clipboard across open windows and track active diagram to enable copy/paste between diagrams of same type
- ensure pasted elements match source diagram type and warn on mismatch
- add regression test for cross-diagram clipboard support
- suppress unnecessary 'Cut' warnings when diagram windows process the action
- bind copy/cut/paste hotkeys globally so shortcuts work in all diagram windows

## Testing
- `pytest -q`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*
- `radon cc -j gui/architecture.py` *(fails: command not found: radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a7436f23248327a7add0136e3b3195