### PR TITLE
Move __future__ imports to module start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.48
+version: 0.2.49
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.49 - Move ``from __future__`` annotations imports to top-level of modules.
 - 0.2.48 - Provide wrapper for 90° connections and serialize SysML diagrams for export.
 - 0.2.47 - Delegate basic event probability updates to probability service to avoid missing risk module method.
 - 0.2.46 - Delegate basic event retrieval to FTASubApp to fix invocation mismatch.

--- a/analysis/causal_bayesian_network.py
+++ b/analysis/causal_bayesian_network.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Simple Causal Bayesian Network utilities.
 
 This module provides a minimal implementation of a causal Bayesian
@@ -41,7 +43,6 @@ The small network above mirrors the example discussed in the project
 README and illustrates how priors, conditional probability tables and
 queries map to the "circles and tables" intuition.
 """
-from __future__ import annotations
 
 from dataclasses import dataclass, field
 from itertools import product

--- a/analysis/confusion_matrix.py
+++ b/analysis/confusion_matrix.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Confusion matrix utilities."""
 from __future__ import annotations
+
+"""Confusion matrix utilities."""
 
 from typing import Dict
 

--- a/analysis/requirement_quality.py
+++ b/analysis/requirement_quality.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Requirement quality checker.
 
 This module provides simple heuristics to verify that requirement
@@ -38,7 +40,6 @@ The implementation intentionally avoids external dependencies to keep the
 checker lightweight and easy to run in constrained environments.
 """
 
-from __future__ import annotations
 
 import re
 from typing import List, Tuple

--- a/analysis/requirement_rule_generator.py
+++ b/analysis/requirement_rule_generator.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Generate requirement patterns from diagram rule configuration.
 
 This module derives requirement pattern definitions for both Safety & AI
@@ -40,7 +42,6 @@ invoked by the application whenever the model changes so requirement patterns
 stay in sync with diagram rule updates and governance diagram creation.
 """
 
-from __future__ import annotations
 
 import argparse
 import json

--- a/analysis/risk_tables.py
+++ b/analysis/risk_tables.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Risk level and CAL determination utilities."""
 from __future__ import annotations
+
+"""Risk level and CAL determination utilities."""
 
 from typing import Optional
 

--- a/analysis/safety_case.py
+++ b/analysis/safety_case.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Data structures for safety & security reports."""

--- a/analysis/scenario_description.py
+++ b/analysis/scenario_description.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Utilities for generating scenario descriptions from parameters."""
 
-from __future__ import annotations
 
 from typing import Iterable, List, Sequence, Tuple
 

--- a/analysis/sotif_validation.py
+++ b/analysis/sotif_validation.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Utilities for acceptance criteria and validation targets per ISO 21448.
 
 This module provides helper functions to derive the rate of hazardous behaviour
@@ -24,7 +26,6 @@ specified in ISO 21448:2022, Annex C. The formulas implemented here correspond
 to equations (C.1) and (C.2) and assume rates are expressed per hour.
 """
 
-from __future__ import annotations
 
 import math
 

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Shared GUI helpers
+
 from __future__ import annotations
 
 """Shared GUI helpers and widget customizations."""

--- a/gui/controls/__init__.py
+++ b/gui/controls/__init__.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Custom control widgets for the AutoML GUI.
 
 The messagebox module is imported lazily to avoid circular import issues.  It
@@ -25,7 +27,6 @@ at module import time would cause a partially initialised package when
 ``messagebox`` is first requested.
 """
 
-from __future__ import annotations
 
 from types import ModuleType
 import importlib

--- a/gui/controls/button_utils.py
+++ b/gui/controls/button_utils.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Utility helpers for consistent button presentation across toolboxes."""
 
-from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk

--- a/gui/controls/capsule_button.py
+++ b/gui/controls/capsule_button.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 import tkinter as tk

--- a/gui/controls/mac_button_style.py
+++ b/gui/controls/mac_button_style.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 import tkinter as tk

