### PR TITLE
Cancel Tk after callbacks for detached widgets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 # Version History
+- 0.2.145 - Cancel Tk after callbacks referencing detached widgets and store
+            animation identifiers for reliable tab closure.
 - 0.2.144 - Resolve _StyledButton detachment by inspecting base-class signatures and
             falling back to widget text options when cloning tabs.
 - 0.2.143 - Cancel widget animations when detaching tabs and default missing text when cloning capsule buttons.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.144
+version: 0.2.145
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -518,6 +518,23 @@ class ClosableNotebook(ttk.Notebook):
     def _cancel_after_events(self, widget: tk.Widget) -> None:
         """Cancel common Tk ``after`` callbacks for *widget* and children."""
         try:
+            tcl_name = str(widget)
+            ids = widget.tk.call("after", "info")
+            if isinstance(ids, str):
+                ids = [ids]
+            for ident in ids:
+                try:
+                    cmd = widget.tk.call("after", "info", ident)
+                except Exception:
+                    continue
+                if tcl_name in cmd:
+                    try:
+                        widget.after_cancel(ident)
+                    except Exception:
+                        pass
+        except Exception:
+            pass
+        try:
             for name in dir(widget):
                 if name.endswith(("_anim", "_after", "_timer")):
                     ident = getattr(widget, name, None)

--- a/gui/windows/splash_screen.py
+++ b/gui/windows/splash_screen.py
@@ -118,8 +118,8 @@ class SplashScreen(tk.Toplevel):
             fill="white",
         )
         # Start animation and fade-in effect
-        self.after(10, self._animate)
-        self.after(10, self._fade_in)
+        self._anim_after = self.after(10, self._animate)
+        self._fade_in_after = self.after(10, self._fade_in)
 
     def close(self):
         """Begin fade-out sequence and invoke on_close callback when done."""
@@ -131,7 +131,7 @@ class SplashScreen(tk.Toplevel):
     def _fade_in(self):
         if not getattr(self, "_alpha_supported", False):
             if self.duration > 0:
-                self.after(self.duration, self._close)
+                self._close_after = self.after(self.duration, self._close)
             return
         alpha = min(self.attributes("-alpha") + 0.05, 1.0)
         self.attributes("-alpha", alpha)
@@ -141,10 +141,10 @@ class SplashScreen(tk.Toplevel):
             except tk.TclError:
                 pass
         if alpha < 1.0:
-            self.after(50, self._fade_in)
+            self._fade_in_after = self.after(50, self._fade_in)
         else:
             if self.duration > 0:
-                self.after(self.duration, self._fade_out)
+                self._fade_out_after = self.after(self.duration, self._fade_out)
 
     def _fade_out(self):
         if not getattr(self, "_alpha_supported", False):
@@ -158,7 +158,7 @@ class SplashScreen(tk.Toplevel):
             except tk.TclError:
                 pass
         if alpha > 0.0:
-            self.after(50, self._fade_out)
+            self._fade_out_after = self.after(50, self._fade_out)
         else:
             self._close()
 
@@ -485,7 +485,7 @@ class SplashScreen(tk.Toplevel):
         self.angle = (self.angle + 2) % 360
         self._draw_gear()
         self._draw_cube()
-        self.after(50, self._animate)
+        self._anim_after = self.after(50, self._animate)
 
     def _close(self):
         """Destroy splash screen and accompanying shadow window."""

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.144"
+VERSION = "0.2.145"
 
 __all__ = ["VERSION"]

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -492,3 +492,80 @@ class TestDetachCleanup:
         root.update()
         assert not errors
         root.destroy()
+
+
+class TestAnimatedWidgetDetach:
+    def test_detach_untracked_animation(self, monkeypatch, capsys):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+
+        class Untracked(ttk.Frame):
+            def __init__(self, master):
+                super().__init__(master)
+                self.after(1, self._spin)
+
+            def _spin(self):
+                self.after(1, self._spin)
+
+        widget = Untracked(nb)
+        nb.add(widget, text="Tab1")
+        nb.update_idletasks()
+
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        root.update()
+        err = capsys.readouterr().err
+        assert "invalid command name" not in err
+        root.destroy()
+
+    def test_detach_child_untracked_animation(self, monkeypatch, capsys):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+
+        class Parent(ttk.Frame):
+            def __init__(self, master):
+                super().__init__(master)
+                child = ttk.Frame(self)
+                child.pack()
+                child.after(1, self._bounce)
+                self.child = child
+
+            def _bounce(self):
+                self.child.after(1, self._bounce)
+
+        widget = Parent(nb)
+        nb.add(widget, text="Tab1")
+        nb.update_idletasks()
+
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        root.update()
+        err = capsys.readouterr().err
+        assert "invalid command name" not in err
+        root.destroy()


### PR DESCRIPTION
## Summary
- Track and cancel Tk `after` callbacks referencing a widget when detaching tabs
- Store animation callback identifiers in splash screen for reliable shutdown
- Test animated widget detachment to avoid "invalid command name" errors

## Testing
- `python tools/metrics_generator.py --path gui/utils --output metrics_utils.json`
- `python tools/metrics_generator.py --path gui/windows --output metrics_windows.json`
- `PYTHONPATH=. pytest tests/test_tab_detach.py` *(fails: ImportError while importing test module)*

------
https://chatgpt.com/codex/tasks/task_b_68ae768934408327ad44ca988f40831e