### PR TITLE
refactor: move requirement helpers to manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.54
+version: 0.2.55
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.55 - Delegate phase requirement menu refresh and traceability matrix to RequirementsManager and wrap core methods.
 - 0.2.54 - Initialize undo manager during service setup to prevent project load errors.
 - 0.2.52 - Move product goal UIs into RequirementsManager and add wrapper methods.
 - 0.2.51 - Extract clone-chain resolution into reusable utility.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -2032,24 +2032,7 @@ class AutoMLApp(
 
     def show_traceability_matrix(self):
         """Display a traceability matrix linking FTA basic events to FMEA components."""
-        basic_events = [n for n in self.get_all_nodes(self.root_node)
-                        if n.node_type.upper() == "BASIC EVENT"]
-        win = tk.Toplevel(self.root)
-        win.title("FTA-FMEA Traceability")
-        columns = ["Basic Event", "Component"]
-        tree = ttk.Treeview(win, columns=columns, show="headings")
-        for col in columns:
-            tree.heading(col, text=col)
-            tree.column(col, width=200, anchor="center")
-        tree.pack(fill=tk.BOTH, expand=True)
-
-        for be in basic_events:
-            comp = self.get_component_name_for_node(be) or "N/A"
-            tree.insert(
-                "",
-                "end",
-                values=[be.user_name or f"BE {be.unique_id}", comp],
-            )
+        return self.requirements_manager.show_traceability_matrix()
 
     def collect_requirements_recursive(self, node):
         return self.safety_analysis.collect_requirements_recursive(node)
@@ -2098,26 +2081,7 @@ class AutoMLApp(
 
 
     def _refresh_phase_requirements_menu(self) -> None:
-        if not hasattr(self, "phase_req_menu"):
-            return
-        self.phase_req_menu.delete(0, tk.END)
-        toolbox = getattr(self, "safety_mgmt_toolbox", None)
-        if not toolbox:
-            return
-        phases = sorted(toolbox.list_modules())
-        for phase in phases:
-            # Use ``functools.partial`` to bind the phase name at creation time
-            # so each menu entry triggers generation for its own phase.
-            self.phase_req_menu.add_command(
-                label=phase,
-                command=partial(self.generate_phase_requirements, phase),
-            )
-        if phases:
-            self.phase_req_menu.add_separator()
-        self.phase_req_menu.add_command(
-            label="Lifecycle",
-            command=self.generate_lifecycle_requirements,
-        )
+        return self.requirements_manager.refresh_phase_requirements_menu()
 
     def export_cybersecurity_goal_requirements(self):
         return self.reporting_export.export_cybersecurity_goal_requirements()

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.54"
+VERSION = "0.2.55"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- delegate traceability matrix display and phase requirements menu refresh to RequirementsManager
- wrap core methods around RequirementsManager to keep API stable
- bump project version to 0.2.55

## Testing
- `python tools/metrics_generator.py --path mainappsrc/managers --output /tmp/metrics_managers.json`
- `python tools/metrics_generator.py --path mainappsrc/core --output /tmp/metrics_core.json`
- `pytest` *(fails: ModuleNotFoundError: No module named 'automl'; ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*
- `python AutoML.py --version`


------
https://chatgpt.com/codex/tasks/task_b_68aca1f702d08327b42a601cf009e61d