### PR TITLE
Ensure SysML diagrams refresh after property edits

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5590,7 +5590,7 @@ class SysMLDiagramWindow(tk.Frame):
                 return
             SysMLObjectDialog(self, obj)
             self._sync_to_repository()
-            self.redraw()
+            self.refresh_from_repository()
             if getattr(self, "app", None):
                 self.app.update_views()
 
@@ -5708,7 +5708,7 @@ class SysMLDiagramWindow(tk.Frame):
     def _edit_object(self, obj):
         SysMLObjectDialog(self, obj)
         self._sync_to_repository()
-        self.redraw()
+        self.refresh_from_repository()
         if self.app:
             self.app.update_views()
         self.update_property_view()

--- a/tests/test_diagram_edit_refresh.py
+++ b/tests/test_diagram_edit_refresh.py
@@ -1,0 +1,36 @@
+import types
+from dataclasses import asdict
+
+from sysml.sysml_repository import SysMLRepository
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+
+
+def test_edit_object_refreshes_diagram(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Internal Block Diagram", name="Diag")
+    obj = SysMLObject(1, "Block", 0.0, 0.0)
+    diag.objects.append(asdict(obj))
+
+    win = object.__new__(SysMLDiagramWindow)
+    win.app = types.SimpleNamespace(update_views=lambda: None)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = [obj]
+    win.connections = []
+    win.update_property_view = lambda: None
+    win.redraw = lambda: None
+
+    called = {"refresh": False}
+
+    def fake_refresh(self, event=None):
+        called["refresh"] = True
+
+    win.refresh_from_repository = types.MethodType(fake_refresh, win)
+    win._sync_to_repository = lambda: None
+
+    monkeypatch.setattr("gui.architecture.SysMLObjectDialog", lambda *args, **kwargs: None)
+
+    SysMLDiagramWindow._edit_object(win, obj)
+
+    assert called["refresh"]


### PR DESCRIPTION
## Summary
- refresh diagrams from repository after editing object properties so nodes remain visible
- add regression test for diagram refresh on object edit

## Testing
- `PYTHONPATH=$PWD pytest tests/test_diagram_edit_refresh.py -q`
- `radon cc -j gui/architecture.py`
- `PYTHONPATH=$PWD pytest -q` *(fails: 37 failed, 1067 passed, 50 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68a9147279c48327a5b67df11b956413