### PR TITLE
fix: ensure launcher loads project AutoML module

### DIFF
--- a/AutoML_Launcher.py
+++ b/AutoML_Launcher.py
@@ -126,8 +126,13 @@ def main() -> None:
     ensure_packages()
     ensure_ghostscript()
     base_path = Path(getattr(sys, "_MEIPASS", Path(__file__).parent))
-    if str(base_path) not in sys.path:
-        sys.path.insert(0, str(base_path))
+    # Insert both the launcher directory and the 'main' module location to ensure
+    # the project-specific AutoML module is discovered rather than any similarly
+    # named third-party package that may be installed in the environment.
+    main_path = base_path / "main"
+    for path in (str(main_path), str(base_path)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
     automl = importlib.import_module("AutoML")
     automl.main()
     memory_manager.cleanup()


### PR DESCRIPTION
## Summary
- fix launcher to import AutoML from project by adding main path to sys.path

## Testing
- `radon cc AutoML_Launcher.py -s -j`
- `PYTHONPATH=main pytest tests/test_user_dialog_buttons.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a9ae67136c832792f676117e8ea202