### PR TITLE
Add compatibility wrappers for relocated GUI modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.20
+version: 0.2.21
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.21 - Provide compatibility wrappers for relocated GUI modules.
 - 0.2.20 - Re-export logger through gui package to fix DIALOG_BG_COLOR import failure.
 - 0.2.19 - Provide compatibility wrapper for splash screen import.
 - 0.2.18 - Organized GUI modules into functional subpackages and reduced threat window refresh complexity.

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1,0 +1,12 @@
+"""Compatibility wrapper for relocated architecture window module."""
+
+from .windows import architecture as _architecture
+from .windows.architecture import *  # noqa: F401,F403
+
+# Re-export private helpers relied upon by tests
+_get_next_id = _architecture._get_next_id
+_ensure_ibd_boundary = _architecture._ensure_ibd_boundary
+_all_connection_tools = _architecture._all_connection_tools
+_sync_ibd_aggregation_parts = getattr(
+    _architecture, "_sync_ibd_aggregation_parts", None
+)

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated causal Bayesian network window."""
+
+from .windows.causal_bayesian_network_window import *  # noqa: F401,F403

--- a/gui/closable_notebook.py
+++ b/gui/closable_notebook.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated closable notebook utility."""
+
+from .utils.closable_notebook import *  # noqa: F401,F403

--- a/gui/diagram_rules_toolbox.py
+++ b/gui/diagram_rules_toolbox.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated diagram rules toolbox."""
+
+from .toolboxes.diagram_rules_toolbox import *  # noqa: F401,F403

--- a/gui/dialog_utils.py
+++ b/gui/dialog_utils.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated dialog utilities."""
+
+from .dialogs.dialog_utils import *  # noqa: F401,F403

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated drawing helper utility."""
+
+from .utils.drawing_helper import *  # noqa: F401,F403

--- a/gui/fault_prioritization.py
+++ b/gui/fault_prioritization.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated fault prioritization window."""
+
+from .windows.fault_prioritization import *  # noqa: F401,F403

--- a/gui/faults_gui.py
+++ b/gui/faults_gui.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated faults window."""
+
+from .windows.faults_gui import *  # noqa: F401,F403

--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated GSN config window."""
+
+from .windows.gsn_config_window import *  # noqa: F401,F403

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated GSN diagram window."""
+
+from .windows.gsn_diagram_window import *  # noqa: F401,F403

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated GSN explorer."""
+
+from .explorers.gsn_explorer import *  # noqa: F401,F403

--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated icon factory utility."""
+
+from .utils.icon_factory import *  # noqa: F401,F403

--- a/gui/name_utils.py
+++ b/gui/name_utils.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated naming utilities."""
+
+from .utils.name_utils import *  # noqa: F401,F403

--- a/gui/report_template_manager.py
+++ b/gui/report_template_manager.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated report template manager."""
+
+from .toolboxes.report_template_manager import *  # noqa: F401,F403

--- a/gui/report_template_toolbox.py
+++ b/gui/report_template_toolbox.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated report template toolbox."""
+
+from .toolboxes.report_template_toolbox import *  # noqa: F401,F403

--- a/gui/requirement_patterns_toolbox.py
+++ b/gui/requirement_patterns_toolbox.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated requirement patterns toolbox."""
+
+from .toolboxes.requirement_patterns_toolbox import *  # noqa: F401,F403

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated review toolbox."""
+
+from .toolboxes.review_toolbox import *  # noqa: F401,F403

--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated safety case explorer."""
+
+from .explorers.safety_case_explorer import *  # noqa: F401,F403

--- a/gui/safety_case_table.py
+++ b/gui/safety_case_table.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated safety case table utility."""
+
+from .utils.safety_case_table import *  # noqa: F401,F403

--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated safety management explorer."""
+
+from .explorers.safety_management_explorer import *  # noqa: F401,F403

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated safety management toolbox."""
+
+from .toolboxes.safety_management_toolbox import *  # noqa: F401,F403

--- a/gui/search_toolbox.py
+++ b/gui/search_toolbox.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated search toolbox."""
+
+from .toolboxes.search_toolbox import *  # noqa: F401,F403

--- a/gui/splash_screen.py
+++ b/gui/splash_screen.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated splash screen module."""
+
+from .windows.splash_screen import *  # noqa: F401,F403

--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated STPA window."""
+
+from .windows.stpa_window import *  # noqa: F401,F403

--- a/gui/style_editor.py
+++ b/gui/style_editor.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated style editor."""
+
+from .styles.style_editor import *  # noqa: F401,F403

--- a/gui/style_manager.py
+++ b/gui/style_manager.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated style manager."""
+
+from .styles.style_manager import *  # noqa: F401,F403

--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated threat dialog."""
+
+from .dialogs.threat_dialog import *  # noqa: F401,F403

--- a/gui/threat_window.py
+++ b/gui/threat_window.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated threat window."""
+
+from .windows.threat_window import *  # noqa: F401,F403

--- a/gui/tooltip.py
+++ b/gui/tooltip.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for relocated tooltip utility."""
+
+from .utils.tooltip import *  # noqa: F401,F403

--- a/gui/utils/__init__.py
+++ b/gui/utils/__init__.py
@@ -1,0 +1,13 @@
+"""Utility helpers re-exported for backwards compatibility."""
+
+from . import logger as logger  # noqa: F401
+
+
+def __getattr__(name: str):
+    if name == "DIALOG_BG_COLOR":
+        from .. import DIALOG_BG_COLOR  # Local import to avoid circular dependency
+        return DIALOG_BG_COLOR
+    raise AttributeError(name)
+
+
+__all__ = ["logger", "DIALOG_BG_COLOR"]

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.20"
+VERSION = "0.2.21"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- add wrapper modules so moved GUI code can still be imported via `gui.*`
- re-export logger and dialog color for backwards compatibility
- bump version to 0.2.21 and document in README

## Testing
- `radon cc -s -j gui/architecture.py gui/gsn_diagram_window.py gui/closable_notebook.py`
- `pytest` *(fails: FileNotFoundError for assets and other import-time errors)*


------
https://chatgpt.com/codex/tasks/task_b_68abc72d9e188327b8c4ab77b9fc4ce5