### PR TITLE
Handle global governance phases and diagram reassignment

### DIFF
--- a/tests/test_global_phase_persistence.py
+++ b/tests/test_global_phase_persistence.py
@@ -1,0 +1,30 @@
+from sysml.sysml_repository import SysMLRepository, GLOBAL_PHASE
+
+
+def test_global_phase_assigned_to_new_items():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    repo.active_phase = GLOBAL_PHASE
+    elem = repo.create_element("Block", name="E")
+    diag = repo.create_diagram("Block Diagram", name="D")
+    rel = repo.create_relationship("Association", elem.elem_id, elem.elem_id)
+    assert elem.phase == GLOBAL_PHASE
+    assert diag.phase == GLOBAL_PHASE
+    assert rel.phase == GLOBAL_PHASE
+
+
+def test_set_diagram_phase_propagates_to_contents():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    repo.active_phase = GLOBAL_PHASE
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    elem = repo.create_element("Action", name="A")
+    repo.add_element_to_diagram(diag.diag_id, elem.elem_id)
+    obj = {"id": 1, "element_id": elem.elem_id}
+    diag.objects.append(obj)
+    repo.set_diagram_phase(diag.diag_id, "P1")
+    assert diag.phase == "P1"
+    assert repo.elements[elem.elem_id].phase == "P1"
+    assert diag.objects[0]["phase"] == "P1"
+    repo.active_phase = "P1"
+    assert repo.object_visible(diag.objects[0], diag.diag_id)


### PR DESCRIPTION
## Summary
- Preserve active phase (including GLOBAL) on new elements, diagrams and relationships.
- Add repository helper to reassign a diagram to a new phase and update contained items.
- Ensure global objects and diagrams remain visible across phases.
- Cover global phase behaviour with regression tests.

## Testing
- `pytest` *(fails: ImportError: libGL.so.1)*
- `radon cc -j sysml/sysml_repository.py`

------
https://chatgpt.com/codex/tasks/task_b_68a9a58229a0832799ea101c123bcc2b