### PR TITLE
Fix PDF export extension handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.69
+version: 0.2.70
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1647,6 +1647,7 @@ and run the build again if you hit this issue.
 - 0.2.68 - Prevent tool tab duplication when switching lifecycle phases.
 - 0.2.67 - Activate risk assessment tools only when risk assessment work products exist.
 - 0.2.66 - Recognize copied work products in active phase governance diagrams.
+- 0.2.70 - Enforce PDF extension on export so files use the selected format.
 - 0.2.65 - Always paste to the focused governance diagram and show focused tab details in the status bar.
 - 0.2.64 - Fix paste so governance diagrams honor the currently focused tab.
 - 0.2.63 - Ensure governance diagram clipboard uses focused tab for copy, cut and paste.

--- a/mainappsrc/core/reporting_export.py
+++ b/mainappsrc/core/reporting_export.py
@@ -68,11 +68,14 @@ class Reporting_Export:
     # Reporting helpers
     def _generate_pdf_report(self) -> None:
         """Export a PDF report using a JSON template."""
-        pdf_path = filedialog.asksaveasfilename(
+        pdf_path_str = filedialog.asksaveasfilename(
             defaultextension=".pdf", filetypes=[("PDF", "*.pdf")]
         )
-        if not pdf_path:
+        if not pdf_path_str:
             return
+        pdf_path = Path(pdf_path_str)
+        if pdf_path.suffix.lower() != ".pdf":
+            pdf_path = pdf_path.with_suffix(".pdf")
 
         template_path = filedialog.askopenfilename(
             defaultextension=".json", filetypes=[("JSON", "*.json")]
@@ -83,7 +86,7 @@ class Reporting_Export:
         try:
             with open(template_path, "r", encoding="utf-8") as tpl:
                 template = json.load(tpl)
-            debug_path = Path(pdf_path).with_suffix(".json")
+            debug_path = pdf_path.with_suffix(".json")
             with open(debug_path, "w", encoding="utf-8") as dbg:
                 json.dump(template, dbg)
 
@@ -94,7 +97,7 @@ class Reporting_Export:
             title = self.app.project_properties.get(
                 "pdf_report_name", "AutoML-Analyzer PDF Report"
             )
-            doc = SimpleDocTemplate(pdf_path)
+            doc = SimpleDocTemplate(str(pdf_path))
             doc.build([Paragraph(title, styles["Title"])])
             logger.log_message(f"PDF report generated at {pdf_path}")
         except Exception as exc:  # pragma: no cover - best effort error path

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.69"
+VERSION = "0.2.70"
 
 __all__ = ["VERSION"]

--- a/tests/test_pdf_template_export.py
+++ b/tests/test_pdf_template_export.py
@@ -137,3 +137,23 @@ def test_generate_pdf_report_handles_extended_placeholders(tmp_path, monkeypatch
     app._generate_pdf_report()
     assert pdf_path.exists()
     assert pdf_path.with_suffix(".json").exists()
+
+
+def test_generate_pdf_report_enforces_pdf_extension(tmp_path, monkeypatch):
+    """Ensure PDFs are saved with the selected PDF extension."""
+    pdf_path = tmp_path / "out.txt"
+    template_path = tmp_path / "template.json"
+    template_path.write_text(json.dumps({"elements": {}, "sections": []}))
+
+    monkeypatch.setattr(filedialog, "asksaveasfilename", lambda **k: str(pdf_path))
+    monkeypatch.setattr(filedialog, "askopenfilename", lambda **k: str(template_path))
+
+    app = type(
+        "A",
+        (),
+        {"project_properties": {}, "_generate_pdf_report": AutoMLApp._generate_pdf_report},
+    )()
+    app._generate_pdf_report()
+
+    assert pdf_path.with_suffix(".pdf").exists()
+    assert pdf_path.with_suffix(".pdf").with_suffix(".json").exists()


### PR DESCRIPTION
## Summary
- ensure PDF report export enforces the .pdf extension
- test PDF export handles incorrect extension and bump version

## Testing
- `radon cc mainappsrc/core/reporting_export.py tests/test_pdf_template_export.py -j`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68acdcab78c08327bfa3f0283350606c