--- a/gui/dialogs/__init__.py
+++ b/gui/dialogs/__init__.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """AutoML package exposing application classes lazily."""
 
-from __future__ import annotations
 
 import importlib
 from types import ModuleType

--- a/gui/dialogs/decomposition_dialog.py
+++ b/gui/dialogs/decomposition_dialog.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Dialog for selecting requirement decomposition schemes.
 
 This module defines :class:`DecompositionDialog`, which allows a user to
@@ -24,7 +26,6 @@ choose a decomposition scheme based on the ASIL level.  It was moved out of
 of the main application file.
 """
 
-from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk, simpledialog

--- a/gui/dialogs/dialog_utils.py
+++ b/gui/dialogs/dialog_utils.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Utility functions for GUI dialogs."""
 from __future__ import annotations
+
+"""Utility functions for GUI dialogs."""
 
 from tkinter import simpledialog
 

--- a/gui/dialogs/edit_node_dialog.py
+++ b/gui/dialogs/edit_node_dialog.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Dialog for editing nodes and related requirement management."""
 
-from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk, simpledialog

--- a/gui/dialogs/fmea_row_dialog.py
+++ b/gui/dialogs/fmea_row_dialog.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Dialog for editing FMEA entries."""
 from __future__ import annotations
+
+"""Dialog for editing FMEA entries."""
 
 import datetime
 import types

--- a/gui/dialogs/gsn_connection_config.py
+++ b/gui/dialogs/gsn_connection_config.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Configuration dialog for editing GSN connections."""
 from __future__ import annotations
+
+"""Configuration dialog for editing GSN connections."""
 
 import tkinter as tk
 from tkinter import ttk

--- a/gui/dialogs/req_dialog.py
+++ b/gui/dialogs/req_dialog.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Dialog for creating or editing global requirements.

--- a/gui/dialogs/select_base_event_dialog.py
+++ b/gui/dialogs/select_base_event_dialog.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Dialog for selecting a base event from a list.

--- a/gui/dialogs/user_select_dialog.py
+++ b/gui/dialogs/user_select_dialog.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Dialog for selecting an existing user or creating a new one."""
 
-from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk, simpledialog

--- a/gui/explorers/gsn_explorer.py
+++ b/gui/explorers/gsn_explorer.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Simple explorer window for GSN argumentation diagrams."""
 from __future__ import annotations
+
+"""Simple explorer window for GSN argumentation diagrams."""
 
 import tkinter as tk
 from tkinter import ttk, simpledialog

--- a/gui/explorers/safety_case_explorer.py
+++ b/gui/explorers/safety_case_explorer.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Explorer for safety & security cases derived from GSN diagrams."""
 from __future__ import annotations
+
+"""Explorer for safety & security cases derived from GSN diagrams."""
 
 import tkinter as tk
 from tkinter import ttk, simpledialog

--- a/gui/explorers/safety_management_explorer.py
+++ b/gui/explorers/safety_management_explorer.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Explorer window for safety governance diagrams."""
 from __future__ import annotations
+
+"""Explorer window for safety governance diagrams."""
 
 import tkinter as tk
 from tkinter import ttk, simpledialog

--- a/gui/toolboxes/search_toolbox.py
+++ b/gui/toolboxes/search_toolbox.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Search toolbox for finding objects within the AutoML model."""
 from __future__ import annotations
+
+"""Search toolbox for finding objects within the AutoML model."""
 
 import re
 import tkinter as tk

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Custom ttk.Notebook widget with detachable tabs.
 
 The widget behaves like a regular :class:`ttk.Notebook` but displays a close
@@ -24,7 +26,6 @@ create a new floating window. Dragging a tab from a floating window back onto a
 notebook re-attaches it to that notebook.
 """
 
-from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk

--- a/gui/utils/name_utils.py
+++ b/gui/utils/name_utils.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Helpers for ensuring unique work product names across analyses.

--- a/gui/utils/safety_case_table.py
+++ b/gui/utils/safety_case_table.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Table view showing solutions for a safety & security case."""
 from __future__ import annotations
