### PR TITLE
feat: auto-generate scenario descriptions

### DIFF
--- a/analysis/scenario_description.py
+++ b/analysis/scenario_description.py
@@ -1,0 +1,52 @@
+"""Utilities for generating scenario descriptions from parameters."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+
+def _phrase_trigger(
+    oru: str, action: str, odds: str, tc: str, fi: str
+) -> str:
+    parts: List[str] = []
+    if tc:
+        parts.append(f"When {tc}")
+    if oru or action:
+        oa = " ".join(p for p in [oru, action] if p).strip()
+        parts.append(oa if parts else oa.capitalize())
+    if odds:
+        parts.append(f"in {odds}")
+    if fi:
+        parts.append(f"leading to {fi}")
+    return " ".join(parts) + "." if parts else ""
+
+
+def _phrase_insufficiency(
+    oru: str, action: str, odds: str, tc: str, fi: str
+) -> str:
+    parts: List[str] = []
+    if fi:
+        parts.append(fi.capitalize())
+    if oru or action:
+        oa = " ".join(p for p in [oru, action] if p).strip()
+        parts.append(f"occurs as {oa}" if parts else oa.capitalize())
+    if tc:
+        parts.append(f"when {tc}")
+    if odds:
+        parts.append(f"under {odds}")
+    return " ".join(parts) + "." if parts else ""
+
+
+def template_phrases(
+    other_road_users: str,
+    action: str,
+    odd_elements: Iterable[str],
+    triggering_condition: str,
+    functional_insufficiency: str,
+) -> List[str]:
+    """Return two descriptive phrases for a scenario."""
+
+    odds = ", ".join(o for o in odd_elements if o) if odd_elements else ""
+    p1 = _phrase_trigger(other_road_users, action, odds, triggering_condition, functional_insufficiency)
+    p2 = _phrase_insufficiency(other_road_users, action, odds, triggering_condition, functional_insufficiency)
+    return [p for p in (p1, p2) if p]

--- a/tests/test_scenario_description.py
+++ b/tests/test_scenario_description.py
@@ -1,0 +1,17 @@
+from analysis.scenario_description import template_phrases
+
+
+def test_template_phrases_full():
+    phrases = template_phrases(
+        "driver", "turns left", ["rainy weather", "night"], "sensor failure", "loss of control"
+    )
+    assert len(phrases) == 2
+    assert "driver turns left" in phrases[0]
+    assert "sensor failure" in phrases[0]
+    assert "loss of control" in phrases[0]
+
+
+def test_template_phrases_partial():
+    phrases = template_phrases("", "stops", [], "", "brake loss")
+    assert phrases
+    assert any(p.lower().startswith("brake loss") for p in phrases)


### PR DESCRIPTION
## Summary
- add `template_phrases` utility to build scenario description phrases
- support action of other road users, multiple ODD elements and auto description generation
- test scenario description template logic

## Testing
- `PYTHONPATH=main:. pytest tests/test_scenario_description.py`
- `PYTHONPATH=main:. pytest` *(fails: ImportError: libGL.so.1)*
- `radon cc analysis/scenario_description.py -j`


------
https://chatgpt.com/codex/tasks/task_b_68a9b0ff0a18832798c98c3e4ae57d14