### PR TITLE
feat: add memory management unit

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 from pathlib import Path
 from tools.crash_report_logger import install_best
+from tools.memory_manager import manager as memory_manager
 
 # Hint PyInstaller to bundle AutoML and its dependencies (e.g. gui package)
 if False:  # pragma: no cover
@@ -114,7 +115,10 @@ def ensure_packages() -> None:
         try:
             importlib.import_module(pkg)
         except ImportError:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+            proc = subprocess.Popen([sys.executable, "-m", "pip", "install", pkg])
+            memory_manager.register_process(pkg, proc)
+            proc.wait()
+    memory_manager.cleanup()
 
 def main() -> None:
     """Entry point used by both source and bundled executions."""
@@ -126,6 +130,7 @@ def main() -> None:
         sys.path.insert(0, str(base_path))
     automl = importlib.import_module("AutoML")
     automl.main()
+    memory_manager.cleanup()
 
 if __name__ == "__main__":
     main()

--- a/tools/memory_manager.py
+++ b/tools/memory_manager.py
@@ -1,0 +1,89 @@
+"""Simple memory management utilities for lazy loading and process cleanup.
+
+The :class:`MemoryManager` centralizes lazy loading of modules or data and
+tracks subprocesses so idle ones can be terminated.  It provides a minimal
+framework for the tool to only keep resources required for the currently
+visible data.
+"""
+from __future__ import annotations
+
+import gc
+import importlib
+from typing import Any, Callable, Dict, Set
+
+try:  # pragma: no cover - optional dependency
+    import psutil
+except Exception:  # pragma: no cover - psutil may not be installed
+    psutil = None
+
+
+class MemoryManager:
+    """Manage cached objects and subprocesses.
+
+    Objects are loaded on demand via :meth:`lazy_load`.  Keys can be marked as
+    active with :meth:`mark_active`; any remaining cached objects and processes
+    are discarded by :meth:`cleanup`.
+    """
+
+    def __init__(self) -> None:
+        self._cache: Dict[str, Any] = {}
+        self._active: Set[str] = set()
+        self._procs: Dict[str, Any] = {}
+
+    def lazy_load(self, key: str, loader: Callable[[], Any]) -> Any:
+        """Return cached object for *key*, loading it if necessary."""
+        if key not in self._cache:
+            self._cache[key] = loader()
+        self._active.add(key)
+        return self._cache[key]
+
+    def mark_active(self, key: str) -> None:
+        """Mark *key* as currently needed."""
+        self._active.add(key)
+
+    def register_process(self, key: str, proc: Any) -> None:
+        """Register a subprocess keyed by *key* for later cleanup."""
+        if psutil is not None and not isinstance(proc, psutil.Process):
+            proc = psutil.Process(proc.pid)
+        self._procs[key] = proc
+        self._active.add(key)
+
+    def cleanup(self) -> None:
+        """Drop inactive cached objects and terminate unused processes."""
+        inactive = set(self._cache) - self._active
+        for key in inactive:
+            obj = self._cache.pop(key, None)
+            if obj is not None:
+                del obj
+        if inactive:
+            gc.collect()
+
+        for key, proc in list(self._procs.items()):
+            if key not in self._active:
+                try:
+                    if psutil is not None:
+                        if proc.is_running():
+                            proc.terminate()
+                            proc.wait(timeout=1)
+                    else:
+                        proc.terminate()
+                        proc.wait(1)
+                except Exception:
+                    pass
+                finally:
+                    self._procs.pop(key, None)
+        self._active.clear()
+
+
+def lazy_import(name: str) -> Any:
+    """Return a proxy module lazily imported on first attribute access."""
+
+    class _LazyModule:
+        def __getattr__(self, item: str) -> Any:  # pragma: no cover - proxy
+            module = manager.lazy_load(name, lambda: importlib.import_module(name))
+            return getattr(module, item)
+
+    return _LazyModule()
+
+
+manager = MemoryManager()

--- a/tools/metrics_generator.py
+++ b/tools/metrics_generator.py
@@ -21,8 +21,10 @@ import sys
 from typing import Dict, Iterable, List
 from dataclasses import dataclass
 
-# Ensure repository root is importable for local matplotlib stub
+# Ensure repository root is importable for local packages
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.memory_manager import lazy_import, manager as memory_manager
 
 
 def _sloc(lines: Iterable[str]) -> int:
@@ -122,7 +124,7 @@ def collect_metrics(root: Path) -> Dict[str, object]:
 def generate_plots(metrics: Dict[str, object], out_dir: Path) -> None:
     """Create simple visualisations of LOC and complexity metrics."""
     try:
-        import matplotlib.pyplot as plt
+        plt = lazy_import("matplotlib.pyplot")
     except Exception as exc:  # pragma: no cover - fallback if matplotlib missing
         print(f"Plotting skipped: {exc}")
         return
@@ -149,6 +151,8 @@ def generate_plots(metrics: Dict[str, object], out_dir: Path) -> None:
         plt.tight_layout()
         plt.savefig(out_dir / "metrics_complexity.png")
         plt.close()
+
+    memory_manager.cleanup()
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)


### PR DESCRIPTION
## Summary
- introduce lightweight memory manager for lazy module loading and subprocess cleanup
- integrate memory management into launcher and metrics generator

## Testing
- `radon cc tools/memory_manager.py tools/metrics_generator.py launcher.py -s -j | jq '.' > /tmp/radon.json`
- `python tools/metrics_generator.py --path tools --output /tmp/metrics.json`
- `pytest` *(fails: KeyError in drag clone tests and others)*

------
https://chatgpt.com/codex/tasks/task_b_68a9a5d27c7c83279f2df518a995ab19