### PR TITLE
Ensure toolbox updates after governance diagram creation

### DIFF
--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -124,6 +124,16 @@ class SafetyManagementExplorer(tk.Frame):
         self.populate()
 
     # ------------------------------------------------------------------
+    def _refresh_diagram_list(self) -> None:
+        """Update diagram dropdowns in the toolbox window, if present."""
+        smw = getattr(getattr(self, "app", None), "safety_mgmt_window", None)
+        if smw and hasattr(smw, "refresh_diagrams"):
+            try:
+                smw.refresh_diagrams()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
     def new_folder(self):
         name = simpledialog.askstring("New Folder", "Name:", parent=self)
         if not name:
@@ -162,6 +172,7 @@ class SafetyManagementExplorer(tk.Frame):
         if typ == "module" and obj is not None:
             obj.diagrams.append(actual)
         self.populate()
+        self._refresh_diagram_list()
 
     # ------------------------------------------------------------------
     def rename_item(self):
@@ -187,6 +198,7 @@ class SafetyManagementExplorer(tk.Frame):
         else:
             return
         self.populate()
+        self._refresh_diagram_list()
 
     # ------------------------------------------------------------------
     def delete_item(self):
@@ -208,6 +220,7 @@ class SafetyManagementExplorer(tk.Frame):
             else:
                 self.toolbox.modules.remove(obj)
         self.populate()
+        self._refresh_diagram_list()
 
     # ------------------------------------------------------------------
     def open_item(self):

--- a/tests/test_governance_explorer_refresh.py
+++ b/tests/test_governance_explorer_refresh.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+import types
+from tkinter import simpledialog
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sysml.sysml_repository import SysMLRepository
+from analysis.safety_management import SafetyManagementToolbox
+from gui.safety_management_explorer import SafetyManagementExplorer
+
+
+def test_new_diagram_refreshes_toolbox(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+
+    refreshed = {"called": False}
+    def refresh_diagrams():
+        refreshed["called"] = True
+
+    app = types.SimpleNamespace(
+        safety_mgmt_window=types.SimpleNamespace(refresh_diagrams=refresh_diagrams)
+    )
+
+    explorer = SafetyManagementExplorer.__new__(SafetyManagementExplorer)
+    explorer.app = app
+    explorer.toolbox = toolbox
+    explorer.tree = types.SimpleNamespace(selection=lambda: ["root"])
+    explorer.item_map = {"root": ("root", None)}
+    explorer.populate = lambda: None
+
+    monkeypatch.setattr(simpledialog, "askstring", lambda *a, **k: "Gov1")
+
+    explorer.new_diagram()
+
+    assert refreshed["called"], "toolbox not refreshed"
+    assert "Gov1" in toolbox.list_diagrams()


### PR DESCRIPTION
## Summary
- Refresh Safety Management toolbox list when diagrams are created, renamed, or deleted
- Test that new governance diagrams trigger a toolbox refresh

## Testing
- `radon cc -s -j gui/safety_management_explorer.py`
- `pytest tests/test_governance_explorer_refresh.py -q`
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'update_unique_id_counter_for_top_events', among others)*

------
https://chatgpt.com/codex/tasks/task_b_68a9a8849b6c8327b74f2bf62cf7f982