### PR TITLE
Restore Item Definition editor and remove background threads (no parallel execution)

### DIFF
--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -21,12 +21,9 @@ from __future__ import annotations
 import math
 import sys
 import json
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 import tkinter as tk
 import os, sys
-import threading
-import time
 base = os.path.dirname(__file__)
 if base not in sys.path:
     sys.path.append(base)
@@ -110,8 +107,7 @@ from mainappsrc.models.sysml.sysml_repository import SysMLRepository
 from ..managers.undo_manager import UndoRedoManager
 from analysis.scenario_description import template_phrases
 from mainappsrc.ui.app_lifecycle_ui import AppLifecycleUI
-from tools.crash_report_logger import install_best, watchdog_best
-from tools.thread_manager import manager as thread_manager
+from tools.crash_report_logger import install_best
 from gui.styles.editing_labels_styling import Editing_Labels_Styling
 import copy
 import tkinter.font as tkFont
@@ -3093,11 +3089,11 @@ class AutoMLApp(
 
 
 def load_user_data() -> tuple[dict, tuple[str, str]]:
-    """Load cached users and last user config concurrently."""
-    with ThreadPoolExecutor() as executor:
-        users_future = executor.submit(user_config_service.load_all_users)
-        config_future = executor.submit(user_config_service.load_user_config)
-        return users_future.result(), config_future.result()
+    """Load cached users and last user config sequentially on the main thread."""
+
+    users = user_config_service.load_all_users()
+    config = user_config_service.load_user_config()
+    return users, config
 
 
 def _shutdown_root(root: tk.Misc) -> None:
@@ -3152,29 +3148,9 @@ def _launch_app() -> None:
         _shutdown_root(root)
 
 
-def _watchdog_feeder(wd, stop_event, interval: float = 1.0) -> None:
-    while not stop_event.is_set():
-        time.sleep(interval)
-        try:
-            wd.feed()
-        except Exception:
-            break
-
-
 def main() -> None:
     install_best()
-    wd = watchdog_best(10.0)
-    stop_event = threading.Event()
-    thread_manager.register(
-        "watchdog",
-        _watchdog_feeder,
-        args=(wd, stop_event),
-        stop_event=stop_event,
-    )
-    try:
-        _launch_app()
-    finally:
-        thread_manager.stop_all()
+    _launch_app()
 
 if __name__ == "__main__":
     main()

--- a/mainappsrc/core/editors.py
+++ b/mainappsrc/core/editors.py
@@ -65,32 +65,32 @@ class Editors:
     # ------------------------------------------------------------------
     # Item definition
     # ------------------------------------------------------------------
-    def _build_item_definition_editor(
-        self, parent: tk.Widget
-    ) -> tk.Widget:  # pragma: no cover - UI code
-        """Build the item definition editor inside *parent*.
-
-        The returned widget owns its text fields and save callback so detached
-        copies can save their own contents without depending on the singleton
-        text-widget attributes used by the docked/original tab.
-        """
+    def show_item_definition_editor(self):  # pragma: no cover - UI code
+        """Open the docked Item Definition editor tab."""
 
         app = self.app
-        """Open editor for item description and assumptions."""
         if hasattr(app, "_item_def_tab") and app._item_def_tab.winfo_exists():
             app.doc_nb.select(app._item_def_tab)
-            return
+            return app._item_def_tab
         app._item_def_tab = app.lifecycle_ui._new_tab("Item Definition")
         app._item_def_tab._detach_factory = self._build_item_definition_editor
         self._build_item_definition_editor(app._item_def_tab)
+        return app._item_def_tab
 
     def _build_item_definition_editor(self, parent: tk.Widget) -> tk.Widget:
-        """Build the item definition form in *parent* for docked or detached tabs."""
+        """Build the item definition form in *parent*.
+
+        Detached tab windows pass a notebook as *parent*.  In that case, build
+        the editor inside a child frame so the caller can insert the populated
+        frame into the detached notebook instead of inserting the notebook into
+        itself.
+        """
 
         app = self.app
-        container = parent
+        container: tk.Widget = parent
         if isinstance(parent, ttk.Notebook):
             container = ttk.Frame(parent)
+
         ttk.Label(container, text="Item Description:").pack(anchor="w")
         desc_text = tk.Text(container, height=8, wrap="word")
         desc_text.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)

