### PR TITLE
Enhance PDF report diagram configuration

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8482,6 +8482,21 @@ class AutoMLApp:
 
         story = [Paragraph(report_title, styles["Title"]), Spacer(1, 12)]
 
+        def _element_diagram(name: str, diag_type: str | None = None, analysis: str | None = None):
+            img = Image.new("RGB", (400, 200), "white")
+            draw = ImageDraw.Draw(img)
+            draw.rectangle([0, 0, 399, 199], outline="black")
+            label = f"{diag_type or 'Diagram'}: {name}"
+            draw.text((10, 10), label, fill="black")
+            buf = BytesIO()
+            img.save(buf, format="PNG")
+            buf.seek(0)
+            items = [Paragraph(label, pdf_styles["Heading3"]), RLImage(buf)]
+            if analysis:
+                items.append(Paragraph(f"Analysis: {analysis}", pdf_styles["Normal"]))
+            items.append(Spacer(1, 12))
+            return items
+
         def _element_base_matrix():
             header_style = ParagraphStyle(
                 name="SafetyGoalsHeader",
@@ -9252,16 +9267,16 @@ class AutoMLApp:
                 items.append(Spacer(1, 12))
             return items
 
-        def _build_element(name: str, kind: str | None):
+        def _build_element(name: str, definition):
+            kind = definition
+            diag_type = None
+            analysis = None
+            if isinstance(definition, dict):
+                kind = definition.get("kind")
+                diag_type = definition.get("diagram_type")
+                analysis = definition.get("analysis")
             if kind == "diagram":
-                img = Image.new("RGB", (400, 200), "white")
-                draw = ImageDraw.Draw(img)
-                draw.rectangle([0, 0, 399, 199], outline="black")
-                draw.text((10, 10), name, fill="black")
-                buf = BytesIO()
-                img.save(buf, format="PNG")
-                buf.seek(0)
-                return [RLImage(buf)]
+                return _element_diagram(name, diag_type, analysis)
             if kind == "base_matrix":
                 return _element_base_matrix()
             if kind == "discretization":

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -231,8 +231,27 @@ def validate_report_template(data: Any) -> dict[str, Any]:
     if not isinstance(elements, dict):
         raise ValueError("'elements' must be an object")
     for name, kind in elements.items():
-        if not isinstance(name, str) or not isinstance(kind, str):
-            raise ValueError("elements must map names to string types")
+        if not isinstance(name, str):
+            raise ValueError("elements keys must be strings")
+        if isinstance(kind, str):
+            continue
+        if isinstance(kind, dict):
+            k = kind.get("kind")
+            if not isinstance(k, str):
+                raise ValueError(f"element '{name}' missing string 'kind'")
+            if k == "diagram":
+                if "diagram_type" in kind and not isinstance(kind["diagram_type"], str):
+                    raise ValueError(
+                        f"element '{name}' diagram_type must be string"
+                    )
+                if "analysis" in kind and not isinstance(kind["analysis"], str):
+                    raise ValueError(
+                        f"element '{name}' analysis must be string"
+                    )
+            continue
+        raise ValueError(
+            "elements must map names to string types or dictionaries"
+        )
 
     sections = data.get("sections", [])
     if not isinstance(sections, list):

--- a/tests/test_report_template_toolbox.py
+++ b/tests/test_report_template_toolbox.py
@@ -104,6 +104,16 @@ def test_validate_report_template_allows_sysml_diagrams():
     }
     assert validate_report_template(cfg) == cfg
 
+
+def test_validate_report_template_diagram_with_analysis():
+    cfg = {
+        "elements": {
+            "d1": {"kind": "diagram", "diagram_type": "block", "analysis": "FMEA"}
+        },
+        "sections": [{"title": "Intro", "content": "<d1>"}],
+    }
+    assert validate_report_template(cfg) == cfg
+
 def test_layout_report_template_basic():
     data = {
         "elements": {"img": "diagram"},


### PR DESCRIPTION
## Summary
- allow report templates to describe diagrams with type and safety analysis metadata
- render diagram elements with headings and optional analysis details
- validate new diagram structure and test template handling

## Testing
- `pytest` *(fails: tests/test_governance_undo.py::test_governance_diagram_undo_redo_work_product, tests/test_project_load_undo.py::test_undo_after_project_load_keeps_project)*
- `python tools/metrics_generator.py --path . --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a774c5140c8327982be2e78d04c166