### PR TITLE
Separate CTA menus and governance

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -46,6 +46,7 @@ ALLOWED_PROPAGATIONS: set[tuple[str, str]] = {
     ("FMEA", "Prototype Assurance Analysis"),
     ("FMEDA", "Prototype Assurance Analysis"),
     ("FTA", "Product Goal Specification"),
+    ("FTA", "CTA"),
     ("Prototype Assurance Analysis", "Product Goal Specification"),
 }
 
@@ -76,6 +77,7 @@ SAFETY_ANALYSIS_WORK_PRODUCTS: set[str] = {
     "FMEA",
     "FMEDA",
     "FTA",
+    "CTA",
     "Prototype Assurance Analysis",
     "Reliability Analysis",
     "Causal Bayesian Network Analysis",

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -164,6 +164,7 @@ WORK_PRODUCT_AREA_MAP = {
     "TC2FI": "Hazard & Threat Analysis",
     "Risk Assessment": "Risk Assessment",
     "FTA": "Safety Analysis",
+    "CTA": "Safety Analysis",
     "Prototype Assurance Analysis": "Safety Analysis",
     "FMEA": "Safety Analysis",
     "FMEDA": "Safety Analysis",

--- a/tests/test_governance_cta_work_product.py
+++ b/tests/test_governance_cta_work_product.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow
+from analysis import SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_governance_cta_work_product_enabled(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    from analysis import safety_management as _sm
+    prev_tb = _sm.ACTIVE_TOOLBOX
+    toolbox = SafetyManagementToolbox()
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+
+    enabled = []
+    captured = {}
+
+    class DummyApp:
+        safety_mgmt_toolbox = toolbox
+
+        def enable_work_product(self, name, *, refresh=True):
+            enabled.append(name)
+
+    win.app = DummyApp()
+
+    class DummyDialog:
+        def __init__(self, parent, title, options):
+            if title == "Add Process Area":
+                self.selection = "Safety Analysis"
+            else:
+                captured["wp_options"] = options
+                self.selection = "CTA"
+
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", DummyDialog)
+    win.add_work_product()
+
+    assert "CTA" in captured.get("wp_options", [])
+    assert "CTA" in enabled
+    _sm.ACTIVE_TOOLBOX = prev_tb


### PR DESCRIPTION
## Summary
- ensure CTA work products belong to the Safety Analysis process area for governance
- cover CTA enablement via governance diagrams with a dedicated test

## Testing
- `radon cc -s -j main/AutoML.py analysis/safety_management.py gui/architecture.py`
- `PYTHONPATH=main pytest -q` *(fails: 45 failed, 1072 passed, 50 skipped)*
- `pytest tests/test_governance_cta_work_product.py::test_governance_cta_work_product_enabled -q`

------
https://chatgpt.com/codex/tasks/task_b_68a9d5b3f1008327b8c88e51b683d06b