--- a/mainappsrc/services/service_loader.py
+++ b/mainappsrc/services/service_loader.py
@@ -26,12 +26,10 @@ context manager automates this pattern.
 
 from __future__ import annotations
 
-import threading
 from contextlib import contextmanager
 from typing import Any
 
 from tools.memory_manager import manager as memory_manager
-from tools.thread_manager import manager as thread_manager
 from mainappsrc import services
 
 
@@ -41,20 +39,9 @@ class LazyServiceRegistry:
     def __init__(self, app: Any, interval: float = 60.0) -> None:
         self._app = app
         self._interval = interval
-        self._stop = threading.Event()
-        self._name = f"service_registry_{id(self)}"
-        thread_manager.register(self._name, self._monitor, daemon=True)
-
-    def _monitor(self) -> None:
-        while not self._stop.is_set():
-            self._stop.wait(self._interval)
-            memory_manager.cleanup()
 
     def shutdown(self) -> None:
-        self._stop.set()
-        thread = thread_manager.unregister(self._name)
-        if thread:
-            thread.join()
+        memory_manager.cleanup()
 
     def get(self, name: str) -> Any:
         """Return service *name*, creating it if necessary."""

--- a/tests/test_user_data_threading.py
+++ b/tests/test_user_data_threading.py
@@ -16,30 +16,29 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import time
-
 import importlib
 
 
-# Import AutoML module for testing
-automl = importlib.import_module("mainappsrc.automl_core")
+# Import AutoML module for testing.
+automl = importlib.import_module("mainappsrc.core.automl_core")
 
 
-def test_load_user_data_parallel(monkeypatch):
+def test_load_user_data_is_sequential(monkeypatch):
+    calls: list[str] = []
+
     def fake_load_all_users():
-        time.sleep(0.2)
+        calls.append("users")
         return {"u": "e"}
 
     def fake_load_user_config():
-        time.sleep(0.2)
+        calls.append("config")
         return "name", "email"
 
-    monkeypatch.setattr(automl, "load_all_users", fake_load_all_users)
-    monkeypatch.setattr(automl, "load_user_config", fake_load_user_config)
+    monkeypatch.setattr(automl.user_config_service, "load_all_users", fake_load_all_users)
+    monkeypatch.setattr(automl.user_config_service, "load_user_config", fake_load_user_config)
 
-    start = time.time()
     users, config = automl.load_user_data()
-    elapsed = time.time() - start
+
     assert users == {"u": "e"}
     assert config == ("name", "email")
-    assert elapsed < 0.35
+    assert calls == ["users", "config"]

--- a/tools/memory_manager.py
+++ b/tools/memory_manager.py
@@ -30,14 +30,8 @@ import atexit
 import ctypes
 import gc
 import importlib
-import os
 import sys
-import threading
-from threading import current_thread, main_thread
-import time
 from typing import Any, Callable, Dict, Set
-
-from .thread_manager import manager as thread_manager
 
 try:  # pragma: no cover - optional dependency
     import psutil
@@ -46,11 +40,9 @@ except Exception:  # pragma: no cover - psutil may not be installed
 
 
 def _destroy_if_safe(obj: Any) -> None:
-    """Destroy Tk objects only from the main thread to avoid Tcl async crashes."""
+    """Destroy Tk objects from the sequential cleanup path."""
     destroy = getattr(obj, "destroy", None)
     if not callable(destroy):
-        return
-    if getattr(obj, "tk", None) is not None and current_thread() is not main_thread():
         return
     try:
         destroy()
@@ -63,104 +55,84 @@ class MemoryManager:
 
     Objects are loaded on demand via :meth:`lazy_load`.  Keys can be marked as
     active with :meth:`mark_active`; any remaining cached objects and processes
