### PR TITLE
Fix paste without target node in AutoML GUI

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -18975,7 +18975,7 @@ class AutoMLApp:
                 if tags:
                     target = self.find_node_by_id(self.root_node, int(tags[0]))
             if not target:
-                target = self.selected_node
+                target = self.selected_node or self.root_node
             if not target:
                 messagebox.showwarning("Paste", "Select a target node to paste into.")
                 return


### PR DESCRIPTION
## Summary
- Default paste target to root node when no selection is made, avoiding warning dialog

## Testing
- `pytest`
- `radon cc AutoML.py -j`


------
https://chatgpt.com/codex/tasks/task_b_68a847fc5dd48327b060275487ffbb3f