### PR TITLE
Fix detached window content rebuild and thread restart/shutdown race

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
+## 0.2.298 - 2026-05-03
+
+- Improve detached tab reopening by trying multiple constructor signatures for
+  diagram windows, preventing empty undocked windows when the primary
+  signature is incompatible.
+- Harden thread supervision to avoid restarting worker threads after their
+  stop event is set, reducing late-lifecycle restart crashes.
+
 ## 0.2.297 - 2025-12-26
 
 - Reopen detached tab content by instantiating fresh widgets in the floating

--- a/gui/utils/detached_tab_reopener.py
+++ b/gui/utils/detached_tab_reopener.py
@@ -80,20 +80,25 @@ class DetachedTabReopener:
         diagram = getattr(window, "diagram", None)
         diagram_id = getattr(window, "diagram_id", None)
         history = getattr(window, "diagram_history", None)
+        create_attempts: list[tuple[tuple, dict]] = []
         if diagram is not None:
-            return self._safe_create(cls, self.notebook, app, diagram)
+            create_attempts.append(((self.notebook, app, diagram), {}))
+            create_attempts.append(((self.notebook, diagram), {}))
         if diagram_id is not None:
-            return self._safe_create(
-                cls,
-                self.notebook,
-                app,
-                diagram_id=diagram_id,
-                history=history,
-            )
-        return self._safe_create(cls, self.notebook, app)
+            create_attempts.append(((self.notebook, app), {"diagram_id": diagram_id, "history": history}))
+            create_attempts.append(((self.notebook,), {"diagram_id": diagram_id, "history": history}))
+        create_attempts.extend([
+            ((self.notebook, app), {}),
+            ((self.notebook,), {}),
+        ])
+        for args, kwargs in create_attempts:
+            rebuilt = self._safe_create(cls, *args, **kwargs)
+            if rebuilt is not None:
+                return rebuilt
+        return None
 
-    def _safe_create(self, cls, container: tk.Widget, app, **kwargs) -> tk.Widget | None:
+    def _safe_create(self, cls, *args, **kwargs) -> tk.Widget | None:
         try:
-            return cls(container, app, **kwargs)
+            return cls(*args, **kwargs)
         except Exception:
             return None

--- a/tests/test_thread_manager.py
+++ b/tests/test_thread_manager.py
@@ -75,3 +75,18 @@ class TestThreadManager:
         assert any(
             "did not exit within" in record.message for record in caplog.records
         )
+
+    def test_check_threads_skips_restart_when_stop_requested(self) -> None:
+        stop_event = threading.Event()
+        runs = {"count": 0}
+
+        def worker() -> None:
+            runs["count"] += 1
+
+        manager = ThreadManager(interval=0.05)
+        thread = manager.register("stoppable", worker, stop_event=stop_event)
+        thread.join(timeout=1.0)
+        stop_event.set()
+        manager._check_threads()
+        assert runs["count"] == 1
+        manager.stop_all()

--- a/tools/thread_manager.py
+++ b/tools/thread_manager.py
@@ -130,6 +130,9 @@ class ThreadManager:
                 if not info.thread.is_alive():
                     if info.target is None:
                         continue
+                    if info.stop_event is not None and info.stop_event.is_set():
+                        self._threads.pop(name, None)
+                        continue
                     thread = threading.Thread(
                         target=info.target,
                         args=info.args,


### PR DESCRIPTION
### Motivation

- Undocked notebook tabs could open as empty windows because the detached-window reopener assumed a single constructor signature for diagram windows.  
- The thread monitor could restart worker threads late in shutdown when their `stop_event` had already been signalled, leading to instability or crashes after the app ran for some time.

### Description

- Improve `DetachedTabReopener._build_from_window` to attempt multiple safe constructor argument patterns when recreating diagram window classes so detached windows rebuild usable content instead of remaining empty.  
- Simplify `_safe_create` to accept variable args/kwargs and safely handle creation failures.  
- Harden `ThreadManager._check_threads` to skip restarting threads whose `stop_event` is set and remove them from the monitor, preventing late restart races.  
- Add a regression test `test_check_threads_skips_restart_when_stop_requested` to `tests/test_thread_manager.py` and update `HISTORY.md` with version `0.2.298` notes.

### Testing

- Ran `pytest -q tests/test_thread_manager.py tests/detachment/test_detachable_window.py`, which completed with `5 passed, 3 skipped`.
- Ran the repository-wide `pytest -q`; the suite exits non-zero due to many pre-existing unrelated failures in this environment (not caused by these changes).  
- Generated static metrics with `python tools/metrics_generator.py --output /tmp/metrics.json`, which produced valid JSON output (metrics generation succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7a0016958832792710bf0cb89b6e5)