-    are discarded by :meth:`cleanup`.  A background thread periodically checks
-    memory pressure and invokes :meth:`cleanup` to free unused resources.
+    are discarded by explicit :meth:`cleanup` calls on the caller's thread.
     """
 
     def __init__(self, interval: float = 60.0, max_usage_percent: float = 70.0) -> None:
         self._cache: Dict[str, Any] = {}
         self._active: Set[str] = set()
         self._procs: Dict[str, Any] = {}
-        self._lock = threading.Lock()
         self._interval = interval
         self._max_usage = max_usage_percent
-        self._stop_event = threading.Event()
-        disable_thread = os.getenv("AUTOML_DISABLE_MEMORY_MANAGER", "").lower() in {
-            "1",
-            "true",
-            "yes",
-        }
-        self._thread = None
-        if not disable_thread:
-            self._thread = thread_manager.register(
-                "memory_manager",
-                self._monitor,
-                daemon=True,
-                stop_event=self._stop_event,
-            )
+        # Cleanup is intentionally caller-driven and sequential.
 
     def lazy_load(self, key: str, loader: Callable[[], Any]) -> Any:
         """Return cached object for *key*, loading it if necessary."""
-        with self._lock:
-            if key not in self._cache:
-                self._cache[key] = loader()
-            self._active.add(key)
-            return self._cache[key]
+        if key not in self._cache:
+            self._cache[key] = loader()
+        self._active.add(key)
+        return self._cache[key]
 
     def mark_active(self, key: str) -> None:
         """Mark *key* as currently needed."""
-        with self._lock:
-            self._active.add(key)
+        self._active.add(key)
 
     def register_process(self, key: str, proc: Any) -> None:
         """Register a subprocess keyed by *key* for later cleanup."""
         if psutil is not None and not isinstance(proc, psutil.Process):
             proc = psutil.Process(proc.pid)
-        with self._lock:
-            self._procs[key] = proc
-            self._active.add(key)
+        self._procs[key] = proc
+        self._active.add(key)
 
     def discard_prefix(self, prefix: str) -> None:
         """Remove cached entries and processes starting with *prefix*."""
-        with self._lock:
-            keys = [k for k in self._cache if k.startswith(prefix)]
-            for key in keys:
-                obj = self._cache.pop(key, None)
-                if obj is not None:
-                    _destroy_if_safe(obj)
-                    del obj
-            proc_keys = [k for k in self._procs if k.startswith(prefix)]
-            for key in proc_keys:
-                proc = self._procs.pop(key, None)
-                if proc is not None:
-                    try:
-                        if psutil is not None:
-                            if proc.is_running():
-                                proc.terminate()
-                                proc.wait(timeout=1)
-                        else:
+        keys = [k for k in self._cache if k.startswith(prefix)]
+        for key in keys:
+            obj = self._cache.pop(key, None)
+            if obj is not None:
+                _destroy_if_safe(obj)
+                del obj
+        proc_keys = [k for k in self._procs if k.startswith(prefix)]
+        for key in proc_keys:
+            proc = self._procs.pop(key, None)
+            if proc is not None:
+                try:
+                    if psutil is not None:
+                        if proc.is_running():
                             proc.terminate()
-                            proc.wait(1)
-                    except Exception:
-                        pass
-            self._active = {k for k in self._active if not k.startswith(prefix)}
+                            proc.wait(timeout=1)
+                    else:
+                        proc.terminate()
+                        proc.wait(1)
+                except Exception:
+                    pass
+        self._active = {k for k in self._active if not k.startswith(prefix)}
         self._trim_memory()
 
     def cleanup(self) -> None:
         """Drop inactive cached objects and terminate unused processes."""
-        with self._lock:
-            inactive = set(self._cache) - self._active
-            for key in inactive:
-                obj = self._cache.pop(key, None)
-                if obj is not None:
-                    _destroy_if_safe(obj)
-                    del obj
+        inactive = set(self._cache) - self._active
+        for key in inactive:
+            obj = self._cache.pop(key, None)
+            if obj is not None:
+                _destroy_if_safe(obj)
+                del obj
 
-            for key, proc in list(self._procs.items()):
-                if key not in self._active:
-                    try:
-                        if psutil is not None:
-                            if proc.is_running():
-                                proc.terminate()
-                                proc.wait(timeout=1)
-                        else:
+        for key, proc in list(self._procs.items()):
+            if key not in self._active:
+                try:
+                    if psutil is not None:
+                        if proc.is_running():
                             proc.terminate()
-                            proc.wait(1)
-                    except Exception:
-                        pass
-                    finally:
-                        self._procs.pop(key, None)
-            self._active.clear()
+                            proc.wait(timeout=1)
+                    else:
+                        proc.terminate()
+                        proc.wait(1)
+                except Exception:
+                    pass
+                finally:
+                    self._procs.pop(key, None)
+        self._active.clear()
         self._trim_memory()
 
     def _memory_percent(self) -> float:
@@ -179,19 +151,9 @@ class MemoryManager:
             except Exception:  # pragma: no cover - optional
                 pass
 
-    def _monitor(self) -> None:
-        """Background thread monitoring memory usage."""
-        while not self._stop_event.is_set():
-            time.sleep(self._interval)
-            if self._memory_percent() > self._max_usage:
-                self.cleanup()
-
     def shutdown(self) -> None:
-        """Stop the monitoring thread."""
-        self._stop_event.set()
-        thread = thread_manager.unregister("memory_manager") if self._thread else None
-        if thread and thread.is_alive():
-            thread.join(timeout=1)
+        """Clean up inactive resources without starting or joining threads."""
+        self.cleanup()
 
 
 def lazy_import(name: str) -> Any:


### PR DESCRIPTION
### Motivation
- Fix a crash on double-click navigation by restoring the missing Item Definition editor entry point and ensure detached windows are rebuilt with visible content.
- Remove background worker threads and any parallel startup logic so all cleanup and user-data loading run sequentially on the main thread.
- Prevent Tcl async deletion issues by avoiding cross-thread Tk operations and removing automatic thread registrations for cleanup.

### Description
- Restored `show_item_definition_editor()` and adjusted the builder ` _build_item_definition_editor(parent)` to return a populated child frame when `parent` is a `ttk.Notebook`, fixing blank detached windows (`mainappsrc/core/editors.py`).
- Changed `load_user_data()` to call `user_config_service.load_all_users()` and `user_config_service.load_user_config()` sequentially on the main thread instead of using `ThreadPoolExecutor` (`mainappsrc/core/automl_core.py`).
- Removed watchdog feeder background registration and now launch the app directly from `main()` without registering threads that run background feeders (`mainappsrc/core/automl_core.py`).
- Disabled the service-registry monitor thread and made `LazyServiceRegistry.shutdown()` perform a synchronous cleanup call (`mainappsrc/services/service_loader.py`).
- Converted `tools/memory_manager.MemoryManager` to a caller-driven, sequential cleanup design (no background monitor thread, no locks/joins used for threads, safe synchronous cleanup) and adjusted `shutdown()` to call `cleanup()` synchronously (`tools/memory_manager.py`).
- Updated the test to assert sequential execution and adjusted import path for the automl module used in the test (`tests/test_user_data_threading.py`).

### Testing
- Ran a compile check: `python -m compileall mainappsrc/core/editors.py mainappsrc/core/automl_core.py mainappsrc/services/service_loader.py tools/memory_manager.py tests/test_user_data_threading.py` (succeeded).
- Ran targeted tests: `PYTHONPATH=. pytest -q tests/test_user_data_threading.py tests/detachment/test_item_definition_detach.py tests/services/test_lazy_service_registry.py` which completed with `2 passed, 2 skipped`.
- Also ran the detachment and lazy-registry subset previously which completed (tests passed/skipped as above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54074eefd4832590a08fedaf3b8bf5)