+
+"""Table view showing solutions for a safety & security case."""
 
 import math
 import tkinter as tk

--- a/gui/windows/faults_gui.py
+++ b/gui/windows/faults_gui.py
@@ -23,6 +23,7 @@
 # Added: comprehensive tooltips for thresholds & columns, per-row breakdown tooltips,
 #        and Help menu with formulas & logic.
 
+
 from __future__ import annotations
 
 import sys

--- a/gui/windows/gsn_config_window.py
+++ b/gui/windows/gsn_config_window.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Configuration dialog for editing GSN node properties."""
 from __future__ import annotations
+
+"""Configuration dialog for editing GSN node properties."""
 
 import tkinter as tk
 from tkinter import ttk

--- a/gui/windows/gsn_diagram_window.py
+++ b/gui/windows/gsn_diagram_window.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Simple canvas window with toolbox for editing GSN diagrams."""
 from __future__ import annotations
+
+"""Simple canvas window with toolbox for editing GSN diagrams."""
 
 import csv
 import tkinter as tk

--- a/mainappsrc/core/analysis_utils.py
+++ b/mainappsrc/core/analysis_utils.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Analysis utility mixins for :class:`AutoMLApp`."""
 
-from __future__ import annotations
 
 from analysis.mechanisms import (
     MechanismLibrary,

--- a/mainappsrc/core/app_lifecycle_ui.py
+++ b/mainappsrc/core/app_lifecycle_ui.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """UI helpers extracted from AutoML core.
 
 This module defines :class:`AppLifecycleUI` which encapsulates window and
@@ -24,7 +26,6 @@ class delegates most attribute access to the parent application instance so
 existing code can continue to operate without modification.
 """
 
-from __future__ import annotations
 
 import datetime
 import tkinter as tk

--- a/mainappsrc/core/config_utils.py
+++ b/mainappsrc/core/config_utils.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Configuration helpers and global state for AutoML."""

--- a/mainappsrc/core/data_access_queries.py
+++ b/mainappsrc/core/data_access_queries.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Data access helper queries for :class:`AutoMLApp`.
 
 This module centralises database and model lookup helpers that were
@@ -23,7 +25,6 @@ previously methods on ``AutoMLApp``.  Separating them keeps the main
 application class focused on orchestration and UI responsibilities while
 these functions provide read-only views over the underlying model.
 """
-from __future__ import annotations
 
 from typing import List
 

--- a/mainappsrc/core/diagram_renderer.py
+++ b/mainappsrc/core/diagram_renderer.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Centralised renderer for AutoML diagrams.

--- a/mainappsrc/core/editing_labels_styling.py
+++ b/mainappsrc/core/editing_labels_styling.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Editing and styling helpers extracted from AutoML core.
 
 This module defines :class:`Editing_Labels_Styling` which groups together
@@ -25,7 +27,6 @@ application instance so existing code can continue to call these methods
 without modification.
 """
 
-from __future__ import annotations
 
 from pathlib import Path
 import tkinter as tk

--- a/mainappsrc/core/editors.py
+++ b/mainappsrc/core/editors.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Editor mixins extracted from :mod:`automl_core`.

--- a/mainappsrc/core/event_dispatcher.py
+++ b/mainappsrc/core/event_dispatcher.py
@@ -16,13 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Event binding utilities for :class:`AutoMLApp`.
 
 The :class:`EventDispatcher` centralises keyboard shortcut and tab-related
 bindings so that the main application class is less cluttered and easier to
 reason about.
 """
-from __future__ import annotations
 
 from typing import TYPE_CHECKING
 

--- a/mainappsrc/core/event_handlers.py
+++ b/mainappsrc/core/event_handlers.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Event handler mixins for :class:`AutoMLApp`."""
 
-from __future__ import annotations
 
 
 class EventHandlersMixin:

