### PR TITLE
Fix governance diagram copy/cut/paste

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -9525,6 +9525,9 @@ class SysMLDiagramWindow(tk.Frame):
     def copy_selected(self, _event=None):
         if self.selected_obj and self.app:
             self.app.active_arch_window = self
+            self.app.selected_node = None
+            self.app.clipboard_node = None
+            self.app.cut_mode = False
             diag = self.repo.diagrams.get(self.diagram_id)
             if self.selected_obj.obj_type == "System Boundary":
                 children = [
@@ -9552,6 +9555,9 @@ class SysMLDiagramWindow(tk.Frame):
             return
         if self.selected_obj and self.app:
             self.app.active_arch_window = self
+            self.app.selected_node = None
+            self.app.clipboard_node = None
+            self.app.cut_mode = True
             diag = self.repo.diagrams.get(self.diagram_id)
             if self.selected_obj.obj_type == "System Boundary":
                 children = [

--- a/tests/test_cross_diagram_clipboard.py
+++ b/tests/test_cross_diagram_clipboard.py
@@ -310,6 +310,61 @@ def test_cut_paste_between_governance_diagrams():
     assert win2.objects[0].obj_type == "Plan"
 
 
+def test_copy_paste_governance_replaces_node_clipboard():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    # Simulate leftover clipboard node from a different analysis
+    app.clipboard_node = types.SimpleNamespace(
+        unique_id="n1",
+        parents=[],
+        children=[],
+        node_type="Goal",
+        x=0,
+        y=0,
+        display_label="dummy",
+        is_primary_instance=True,
+    )
+    app.selected_node = app.clipboard_node
+    app.root_node = object()
+    app.cut_mode = False
+    repo = DummyRepo("Governance Diagram", "Governance Diagram")
+
+    obj = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.objects = [obj]
+    win1.selected_obj = obj
+
+    win2 = make_window(app, repo, 2)
+
+    win1._on_focus_in()
+    # Directly invoke window copy to mimic context menu usage
+    win1.copy_selected()
+    assert app.diagram_clipboard is not None
+    assert app.clipboard_node is None
+
+    win2._on_focus_in()
+    app.paste_node()
+
+    assert len(win2.objects) == 1
+    assert win2.objects[0].obj_type == "Plan"
+
+
 def test_copy_paste_process_area_between_diagrams():
     ARCH_WINDOWS.clear()
     app = AutoMLApp.__new__(AutoMLApp)


### PR DESCRIPTION
## Summary
- reset global node clipboard when copying or cutting governance diagram elements
- add regression test for governance copy/paste replacing existing node clipboard

## Testing
- `pytest tests/test_cross_diagram_clipboard.py::test_copy_paste_governance_replaces_node_clipboard -q`
- `radon cc -j gui/architecture.py | jq '."gui/architecture.py" | .[] | {name, complexity}' | head -n 20`
- `pytest -q` *(fails: AutoML_Helper and other attributes missing)*

------
https://chatgpt.com/codex/tasks/task_b_68a9104bc01c83279fe122d0b69e63fc