### PR TITLE
feat: prompt save before loading model

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -20288,9 +20288,39 @@ class AutoMLApp:
         if getattr(self, "canvas", None):
             self.canvas.delete("all")
 
+    def _prompt_save_before_load_v1(self):
+        return messagebox.askyesnocancel(
+            "Load Model", "Save current project before loading?"
+        )
+
+    def _prompt_save_before_load_v2(self):
+        return messagebox.askyesnocancel(
+            "Load Model", "Would you like to save before loading a new project?"
+        )
+
+    def _prompt_save_before_load_v3(self):
+        message = "You have unsaved changes. Save before loading a project?"
+        return messagebox.askyesnocancel("Load Model", message)
+
+    def _prompt_save_before_load_v4(self):
+        opts = {
+            "title": "Load Model",
+            "message": "Save changes before loading another project?",
+        }
+        return messagebox.askyesnocancel(**opts)
+
+    def _prompt_save_before_load(self):
+        return self._prompt_save_before_load_v3()
+
     def load_model(self):
         import json
 
+        if getattr(self, "has_unsaved_changes", lambda: False)():
+            resp = self._prompt_save_before_load()
+            if resp is None:
+                return
+            if resp:
+                self.save_model()
         path = filedialog.askopenfilename(
             defaultextension=".autml",
             filetypes=[("AutoML Project", "*.autml"), ("JSON", "*.json")],

--- a/tests/test_load_model_cleanup.py
+++ b/tests/test_load_model_cleanup.py
@@ -68,6 +68,7 @@ def test_load_model_invokes_reset(tmp_path, monkeypatch):
     app.apply_model_data = MagicMock()
     app.set_last_saved_state = MagicMock()
     app._reset_on_load = MagicMock()
+    app.has_unsaved_changes = lambda: False
 
     monkeypatch.setattr(AutoML.filedialog, "askopenfilename", lambda **k: str(model))
     monkeypatch.setattr(AutoML.messagebox, "showerror", lambda *a, **k: None)

--- a/tests/test_load_model_save_prompt.py
+++ b/tests/test_load_model_save_prompt.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+# Stub PIL modules for AutoML import
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+import AutoML
+
+
+def test_load_model_cancel(monkeypatch):
+    app = AutoMLApp.__new__(AutoMLApp)
+    app._loaded_model_paths = []
+    app._reset_on_load = MagicMock()
+    app.apply_model_data = MagicMock()
+    app.set_last_saved_state = MagicMock()
+    monkeypatch.setattr(app, "has_unsaved_changes", lambda: True)
+    askopen = MagicMock()
+    monkeypatch.setattr(AutoML.filedialog, "askopenfilename", askopen)
+    app._prompt_save_before_load = lambda: None
+    app.load_model()
+    askopen.assert_not_called()
+    app._reset_on_load.assert_not_called()
+
+
+def test_load_model_no_save(monkeypatch, tmp_path):
+    model = tmp_path / "model.json"
+    model.write_text("{}")
+    app = AutoMLApp.__new__(AutoMLApp)
+    app._loaded_model_paths = []
+    app._reset_on_load = MagicMock()
+    app.apply_model_data = MagicMock()
+    app.set_last_saved_state = MagicMock()
+    app.save_model = MagicMock()
+    monkeypatch.setattr(app, "has_unsaved_changes", lambda: True)
+    monkeypatch.setattr(AutoML.filedialog, "askopenfilename", lambda **k: str(model))
+    app._prompt_save_before_load = lambda: False
+    app.load_model()
+    app.save_model.assert_not_called()
+    app._reset_on_load.assert_called_once()


### PR DESCRIPTION
## Summary
- prompt to save or discard changes before loading a model
- cover save prompt workflow in tests

## Testing
- `pytest -q`
- `pip install radon -q` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a756fba9ac8327b78b122a2218ccd6