--- a/mainappsrc/core/fmea_service.py
+++ b/mainappsrc/core/fmea_service.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """FMEA service handling list management and dialogs."""
 
-from __future__ import annotations
 
 import datetime
 import tkinter as tk

--- a/mainappsrc/core/icon_setup_mixin.py
+++ b/mainappsrc/core/icon_setup_mixin.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Mix-in for building style-aware icons used across the UI."""

--- a/mainappsrc/core/navigation_selection_input.py
+++ b/mainappsrc/core/navigation_selection_input.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 import tkinter as tk

--- a/mainappsrc/core/open_windows_features.py
+++ b/mainappsrc/core/open_windows_features.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Window management and opening helpers for AutoMLApp."""
 
-from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk, simpledialog

--- a/mainappsrc/core/page_diagram.py
+++ b/mainappsrc/core/page_diagram.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Page diagram rendering and interaction utilities."""
 
-from __future__ import annotations
 
 from pathlib import Path
 import tkinter as tk

--- a/mainappsrc/core/pages_and_paa.py
+++ b/mainappsrc/core/pages_and_paa.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Helpers for page diagrams and Prototype Assurance activities."""
 
-from __future__ import annotations
 
 import tkinter as tk
 from gui.styles.style_manager import StyleManager

--- a/mainappsrc/core/persistence_wrappers.py
+++ b/mainappsrc/core/persistence_wrappers.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Persistence helper mixins for :class:`AutoMLApp`."""
 
-from __future__ import annotations
 
 
 class PersistenceWrappersMixin:

--- a/mainappsrc/core/probability_reliability.py
+++ b/mainappsrc/core/probability_reliability.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Probability and reliability helpers for AutoML."""
 
-from __future__ import annotations
 
 import math
 import tkinter as tk

--- a/mainappsrc/core/reporting_export.py
+++ b/mainappsrc/core/reporting_export.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Reporting and export helpers for :class:`AutoMLApp`."""

--- a/mainappsrc/core/safety_analysis.py
+++ b/mainappsrc/core/safety_analysis.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Combined FTA/FMEA helper class.

--- a/mainappsrc/core/safety_ui.py
+++ b/mainappsrc/core/safety_ui.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""UI mixin providing safety-related dialogs and editors."""
 from __future__ import annotations
+
+"""UI mixin providing safety-related dialogs and editors."""
 
 import csv
 import tkinter as tk

--- a/mainappsrc/core/service_init_mixin.py
+++ b/mainappsrc/core/service_init_mixin.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Mix-in responsible for constructing application services and managers."""

--- a/mainappsrc/core/structure_tree_operations.py
+++ b/mainappsrc/core/structure_tree_operations.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Structure tree manipulation helpers extracted from AutoML core."""
 
-from __future__ import annotations
 
 from gui.controls import messagebox
 

--- a/mainappsrc/core/style_setup_mixin.py
+++ b/mainappsrc/core/style_setup_mixin.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Mix-in providing GUI style configuration for :class:`AutoMLApp`."""

--- a/mainappsrc/core/syncing_and_ids.py
+++ b/mainappsrc/core/syncing_and_ids.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Synchronization helpers for nodes keyed by unique IDs."""
 from __future__ import annotations
+
+"""Synchronization helpers for nodes keyed by unique IDs."""
 
 from typing import TYPE_CHECKING, List, Any
 

--- a/mainappsrc/core/top_event_workflows.py
+++ b/mainappsrc/core/top_event_workflows.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Helpers for fault tree top event workflows.

--- a/mainappsrc/core/ui_setup.py
+++ b/mainappsrc/core/ui_setup.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """UI setup helpers for AutoMLApp.
 
 This module groups methods related to user interface
@@ -24,7 +26,6 @@ initialisation and diagram tab management. They are mixed into
 :class:`UISetupMixin` to keep ``automl_core`` lean.
 """
 
-from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk

