### PR TITLE
Restrict legacy widget transfer detachment

### DIFF
--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -1302,16 +1302,28 @@ class ClosableNotebook(ttk.Notebook):
         except Exception:
             return False
 
-    def _should_transfer_legacy_tab(self, child: tk.Widget) -> bool:
-        """Whether *child* explicitly requires legacy move-based detachment."""
+    def _legacy_transfer_dock(self, child: tk.Widget) -> t.Any | None:
+        """Return a validated dockable owner for legacy move-based detachment.
 
-        if getattr(child, "_use_widget_transfer_manager_detach", False):
-            return True
+        ``WidgetTransferManager.detach_tab`` moves an existing widget instead
+        of rebuilding it, so it is intentionally restricted to dockable legacy
+        tabs where the owner exposes a known-safe ``dock`` path.  Complex
+        application document tabs, including Item Definition tabs, should fall
+        through to the reconstruction/factory path.
+        """
+
         try:
             from gui.utils.dockable_diagram_window import DockableDiagramWindow as DDW
         except Exception:  # pragma: no cover - legacy direct imports
             from dockable_diagram_window import DockableDiagramWindow as DDW
-        return isinstance(getattr(child, "_dock_window", None), DDW)
+        dock = getattr(child, "_dock_window", None)
+        if not isinstance(dock, DDW):
+            return None
+        if getattr(dock, "content_frame", None) is not child:
+            return None
+        if not callable(getattr(dock, "dock", None)):
+            return None
+        return dock
 
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
         """Detach *tab_id* transactionally into a floating window."""
@@ -1350,6 +1362,7 @@ class ClosableNotebook(ttk.Notebook):
         win: tk.Toplevel | None = None
         target: ClosableNotebook | None = None
         hosted_child: tk.Widget | None = None
+        moved_legacy_child = False
 
         def _cleanup_failed_window() -> None:
             if win is not None:
@@ -1387,12 +1400,17 @@ class ClosableNotebook(ttk.Notebook):
 
             win.bind("<Destroy>", _forget_window, add="+")
 
-            hosted_child = self._build_detached_tab_content(child, target, title)
-            if hosted_child is None:
-                raise RuntimeError(f"No detached content builder for {child_path}")
-
-            target.add(hosted_child, text=title)
-            target.select(hosted_child)
+            if self._legacy_transfer_dock(child) is not None:
+                hosted_child = WidgetTransferManager().detach_tab(
+                    self, tab_id, target
+                )
+                moved_legacy_child = True
+            else:
+                hosted_child = self._build_detached_tab_content(child, target, title)
+                if hosted_child is None:
+                    raise RuntimeError(f"No detached content builder for {child_path}")
+                target.add(hosted_child, text=title)
+                target.select(hosted_child)
             hosted_child.update_idletasks()
             target.update_idletasks()
             win.update_idletasks()
@@ -1414,10 +1432,6 @@ class ClosableNotebook(ttk.Notebook):
                 raise RuntimeError(
                     f"Detached content {hosted_child} has no visible descendants or meaningful content"
                 )
-            if self._should_transfer_legacy_tab(child):
-                hosted_child = WidgetTransferManager().detach_tab(
-                    self, str(child), target
-                )
         except Exception as exc:
             _cleanup_failed_window()
             try:
@@ -1436,25 +1450,26 @@ class ClosableNotebook(ttk.Notebook):
             )
             return
 
-        try:
-            self.forget(tab_id)
-        except tk.TclError as exc:
-            _cleanup_failed_window()
+        if not moved_legacy_child:
             try:
-                self.select(tab_id)
-            except tk.TclError:
-                pass
-            logger.exception(
-                "Failed to mark detached tab after verification: title=%r "
-                "original_path=%s original_class=%s detach_metadata=%r exception=%r",
-                title,
-                child_path,
-                child_class,
-                detach_metadata,
-                exc,
-            )
-            return
-        self._safe_destroy(child)
+                self.forget(tab_id)
+            except tk.TclError as exc:
+                _cleanup_failed_window()
+                try:
+                    self.select(tab_id)
+                except tk.TclError:
+                    pass
+                logger.exception(
+                    "Failed to mark detached tab after verification: title=%r "
+                    "original_path=%s original_class=%s detach_metadata=%r exception=%r",
+                    title,
+                    child_path,
+                    child_class,
+                    detach_metadata,
+                    exc,
+                )
+                return
+            self._safe_destroy(child)
 
         ClosableNotebook._tab_hosts[hosted_child] = win
         try:

--- a/gui/utils/widget_transfer_manager.py
+++ b/gui/utils/widget_transfer_manager.py
@@ -34,7 +34,14 @@ if TYPE_CHECKING:  # pragma: no cover - type hints only
 
 
 class WidgetTransferManager:
-    """Move widgets between notebooks while preserving their state."""
+    """Legacy helper for moving known-safe widgets between notebooks.
+
+    ``detach_tab`` reparents an existing widget instead of rebuilding it.  That
+    is only safe for explicitly supported legacy/dockable widgets whose owners
+    know how to survive a notebook move.  Normal application document tabs
+    should use a reconstruction/factory based detach path instead so complex
+    widget state, callbacks, and ownership remain consistent.
+    """
 
     def detach_tab(
         self,
@@ -43,6 +50,10 @@ class WidgetTransferManager:
         target: "tk.Widget",
     ) -> tk.Widget:
         """Move *tab_id* from *source* notebook to *target* notebook.
+
+        This method is not the default document-tab detachment mechanism.  Use
+        it only when the caller has already validated that the widget is a
+        supported legacy/dockable tab that can safely be moved as-is.
 
         Parameters
         ----------


### PR DESCRIPTION
### Motivation
- Prevent `WidgetTransferManager.detach_tab` from being treated as the default detachment mechanism for complex document tabs and clarify that moving widgets in-place is only safe for known legacy/dockable widgets.
- Ensure complex application document tabs (e.g. Item Definition and similar) follow the reconstruction/factory-based detach path so ownership, callbacks and state are rebuilt correctly.

### Description
- Updated `gui/utils/widget_transfer_manager.py` docstring to mark `WidgetTransferManager.detach_tab` as a legacy, move-only helper and warn callers to only use it for validated move-safe widgets.
- Replaced the broad legacy predicate in `gui/utils/closable_notebook.py` with a new `_legacy_transfer_dock` helper that validates a `DockableDiagramWindow` owner (ensures `content_frame` is the child and that a callable `dock` path exists).
- Changed `_detach_tab` in `ClosableNotebook` to call `WidgetTransferManager.detach_tab` only when `_legacy_transfer_dock(child)` returns a validated dock owner; otherwise the code uses the reconstruction/factory detach path (`_build_detached_tab_content`) and only destroys the original tab when it was not moved by the legacy path.

### Testing
- Ran `python -m py_compile gui/utils/widget_transfer_manager.py gui/utils/closable_notebook.py` which succeeded.
- Ran `pytest -q tests/detachment/after_callbacks/test_dockable_detach_no_invalid_command.py tests/detachment/window/test_widget_transfer_manager_dockable.py` and the tests were executed but skipped due to the Tk display not being available (`4 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a540301d9888325b15d7f329845e876)