### PR TITLE
Fix module lookup for cloned GSN nodes

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -220,10 +220,22 @@ class GSNDiagram:
 
     # ------------------------------------------------------------------
     def _find_module_name_strategy1(self, node: GSNNode) -> str:
-        for parent in getattr(getattr(node, "original", node), "parents", []):
-            if getattr(parent, "node_type", "") == "Module":
-                return getattr(parent, "user_name", "")
-        return ""
+        app = getattr(self, "app", None)
+        if not app:
+            return ""
+        target = getattr(node, "original", node)
+
+        def _search(modules):
+            for mod in modules:
+                for diag in getattr(mod, "diagrams", []):
+                    if target in getattr(diag, "nodes", []):
+                        return getattr(mod, "name", "")
+                result = _search(getattr(mod, "modules", []))
+                if result:
+                    return result
+            return ""
+
+        return _search(getattr(app, "gsn_modules", []))
 
     def _find_module_name_strategy2(self, node: GSNNode) -> str:
         for parent in getattr(node, "parents", []):
@@ -232,6 +244,12 @@ class GSNDiagram:
         return ""
 
     def _find_module_name_strategy3(self, node: GSNNode) -> str:
+        for parent in getattr(getattr(node, "original", node), "parents", []):
+            if getattr(parent, "node_type", "") == "Module":
+                return getattr(parent, "user_name", "")
+        return ""
+
+    def _find_module_name_strategy4(self, node: GSNNode) -> str:
         parents = []
         if getattr(node, "original", None):
             parents.extend(getattr(node.original, "parents", []))
@@ -240,16 +258,6 @@ class GSNDiagram:
             if getattr(parent, "node_type", "") == "Module":
                 return getattr(parent, "user_name", "")
         return ""
-
-    def _find_module_name_strategy4(self, node: GSNNode) -> str:
-        try:
-            return next(
-                p.user_name
-                for p in getattr(getattr(node, "original", node), "parents", [])
-                if getattr(p, "node_type", "") == "Module"
-            )
-        except StopIteration:
-            return ""
 
     def _find_module_name(self, node: GSNNode) -> str:
         for strat in (


### PR DESCRIPTION
## Summary
- ensure cloned GSN nodes resolve module names from the application's module tree
- cover module-name lookup with an additional test

## Testing
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'get_next_unique_id', etc.)*
- `pytest tests/test_gsn_away_shapes.py::test_clone_module_name_follows_module_container -q`
- `radon cc gsn/diagram.py -j | head -c 1000`


------
https://chatgpt.com/codex/tasks/task_b_68a8c2b743888327949dd3108b9312d7