--- a/mainappsrc/core/validation_consistency.py
+++ b/mainappsrc/core/validation_consistency.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Validation and work product consistency helpers."""
 
-from __future__ import annotations
 
 import tkinter as tk
 from analysis.models import global_requirements

--- a/mainappsrc/core/versioning_review.py
+++ b/mainappsrc/core/versioning_review.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Review and versioning helpers separated from the main application."""
 from __future__ import annotations
+
+"""Review and versioning helpers separated from the main application."""
 
 from typing import Any
 

--- a/mainappsrc/core/window_controllers.py
+++ b/mainappsrc/core/window_controllers.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Window management helpers for AutoML.

--- a/mainappsrc/managers/capture_manager.py
+++ b/mainappsrc/managers/capture_manager.py
@@ -16,12 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Helpers for capturing various diagram types into images.
 
 This manager centralises logic that was previously scattered in
 ``automl_core`` to reduce its complexity and improve modularity.
 """
-from __future__ import annotations
 
 import tkinter as tk
 from gui.styles.style_manager import StyleManager

--- a/mainappsrc/managers/cta_manager.py
+++ b/mainappsrc/managers/cta_manager.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""CTA diagram utilities for AutoMLApp."""
 from __future__ import annotations
+
+"""CTA diagram utilities for AutoMLApp."""
 
 import tkinter as tk
 from typing import Dict

--- a/mainappsrc/managers/cyber_manager.py
+++ b/mainappsrc/managers/cyber_manager.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Cybersecurity utilities for AutoMLApp."""
 from __future__ import annotations
+
+"""Cybersecurity utilities for AutoMLApp."""
 
 import csv
 import tkinter as tk

--- a/mainappsrc/managers/drawing_manager.py
+++ b/mainappsrc/managers/drawing_manager.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Centralised drawing helpers for AutoML diagrams."""

--- a/mainappsrc/managers/governance_manager.py
+++ b/mainappsrc/managers/governance_manager.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Governance management helpers for :class:`AutoMLApp`.
 
 This module centralises interactions with the Safety Management Toolbox so the
@@ -24,7 +26,6 @@ controls lifecycle module activation, toolbox change propagation and diagram
 freezing utilities.
 """
 
-from __future__ import annotations
 
 from typing import Optional, Iterable
 import tkinter as tk

--- a/mainappsrc/managers/gsn_manager.py
+++ b/mainappsrc/managers/gsn_manager.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Utility class to handle GSN specific UI actions."""

--- a/mainappsrc/managers/paa_manager.py
+++ b/mainappsrc/managers/paa_manager.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """
 ===============================================================================
 Risk & Assurance Gate Calculator for Autonomous Systems
@@ -223,7 +225,6 @@ References
 """
 
 """Prototype Assurance Analysis utilities for AutoMLApp."""
-from __future__ import annotations
 
 import tkinter as tk
 

--- a/mainappsrc/managers/project_manager.py
+++ b/mainappsrc/managers/project_manager.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project persistence utilities for AutoMLApp."""
 from __future__ import annotations
+
+"""Project persistence utilities for AutoMLApp."""
 
 from tkinter import filedialog, simpledialog
 from gui.dialogs.dialog_utils import askstring_fixed

--- a/mainappsrc/managers/repository_manager.py
+++ b/mainappsrc/managers/repository_manager.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Utilities for managing SysML and FTA repositories."""
 from __future__ import annotations
+
+"""Utilities for managing SysML and FTA repositories."""
 
 import tkinter as tk
 from tkinter import ttk

--- a/mainappsrc/managers/requirements_manager.py
+++ b/mainappsrc/managers/requirements_manager.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Requirement management utilities for AutoML."""

--- a/mainappsrc/managers/sotif_manager.py
+++ b/mainappsrc/managers/sotif_manager.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""SOTIF management utilities for AutoMLApp."""
 from __future__ import annotations
+
+"""SOTIF management utilities for AutoMLApp."""
 
 import math
 import tkinter as tk

