### PR TITLE
Import WidgetTransferManager at module level and remove redundant runtime import

### DIFF
--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -35,8 +35,10 @@ import re
 from tkinter import ttk
 try:  # pragma: no cover - support direct module execution
     from .tk_utils import cancel_after_events
+    from .widget_transfer_manager import WidgetTransferManager
 except Exception:  # pragma: no cover - legacy path
     from tk_utils import cancel_after_events
+    from widget_transfer_manager import WidgetTransferManager
 
 logger = logging.getLogger(__name__)
 
@@ -1273,8 +1275,6 @@ class ClosableNotebook(ttk.Notebook):
 
         try:
             if self._should_transfer_legacy_tab(child):
-                from gui.utils.widget_transfer_manager import WidgetTransferManager
-
                 hosted_child = WidgetTransferManager().detach_tab(
                     self, str(child), target
                 )


### PR DESCRIPTION
### Motivation

- Ensure `WidgetTransferManager` is available without performing a runtime import inside the detachment flow and avoid repeated or late imports that can complicate module loading.

### Description

- Move the `WidgetTransferManager` import to the module-level `try/except` import block alongside `cancel_after_events` and remove the redundant in-method import in the tab detachment path, with no functional change to detachment logic.

### Testing

- Ran the project's automated test suite with `pytest -q`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53f6a0154083259fb44b46ff845723)