### PR TITLE
Avoid early circular import in custom messagebox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.15
+version: 0.2.16
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.16 - Import PurpleButton lazily in custom messagebox to avoid early circular imports.
 - 0.2.15 - Lazily import messagebox module to resolve circular import.
 - 0.2.14 - Fade out splash screen symmetrically before launching application.
 - 0.2.13 - Delegate tab motion events to lifecycle UI to prevent missing handler error.

--- a/gui/controls/messagebox.py
+++ b/gui/controls/messagebox.py
@@ -11,7 +11,7 @@ from tkinter import TclError
 import tkinter as tk
 from tkinter import ttk
 
-from .. import logger, DIALOG_BG_COLOR, PurpleButton
+from .. import logger, DIALOG_BG_COLOR
 
 
 def _log_and_return(title: str | None, message: str | None, level: str) -> str:
@@ -50,6 +50,8 @@ def _create_dialog(
     buttons: list[tuple[str, object]],
 ) -> object:
     """Create a simple ``ttk`` dialog returning the associated button value."""
+
+    from .. import PurpleButton  # Local import to avoid circular dependency
 
     root = tk._default_root
     temp_root = False


### PR DESCRIPTION
## Summary
- Import PurpleButton lazily inside the custom messagebox to prevent circular imports when the module loads early
- Document new 0.2.16 version in README

## Testing
- `pytest -q` *(fails: cannot import AutoML_Helper and other modules; missing PyQt6)*
- `radon cc -j gui/controls/messagebox.py`


------
https://chatgpt.com/codex/tasks/task_b_68abb33900908327b386bcaa095a5768