### PR TITLE
Add Prototype Risk Analysis mode

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -39,10 +39,14 @@ ALLOWED_PROPAGATIONS: set[tuple[str, str]] = {
     ("Risk Assessment", "FMEA"),
     ("Risk Assessment", "FMEDA"),
     ("Risk Assessment", "FTA"),
+    ("Risk Assessment", "Prototype Risk Analysis"),
     ("Risk Assessment", "Product Goal Specification"),
     ("FMEA", "FTA"),
     ("FMEDA", "FTA"),
+    ("FMEA", "Prototype Risk Analysis"),
+    ("FMEDA", "Prototype Risk Analysis"),
     ("FTA", "Product Goal Specification"),
+    ("Prototype Risk Analysis", "Product Goal Specification"),
 }
 
 # Valid "Used" relationships between safety analysis work products. These
@@ -72,6 +76,7 @@ SAFETY_ANALYSIS_WORK_PRODUCTS: set[str] = {
     "FMEA",
     "FMEDA",
     "FTA",
+    "Prototype Risk Analysis",
     "Reliability Analysis",
     "Causal Bayesian Network Analysis",
     "Safety & Security Case",
@@ -93,6 +98,7 @@ ALLOWED_USAGE.update(
     {
         ("Mission Profile", "Reliability Analysis"),
         ("Mission Profile", "FTA"),
+        ("Mission Profile", "Prototype Risk Analysis"),
         ("Requirement Specification", "HAZOP"),
         ("ODD", "Scenario Library"),
         ("Scenario Library", "HAZOP"),

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -164,6 +164,7 @@ WORK_PRODUCT_AREA_MAP = {
     "TC2FI": "Hazard & Threat Analysis",
     "Risk Assessment": "Risk Assessment",
     "FTA": "Safety Analysis",
+    "Prototype Risk Analysis": "Safety Analysis",
     "FMEA": "Safety Analysis",
     "FMEDA": "Safety Analysis",
     "Scenario Library": "Scenario",

--- a/main/AutoML.py
+++ b/main/AutoML.py
@@ -2221,6 +2221,11 @@ class AutoMLApp:
             "FMEDA Manager",
             "show_fmeda_list",
         ),
+        "Prototype Risk Analysis": (
+            "Safety Analysis",
+            "Prototype Risk Analysis",
+            "create_pra_diagram",
+        ),
         "FTA": (
             "Safety Analysis",
             "FTA Cut Sets",
@@ -2289,6 +2294,7 @@ class AutoMLApp:
         "FI2TC": "Qualitative Analysis",
         "TC2FI": "Qualitative Analysis",
         "FMEA": "Qualitative Analysis",
+        "Prototype Risk Analysis": "Qualitative Analysis",
         "FMEDA": "Quantitative Analysis",
         "Mission Profile": "Quantitative Analysis",
         "Reliability Analysis": "Quantitative Analysis",
@@ -2853,6 +2859,14 @@ class AutoMLApp:
             label="Fault Prioritization",
             command=self.open_fault_prioritization_window,
         )
+        qualitative_menu.add_command(
+            label="Prototype Risk Analysis",
+            command=self.create_pra_diagram,
+            state=tk.DISABLED,
+        )
+        self.work_product_menus.setdefault("Prototype Risk Analysis", []).append(
+            (qualitative_menu, qualitative_menu.index("end"))
+        )
         # --- Quantitative Analysis Menu ---
         quantitative_menu = tk.Menu(menubar, tearoff=0)
         quantitative_menu.add_command(
@@ -3206,6 +3220,7 @@ class AutoMLApp:
             "Safety Analysis": [
                 "Fault Prioritization",
                 "Cause & Effect Diagram",
+                "Prototype Risk Analysis",
             ],
             "Configuration": [
                 "Diagram Rule Editor",
@@ -4867,6 +4882,7 @@ class AutoMLApp:
         new_event = FaultTreeNode("", "TOP EVENT")
         new_event.x, new_event.y = 300, 200
         new_event.is_top_event = True
+        new_event.analysis_mode = "FTA"
         self.top_events.append(new_event)
         self.root_node = new_event
         # Track creation for lifecycle phase filtering
@@ -10139,7 +10155,12 @@ class AutoMLApp:
             if node:
                 old = node.user_name
                 node.user_name = new
-                self.safety_mgmt_toolbox.rename_document("FTA", old, new)
+                analysis = (
+                    "Prototype Risk Analysis"
+                    if getattr(getattr(self, "canvas", None), "mode", "") == "PRA"
+                    else "FTA"
+                )
+                self.safety_mgmt_toolbox.rename_document(analysis, old, new)
         elif kind == "arch" and repo.diagrams.get(ident):
             repo.diagrams[ident].name = new
         elif kind == "gov":
@@ -10163,7 +10184,12 @@ class AutoMLApp:
             old = node.name
             node.user_name = new
             if hasattr(self, "safety_mgmt_toolbox"):
-                self.safety_mgmt_toolbox.rename_document("FTA", old, node.name)
+                analysis = (
+                    "Prototype Risk Analysis"
+                    if getattr(getattr(self, "canvas", None), "mode", "") == "PRA"
+                    else "FTA"
+                )
+                self.safety_mgmt_toolbox.rename_document(analysis, old, node.name)
         elif kind == "pkg" and repo.elements.get(ident):
             repo.elements[ident].name = new
         self.update_views()
@@ -10419,6 +10445,7 @@ class AutoMLApp:
             "FMEA": "reliability_analyses",
             "FMEDA": "fmeda_components",
             "FTA": "top_events",
+            "Prototype Risk Analysis": "top_events",
             "Architecture Diagram": "arch_diagrams",
             "Scenario Library": "scenario_libraries",
             "ODD": "odd_libraries",
@@ -10745,12 +10772,16 @@ class AutoMLApp:
         menu.add_command(label="Edit Controllability", command=lambda: self.edit_controllability())
         menu.add_command(label="Edit Page Flag", command=lambda: self.edit_page_flag())
         menu.add_separator()
-        menu.add_command(label="Add Confidence", command=lambda: self.add_node_of_type("Confidence Level"))
-        menu.add_command(label="Add Robustness", command=lambda: self.add_node_of_type("Robustness Score"))
-        menu.add_command(label="Add Gate", command=lambda: self.add_node_of_type("GATE"))
-        menu.add_command(label="Add Basic Event", command=lambda: self.add_node_of_type("Basic Event"))
-        menu.add_command(label="Add Triggering Condition", command=lambda: self.add_node_of_type("Triggering Condition"))
-        menu.add_command(label="Add Functional Insufficiency", command=lambda: self.add_node_of_type("Functional Insufficiency"))
+        if getattr(self.canvas, "mode", "") == "PRA":
+            menu.add_command(label="Add Confidence", command=lambda: self.add_node_of_type("Confidence Level"))
+            menu.add_command(label="Add Robustness", command=lambda: self.add_node_of_type("Robustness Score"))
+        else:
+            menu.add_command(label="Add Confidence", command=lambda: self.add_node_of_type("Confidence Level"))
+            menu.add_command(label="Add Robustness", command=lambda: self.add_node_of_type("Robustness Score"))
+            menu.add_command(label="Add Gate", command=lambda: self.add_node_of_type("GATE"))
+            menu.add_command(label="Add Basic Event", command=lambda: self.add_node_of_type("Basic Event"))
+            menu.add_command(label="Add Triggering Condition", command=lambda: self.add_node_of_type("Triggering Condition"))
+            menu.add_command(label="Add Functional Insufficiency", command=lambda: self.add_node_of_type("Functional Insufficiency"))
         menu.tk_popup(event.x_root, event.y_root)
 
     def on_canvas_click(self, event):
@@ -11884,10 +11915,28 @@ class AutoMLApp:
                 nonlocal safety_root
                 if safety_root is None:
                     safety_root = tree.insert("", "end", text="Safety Analysis", open=True)
-            if "FTA" in enabled or getattr(self, "top_events", []):
+
+            pra_events = [
+                te for te in getattr(self, "top_events", [])
+                if getattr(te, "analysis_mode", "FTA") == "PRA"
+            ]
+            fta_events = [
+                te for te in getattr(self, "top_events", [])
+                if getattr(te, "analysis_mode", "FTA") != "PRA"
+            ]
+
+            if "Prototype Risk Analysis" in enabled or pra_events:
+                _ensure_safety_root()
+                pra_root = tree.insert(safety_root, "end", text="PRAs", open=True)
+                for idx, te in enumerate(pra_events):
+                    if not _visible("Prototype Risk Analysis", te.name):
+                        continue
+                    tree.insert(pra_root, "end", text=te.name, tags=("pra", str(te.unique_id)))
+
+            if "FTA" in enabled or fta_events:
                 _ensure_safety_root()
                 fta_root = tree.insert(safety_root, "end", text="FTAs", open=True)
-                for idx, te in enumerate(self.top_events):
+                for idx, te in enumerate(fta_events):
                     if not _visible("FTA", te.name):
                         continue
                     tree.insert(fta_root, "end", text=te.name, tags=("fta", str(te.unique_id)))
@@ -12442,10 +12491,18 @@ class AutoMLApp:
 
     def add_node_of_type(self, event_type):
         self.push_undo_state()
+        if getattr(self.canvas, "mode", "") == "PRA":
+            allowed = {"CONFIDENCE LEVEL", "ROBUSTNESS SCORE"}
+            if event_type.upper() not in allowed:
+                messagebox.showwarning(
+                    "Invalid",
+                    "Only Confidence and Robustness nodes are allowed in Prototype Risk Analysis.",
+                )
+                return
         # If a node is selected, ensure it is a primary instance.
         if self.selected_node:
             if not self.selected_node.is_primary_instance:
-                messagebox.showwarning("Invalid Operation", 
+                messagebox.showwarning("Invalid Operation",
                     "Cannot add new elements to a clone node.\nPlease select the original node instead.")
                 return
             parent_node = self.selected_node
@@ -12691,7 +12748,12 @@ class AutoMLApp:
         self.top_events.append(new_event)
         self.root_node = new_event
         if hasattr(self, "safety_mgmt_toolbox"):
-            self.safety_mgmt_toolbox.register_created_work_product("FTA", new_event.name)
+            analysis = (
+                "Prototype Risk Analysis"
+                if getattr(getattr(self, "canvas", None), "mode", "") == "PRA"
+                else "FTA"
+            )
+            self.safety_mgmt_toolbox.register_created_work_product(analysis, new_event.name)
         self.update_views()
 
     def delete_top_events_for_malfunction(self, name: str) -> None:
@@ -12702,11 +12764,16 @@ class AutoMLApp:
             return
         for te in removed:
             if hasattr(self, "safety_mgmt_toolbox"):
-                self.safety_mgmt_toolbox.register_deleted_work_product("FTA", te.name)
+                analysis = (
+                    "Prototype Risk Analysis"
+                    if getattr(getattr(self, "canvas", None), "mode", "") == "PRA"
+                    else "FTA"
+                )
+                self.safety_mgmt_toolbox.register_deleted_work_product(analysis, te.name)
             self.top_events.remove(te)
             if hasattr(self, "safety_mgmt_toolbox"):
                 self.safety_mgmt_toolbox.register_deleted_work_product(
-                    "FTA", te.user_name
+                    analysis, te.user_name
                 )
         if self.root_node in removed:
             self.root_node = self.top_events[0] if self.top_events else FaultTreeNode("", "TOP EVENT")
@@ -18643,6 +18710,26 @@ class AutoMLApp:
         self.canvas.bind("<Double-1>", self.on_canvas_double_click)
         self.canvas.bind("<Control-MouseWheel>", self.on_ctrl_mousewheel)
 
+    def create_pra_diagram(self):
+        """Initialize a Prototype Risk Analysis diagram."""
+        self._create_fta_tab()
+        if getattr(self, "canvas", None) is not None:
+            self.canvas.mode = "PRA"
+        # Automatically create the top-level event for PRA mode
+        new_event = FaultTreeNode("", "TOP EVENT")
+        new_event.x, new_event.y = 300, 200
+        new_event.is_top_event = True
+        new_event.analysis_mode = "PRA"
+        if not hasattr(self, "top_events"):
+            self.top_events = []
+        self.top_events.append(new_event)
+        self.root_node = new_event
+        if hasattr(self, "safety_mgmt_toolbox"):
+            self.safety_mgmt_toolbox.register_created_work_product(
+                "Prototype Risk Analysis", new_event.user_name
+            )
+        self.update_views()
+
     def _reset_fta_state(self):
         """Clear references to the FTA tab and its canvas."""
         self.canvas_tab = None
@@ -22835,6 +22922,7 @@ class PageDiagram:
         self.app = app
         self.root_node = page_gate_node
         self.canvas = canvas
+        self.mode = getattr(canvas, "mode", "")
         self.zoom = 1.0
         self.diagram_font = tkFont.Font(family="Arial", size=int(8 * self.zoom))
         self.grid_size = 20
@@ -22940,14 +23028,18 @@ class PageDiagram:
         if node.node_type.upper() not in ["TOP EVENT", "BASIC EVENT"]:
             menu.add_command(label="Edit Page Flag", command=lambda: self.context_edit_page_flag(node))
         menu.add_separator()
-        menu.add_command(label="Add Confidence", command=lambda: self.context_add("Confidence Level"))
-        menu.add_command(label="Add Robustness", command=lambda: self.context_add("Robustness Score"))
-        menu.add_command(label="Add Gate", command=lambda: self.context_add("GATE"))
-        menu.add_command(label="Add Basic Event", command=lambda: self.context_add("Basic Event"))
-        menu.add_command(label="Add Triggering Condition", command=lambda: self.context_add("Triggering Condition"))
-        menu.add_command(label="Add Functional Insufficiency", command=lambda: self.context_add("Functional Insufficiency"))
-        menu.add_command(label="Add Gate from Failure Mode", command=lambda: self.context_add_gate_from_failure_mode())
-        menu.add_command(label="Add Fault Event", command=lambda: self.context_add_fault_event())
+        if getattr(self, "mode", "") == "PRA":
+            menu.add_command(label="Add Confidence", command=lambda: self.context_add("Confidence Level"))
+            menu.add_command(label="Add Robustness", command=lambda: self.context_add("Robustness Score"))
+        else:
+            menu.add_command(label="Add Confidence", command=lambda: self.context_add("Confidence Level"))
+            menu.add_command(label="Add Robustness", command=lambda: self.context_add("Robustness Score"))
+            menu.add_command(label="Add Gate", command=lambda: self.context_add("GATE"))
+            menu.add_command(label="Add Basic Event", command=lambda: self.context_add("Basic Event"))
+            menu.add_command(label="Add Triggering Condition", command=lambda: self.context_add("Triggering Condition"))
+            menu.add_command(label="Add Functional Insufficiency", command=lambda: self.context_add("Functional Insufficiency"))
+            menu.add_command(label="Add Gate from Failure Mode", command=lambda: self.context_add_gate_from_failure_mode())
+            menu.add_command(label="Add Fault Event", command=lambda: self.context_add_fault_event())
         menu.tk_popup(event.x_root, event.y_root)
 
     def context_edit(self, node):

--- a/tests/test_governance_group_activation.py
+++ b/tests/test_governance_group_activation.py
@@ -7,7 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
 from sysml.sysml_repository import SysMLRepository
-from AutoML import AutoMLApp
+from main.AutoML import AutoMLApp
 
 
 class DummyListbox:
@@ -46,6 +46,7 @@ class DummyMenu:
         ("Safety & Security Case", "GSN"),
         ("GSN Argumentation", "GSN"),
         ("FMEA", "Qualitative Analysis"),
+        ("Prototype Risk Analysis", "Qualitative Analysis"),
         ("FMEDA", "Quantitative Analysis"),
         ("Causal Bayesian Network Analysis", "Quantitative Analysis"),
         ("Mission Profile", "Quantitative Analysis"),

--- a/tests/test_governance_pra_work_product.py
+++ b/tests/test_governance_pra_work_product.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow
+from analysis import SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_governance_pra_work_product_enabled(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    from analysis import safety_management as _sm
+    prev_tb = _sm.ACTIVE_TOOLBOX
+    toolbox = SafetyManagementToolbox()
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+
+    enabled = []
+    captured = {}
+
+    class DummyApp:
+        safety_mgmt_toolbox = toolbox
+
+        def enable_work_product(self, name, *, refresh=True):
+            enabled.append(name)
+
+    win.app = DummyApp()
+
+    class DummyDialog:
+        def __init__(self, parent, title, options):
+            if title == "Add Process Area":
+                self.selection = "Safety Analysis"
+            else:
+                captured["wp_options"] = options
+                self.selection = "Prototype Risk Analysis"
+
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", DummyDialog)
+    win.add_work_product()
+
+    assert "Prototype Risk Analysis" in captured.get("wp_options", [])
+    assert "Prototype Risk Analysis" in enabled
+    _sm.ACTIVE_TOOLBOX = prev_tb

--- a/tests/test_pra_group_in_analysis_tree.py
+++ b/tests/test_pra_group_in_analysis_tree.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis import SafetyManagementToolbox
+from main.AutoML import AutoMLApp, FaultTreeNode
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_pra_listed_under_safety_analysis(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    toolbox.create_diagram("Gov")
+    repo.create_diagram("Block Definition Diagram", name="Arch")
+
+    class DummyTree:
+        def __init__(self):
+            self.items = {}
+            self.counter = 0
+
+        def delete(self, *items):
+            pass
+
+        def get_children(self, item=""):
+            return [iid for iid, meta in self.items.items() if meta["parent"] == item]
+
+        def insert(self, parent, index, iid=None, text="", **kwargs):
+            if iid is None:
+                iid = f"i{self.counter}"
+                self.counter += 1
+            self.items[iid] = {"parent": parent, "text": text}
+            return iid
+
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.refresh_model = lambda: None
+    app.compute_occurrence_counts = lambda: {}
+    app.diagram_icons = {}
+    app.hazop_docs = []
+    app.stpa_docs = []
+    app.threat_docs = []
+    app.fi2tc_docs = []
+    app.tc2fi_docs = []
+    app.hara_docs = []
+    app.fmeas = []
+    app.fmedas = []
+    app.analysis_tree = DummyTree()
+    app.update_lifecycle_cb = lambda: None
+    app.refresh_tool_enablement = lambda: None
+    app.enabled_work_products = set()
+    app.safety_mgmt_toolbox = toolbox
+    toolbox.document_visible = lambda analysis, name: True
+    toolbox.enabled_products = lambda: {"Prototype Risk Analysis"}
+
+    pra_event = FaultTreeNode("", "TOP EVENT")
+    pra_event.analysis_mode = "PRA"
+    app.top_events = [pra_event]
+
+    app.update_views()
+    names = [meta["text"] for meta in app.analysis_tree.items.values()]
+    assert "PRAs" in names
+    assert pra_event.name in names

--- a/tests/test_pra_top_event_creation.py
+++ b/tests/test_pra_top_event_creation.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main.AutoML import AutoMLApp
+
+
+def test_pra_diagram_has_top_event(monkeypatch):
+    app = AutoMLApp.__new__(AutoMLApp)
+    class DummyCanvas:
+        mode = ""
+    def fake_create_tab():
+        app.canvas = DummyCanvas()
+    app._create_fta_tab = fake_create_tab
+    app.top_events = []
+    app.update_views = lambda: None
+    app.create_pra_diagram()
+    assert app.canvas.mode == "PRA"
+    assert len(app.top_events) == 1
+    assert getattr(app.top_events[0], "is_top_event", False)
+    assert getattr(app.top_events[0], "analysis_mode", "") == "PRA"


### PR DESCRIPTION
## Summary
- group existing Prototype Risk Analyses under a dedicated PRAs section in the Safety Analysis file explorer
- tag top-level events with an analysis mode and ensure PRAs mark their root node accordingly
- verify PRA top events, menu items, and explorer grouping with new unit tests

## Testing
- `pytest tests/test_pra_top_event_creation.py tests/test_pra_group_in_analysis_tree.py tests/test_governance_pra_work_product.py tests/test_governance_group_activation.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'AutoML')*
- `radon cc main/AutoML.py -j | jq | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68a9c964e6f0832795033fe00a88b321