--- a/mainappsrc/managers/user_manager.py
+++ b/mainappsrc/managers/user_manager.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""User management utilities for AutoMLApp."""
 from __future__ import annotations
+
+"""User management utilities for AutoMLApp."""
 
 from tkinter import simpledialog
 from gui.toolboxes.review_toolbox import UserSelectDialog as ReviewUserSelectDialog

--- a/mainappsrc/models/gsn/diagram.py
+++ b/mainappsrc/models/gsn/diagram.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Simple rendering support for GSN diagrams."""
 from __future__ import annotations
+
+"""Simple rendering support for GSN diagrams."""
 
 from dataclasses import dataclass, field
 from typing import Iterable, List

--- a/mainappsrc/models/gsn/module.py
+++ b/mainappsrc/models/gsn/module.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/mainappsrc/models/gsn/nodes.py
+++ b/mainappsrc/models/gsn/nodes.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Basic data structures for GSN argumentation diagrams."""
 from __future__ import annotations
+
+"""Basic data structures for GSN argumentation diagrams."""
 
 from dataclasses import dataclass, field
 from typing import List, Optional

--- a/mainappsrc/subapps/activity_diagram_subapp.py
+++ b/mainappsrc/subapps/activity_diagram_subapp.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 from tkinter import simpledialog

--- a/mainappsrc/subapps/block_diagram_subapp.py
+++ b/mainappsrc/subapps/block_diagram_subapp.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 from tkinter import simpledialog

--- a/mainappsrc/subapps/control_flow_diagram_subapp.py
+++ b/mainappsrc/subapps/control_flow_diagram_subapp.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 from tkinter import simpledialog

--- a/mainappsrc/subapps/diagram_export_subapp.py
+++ b/mainappsrc/subapps/diagram_export_subapp.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Diagram export utilities for :class:`AutoMLApp`."""
 from __future__ import annotations
+
+"""Diagram export utilities for :class:`AutoMLApp`."""
 
 from tkinter import filedialog
 from PIL import Image, ImageDraw, ImageFont

--- a/mainappsrc/subapps/fta_subapp.py
+++ b/mainappsrc/subapps/fta_subapp.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Fault tree analysis helpers separated from the main application."""

--- a/mainappsrc/subapps/internal_block_diagram_subapp.py
+++ b/mainappsrc/subapps/internal_block_diagram_subapp.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 from tkinter import simpledialog

--- a/mainappsrc/subapps/project_editor_subapp.py
+++ b/mainappsrc/subapps/project_editor_subapp.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Project editing helpers separated from the main application."""

--- a/mainappsrc/subapps/reliability_subapp.py
+++ b/mainappsrc/subapps/reliability_subapp.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Reliability analysis helpers separated from the main application."""

--- a/mainappsrc/subapps/risk_assessment_subapp.py
+++ b/mainappsrc/subapps/risk_assessment_subapp.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Risk assessment utilities separated from the main application."""

--- a/mainappsrc/subapps/style_subapp.py
+++ b/mainappsrc/subapps/style_subapp.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """UI styling helper used by :class:`AutoMLApp`.

--- a/mainappsrc/subapps/tree_subapp.py
+++ b/mainappsrc/subapps/tree_subapp.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Tree-related event handlers for AutoML."""

--- a/mainappsrc/subapps/use_case_diagram_subapp.py
+++ b/mainappsrc/subapps/use_case_diagram_subapp.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 from tkinter import simpledialog

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.48"
+VERSION = "0.2.49"
 
 __all__ = ["VERSION"]

--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Tiny fallback implementation of :mod:`networkx`.
 
 The repository bundles a very small subset of NetworkX so the test suite can
@@ -24,7 +26,6 @@ NetworkX exists somewhere else on ``sys.path`` we defer to that version to
 provide the full feature set expected by end users.
 """
 
-from __future__ import annotations
 
 import importlib.machinery
 import importlib.util

--- a/reportlab/__init__.py
+++ b/reportlab/__init__.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Lightweight stand-in for the real :mod:`reportlab` package.
 
 This module provides a very small subset of the real project's
@@ -28,7 +30,6 @@ while the test environment continues to rely on the tiny fallback
 defined in this repo.
 """
 
