### PR TITLE
Add package initializer to mainappsrc

### DIFF
--- a/mainappsrc/__init__.py
+++ b/mainappsrc/__init__.py
@@ -1,0 +1,5 @@
+"""Main application package initializer."""
+
+from .AutoML import AutoMLApp
+
+__all__ = ["AutoMLApp"]


### PR DESCRIPTION
## Summary
- add `__init__.py` to `mainappsrc` exposing `AutoMLApp`

## Testing
- `pytest` (fails: ModuleNotFoundError: AutoML)
- `radon cc mainappsrc -j`


------
https://chatgpt.com/codex/tasks/task_b_68aa508c5ff88327ade70a410572ca43