### PR TITLE
Ensure table and list selections move focus

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -124,6 +124,39 @@ class HoverListbox(tk.Listbox):
 
 tk.Listbox = HoverListbox  # type: ignore[assignment]
 
+# ---------------------------------------------------------------------------
+# Ensure listbox selection moves focus to the newly selected item
+# ---------------------------------------------------------------------------
+_orig_listbox_selection_set = tk.Listbox.selection_set
+
+
+def _listbox_selection_set_v1(self, first, last=None):
+    _orig_listbox_selection_set(self, first, last)
+
+
+def _listbox_selection_set_v2(self, first, last=None):
+    self.selection_clear(0, tk.END)
+    _orig_listbox_selection_set(self, first, last)
+
+
+def _listbox_selection_set_v3(self, first, last=None):
+    self.selection_clear(0, tk.END)
+    _orig_listbox_selection_set(self, first, last)
+    self.activate(first)
+
+
+def _listbox_selection_set_v4(self, first, last=None):
+    self.selection_clear(0, tk.END)
+    _orig_listbox_selection_set(self, first, last)
+    self.activate(first)
+    try:
+        self.focus_set()
+    except Exception:  # pragma: no cover - widget may not support focus_set
+        pass
+
+
+tk.Listbox.selection_set = _listbox_selection_set_v4
+
 
 def format_name_with_phase(name: str, phase: str | None) -> str:
     """Return ``name`` with ``" (phase)"`` appended when ``phase")" is set."""
@@ -202,3 +235,33 @@ def _sortable_heading(self, column, option=None, **kw):
 
 
 ttk.Treeview.heading = _sortable_heading
+
+# ---------------------------------------------------------------------------
+# Ensure Treeview selection moves focus to the newly selected item
+# ---------------------------------------------------------------------------
+_orig_treeview_selection_set = ttk.Treeview.selection_set
+
+
+def _treeview_selection_set_v1(self, *items):
+    _orig_treeview_selection_set(self, *items)
+
+
+def _treeview_selection_set_v2(self, *items):
+    _orig_treeview_selection_set(self, *items)
+    if items:
+        self.focus(items[0])
+
+
+def _treeview_selection_set_v3(self, *items):
+    _orig_treeview_selection_set(self, *items)
+    if items:
+        self.focus(items[-1])
+
+
+def _treeview_selection_set_v4(self, *items):
+    _orig_treeview_selection_set(self, *items)
+    if items:
+        self.focus(items[0])
+
+
+ttk.Treeview.selection_set = _treeview_selection_set_v4

--- a/tests/test_focus_cleanup.py
+++ b/tests/test_focus_cleanup.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import gui
+from gui import _listbox_selection_set_v4, _treeview_selection_set_v4
+
+
+class DummyListbox:
+    def __init__(self):
+        self.cleared = False
+        self.selected = []
+        self.active = None
+        self.focused = False
+
+    def selection_clear(self, start, end):
+        self.cleared = True
+
+    def selection_set(self, first, last=None):
+        self.selected.append(first)
+
+    def activate(self, index):
+        self.active = index
+
+    def focus_set(self):
+        self.focused = True
+
+
+class DummyTreeview:
+    def __init__(self):
+        self.selected = []
+        self.focus_item = None
+
+    def selection_set(self, *items):
+        self.selected.extend(items)
+
+    def focus(self, item=None):
+        if item is None:
+            return self.focus_item
+        self.focus_item = item
+
+
+def test_listbox_focus_updates():
+    lb = DummyListbox()
+    gui._orig_listbox_selection_set = DummyListbox.selection_set
+    _listbox_selection_set_v4(lb, 0)
+    _listbox_selection_set_v4(lb, 1)
+    assert lb.active == 1
+    assert lb.focused
+    assert lb.selected == [0, 1]
+    assert lb.cleared
+
+
+def test_treeview_focus_updates():
+    tv = DummyTreeview()
+    gui._orig_treeview_selection_set = DummyTreeview.selection_set
+    _treeview_selection_set_v4(tv, 'i1')
+    _treeview_selection_set_v4(tv, 'i2')
+    assert tv.focus() == 'i2'


### PR DESCRIPTION
## Summary
- ensure Listbox selection clears previous focus and focuses the new item
- make Treeview selection update focus to the first selected entry
- add unit tests covering Listbox and Treeview focus behavior

## Testing
- `pytest tests/test_focus_cleanup.py -q`
- `pytest -q`
- `radon cc -s -j gui/__init__.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a77e85b68c8327b93b3977e407d1d8