-from __future__ import annotations
 
 import importlib.machinery
 import importlib.util

--- a/reportlab/lib/colors.py
+++ b/reportlab/lib/colors.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Minimal color definitions for the ReportLab stub.
 
 The real :mod:`reportlab.lib.colors` module exposes a fairly extensive
@@ -30,7 +32,6 @@ tests, but storing something sensible makes debugging easier and keeps the
 API reasonably faithful.
 """
 
-from __future__ import annotations
 
 from typing import Tuple
 

--- a/tests/test_dialog_instantiation.py
+++ b/tests/test_dialog_instantiation.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 import types

--- a/tests/test_gsn_node_at.py
+++ b/tests/test_gsn_node_at.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Tests for GSNDiagramWindow node selection helpers.
 
 These tests exercise the four different ``_node_at`` strategies used by
@@ -25,7 +27,6 @@ select a node which previously happened due to ``Canvas.find_closest`` always
 returning an item.
 """
 
-from __future__ import annotations
 
 import pytest
 

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Regression tests ensuring version consistency."""
 
-from __future__ import annotations
 
 import subprocess
 import sys

--- a/tools/crash_report_logger.py
+++ b/tools/crash_report_logger.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Crash report logging utilities with multiple implementations."""
 
-from __future__ import annotations
 
 import datetime
 import logging

--- a/tools/create_installer.py
+++ b/tools/create_installer.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Utilities to package the AutoML executable into installable archives.
 
 Four different packaging strategies are provided so that the build
@@ -24,7 +26,6 @@ process can choose the most appropriate installer format.  The
 scripts, but the other strategies are available for comparison and
 testing.
 """
-from __future__ import annotations
 
 import argparse
 import os

--- a/tools/diagnostics_manager.py
+++ b/tools/diagnostics_manager.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Background diagnostics utilities for monitoring tool integrity.

--- a/tools/icon_builder.py
+++ b/tools/icon_builder.py
@@ -17,13 +17,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #!/usr/bin/env python3
+from __future__ import annotations
+
 """Utility to programmatically generate an AutoML icon.
 
 Provides four drawing strategies, each producing a small 3D cube with a gear
 inside.  Strategy ``v4`` offers the most detailed rendering and is the default
 used by build scripts.
 """
-from __future__ import annotations
 
 import struct
 from pathlib import Path

--- a/tools/memory_manager.py
+++ b/tools/memory_manager.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Simple memory management utilities for lazy loading and process cleanup.
 
 The :class:`MemoryManager` centralizes lazy loading of modules or data and
@@ -23,7 +25,6 @@ tracks subprocesses so idle ones can be terminated.  It provides a minimal
 framework for the tool to only keep resources required for the currently
 visible data.
 """
-from __future__ import annotations
 
 import gc
 import importlib

--- a/tools/metrics_generator.py
+++ b/tools/metrics_generator.py
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 """Generate simple code metrics for ISO 26262 quality checks.
 
 This script traverses a target directory and gathers basic metrics such as
@@ -30,7 +32,6 @@ Example usage::
 
 The output path may be customised with ``--output``.
 """
-from __future__ import annotations
 
 import argparse
 import ast

--- a/tools/splash_launcher.py
+++ b/tools/splash_launcher.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from __future__ import annotations
 
 """Utility for displaying a splash screen during application start-up."""


### PR DESCRIPTION
## Summary
- ensure `from __future__` annotations imports appear at top of modules
- bump version to 0.2.49

## Testing
- `radon cc -j analysis gui mainappsrc tests tools networkx reportlab`
- `pytest` *(fails: libGL.so.1 missing, test setup file errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ac8c73c2a0832785ac6f6b75f24f94