### PR TITLE
Enable detachable/resizable tabs, remove background service threads, and simplify startup loading

### DIFF
--- a/gui/controls/window_controllers.py
+++ b/gui/controls/window_controllers.py
@@ -91,18 +91,29 @@ class WindowControllers:
             self.app.diagram_tabs.pop(diag.diag_id, None)
         tab = self.app._new_tab(self.app._format_diag_title(diag))
         self.app.diagram_tabs[diag.diag_id] = tab
-        if diag.diag_type == "Use Case Diagram":
-            UseCaseDiagramWindow(tab, self.app, diagram_id=diag.diag_id)
-        elif diag.diag_type == "Activity Diagram":
-            ActivityDiagramWindow(tab, self.app, diagram_id=diag.diag_id)
-        elif diag.diag_type == "Governance Diagram":
-            GovernanceDiagramWindow(tab, self.app, diagram_id=diag.diag_id)
-        elif diag.diag_type == "Block Diagram":
-            BlockDiagramWindow(tab, self.app, diagram_id=diag.diag_id)
-        elif diag.diag_type == "Internal Block Diagram":
-            InternalBlockDiagramWindow(tab, self.app, diagram_id=diag.diag_id)
-        elif diag.diag_type == "Control Flow Diagram":
-            ControlFlowDiagramWindow(tab, self.app, diagram_id=diag.diag_id)
+
+        def _build_architecture_tab(parent, _title=None):
+            container = parent
+            if isinstance(parent, ttk.Notebook):
+                container = ttk.Frame(parent)
+            self.app.diagram_tabs[diag.diag_id] = container
+            if diag.diag_type == "Use Case Diagram":
+                UseCaseDiagramWindow(container, self.app, diagram_id=diag.diag_id)
+            elif diag.diag_type == "Activity Diagram":
+                ActivityDiagramWindow(container, self.app, diagram_id=diag.diag_id)
+            elif diag.diag_type == "Governance Diagram":
+                GovernanceDiagramWindow(container, self.app, diagram_id=diag.diag_id)
+            elif diag.diag_type == "Block Diagram":
+                BlockDiagramWindow(container, self.app, diagram_id=diag.diag_id)
+            elif diag.diag_type == "Internal Block Diagram":
+                InternalBlockDiagramWindow(container, self.app, diagram_id=diag.diag_id)
+            elif diag.diag_type == "Control Flow Diagram":
+                ControlFlowDiagramWindow(container, self.app, diagram_id=diag.diag_id)
+            container._detach_factory = _build_architecture_tab
+            return container
+
+        tab._detach_factory = _build_architecture_tab
+        _build_architecture_tab(tab)
         self.app.refresh_all()
 
     def open_page_diagram(self, node, push_history: bool = True) -> None:

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -36,9 +36,11 @@ from tkinter import ttk
 try:  # pragma: no cover - support direct module execution
     from .tk_utils import cancel_after_events
     from .widget_transfer_manager import WidgetTransferManager
+    from .window_resizer import WindowResizeController
 except Exception:  # pragma: no cover - legacy path
     from tk_utils import cancel_after_events
     from widget_transfer_manager import WidgetTransferManager
+    from window_resizer import WindowResizeController
 
 logger = logging.getLogger(__name__)
 
@@ -1357,7 +1359,7 @@ class ClosableNotebook(ttk.Notebook):
         return dock
 
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
-        """Detach *tab_id* transactionally into a floating window."""
+        """Detach *tab_id* transactionally into a resizable floating window."""
 
         try:
             if isinstance(tab_id, int):
@@ -1368,6 +1370,7 @@ class ClosableNotebook(ttk.Notebook):
         try:
             child = self.nametowidget(tab_id)
             title = self.tab(tab_id, "text") or "Detached"
+            original_index = self.index(tab_id)
         except tk.TclError:
             return
 
@@ -1377,11 +1380,6 @@ class ClosableNotebook(ttk.Notebook):
         except tk.TclError:
             child_class = type(child).__name__
         detach_metadata = self._detach_debug_metadata(child)
-
-        try:
-            self.select(tab_id)
-        except tk.TclError:
-            pass
 
         root = self._app_root
         try:
@@ -1393,9 +1391,11 @@ class ClosableNotebook(ttk.Notebook):
         win: tk.Toplevel | None = None
         target: ClosableNotebook | None = None
         hosted_child: tk.Widget | None = None
-        moved_legacy_child = False
+        resizer: WindowResizeController | None = None
 
         def _cleanup_failed_window() -> None:
+            if resizer is not None:
+                resizer.shutdown()
             if win is not None:
                 if win in self._floating_windows:
                     self._floating_windows.remove(win)
@@ -1411,45 +1411,106 @@ class ClosableNotebook(ttk.Notebook):
                 ClosableNotebook._tab_hosts.pop(hosted_child, None)
             ClosableNotebook._tab_hosts.pop(child, None)
 
+        def _track_resize_targets(widget: tk.Widget) -> None:
+            if resizer is None:
+                return
+            resizer.add_target(widget)
+            pending = [widget]
+            visited: set[tk.Widget] = set()
+            while pending:
+                current = pending.pop()
+                if current in visited:
+                    continue
+                visited.add(current)
+                resizer.add_target(current)
+                try:
+                    pending.extend(current.winfo_children())
+                except Exception:
+                    pass
+
+        def _dock_back() -> None:
+            nonlocal hosted_child
+            if win is None or target is None or hosted_child is None:
+                return
+            try:
+                title_now = target.tab(hosted_child, "text") or title
+            except tk.TclError:
+                title_now = title
+            builder_source = hosted_child
+            try:
+                target.forget(hosted_child)
+            except tk.TclError:
+                pass
+            rebuilt = self._build_detached_tab_content(builder_source, self, title_now)
+            if rebuilt is None:
+                rebuilt = ttk.Frame(self)
+            try:
+                self.insert(original_index, rebuilt, text=title_now)
+            except tk.TclError:
+                self.add(rebuilt, text=title_now)
+            try:
+                self.select(rebuilt)
+            except tk.TclError:
+                pass
+            ClosableNotebook._tab_hosts.pop(hosted_child, None)
+            hosted_child = None
+            if resizer is not None:
+                resizer.shutdown()
+            if win in self._floating_windows:
+                self._floating_windows.remove(win)
+            try:
+                self._cancel_after_events(win)
+            except Exception:
+                pass
+            try:
+                win.destroy()
+            except tk.TclError:
+                pass
+
         try:
+            win = tk.Toplevel(root)
+            win.withdraw()
+            win.title(title)
+            win.geometry("1200x700")
+            win.minsize(700, 450)
+            win.protocol("WM_DELETE_WINDOW", _dock_back)
+
+            toolbar = ttk.Frame(win)
+            toolbar.pack(side=tk.TOP, fill=tk.X)
+            ttk.Label(toolbar, text=title).pack(side=tk.LEFT, padx=8, pady=4)
+            dock_btn = ttk.Button(toolbar, text="Dock", command=_dock_back, width=10)
+            dock_btn._fixed_size = True
+            dock_btn.pack(side=tk.RIGHT, padx=4, pady=2)
+
+            target = ClosableNotebook(win)
+            target.pack(fill=tk.BOTH, expand=True)
+            resizer = WindowResizeController(win, target)
+
             if self._should_transfer_legacy_tab(child):
-                hosted_child = WidgetTransferManager().detach_tab(
-                    self, tab_id, target
-                )
-                moved_legacy_child = True
+                hosted_child = WidgetTransferManager().detach_tab(self, tab_id, target)
             else:
                 hosted_child = self._build_detached_tab_content(child, target, title)
                 if hosted_child is None:
                     raise RuntimeError(f"No detached content builder for {child_path}")
                 target.add(hosted_child, text=title)
                 target.select(hosted_child)
-                win.update_idletasks()
-                target.update_idletasks()
-                hosted_child.update_idletasks()
-                if not self._detached_content_visible(hosted_child):
-                    raise RuntimeError(f"Detached content for {title!r} is blank")
-                try:
-                    self._cancel_after_events(child)
-                except Exception:
-                    pass
-                self.forget(tab_id)
-                self._safe_destroy(child)
-        except Exception as exc:
-            _forget_window()
-            try:
-                selected_widget = target.nametowidget(selected)
-            except Exception as exc:
-                raise RuntimeError(
-                    f"Detached notebook selected unknown tab {selected!r}"
-                ) from exc
-            if selected_widget is not hosted_child:
-                raise RuntimeError(
-                    f"Detached notebook selected {selected_widget}, expected {hosted_child}"
-                )
+
+            win.update_idletasks()
+            target.update_idletasks()
+            hosted_child.update_idletasks()
             if not self._detached_content_visible(hosted_child):
-                raise RuntimeError(
-                    f"Detached content {hosted_child} has no visible descendants or meaningful content"
-                )
+                raise RuntimeError(f"Detached content for {title!r} is blank")
+
+            _track_resize_targets(hosted_child)
+            resizer.sync_to_host()
+            try:
+                self._cancel_after_events(child)
+            except Exception:
+                pass
+            if str(tab_id) in self.tabs():
+                self.forget(tab_id)
+            if hosted_child is not child:
+                self._safe_destroy(child)
         except Exception as exc:
             _cleanup_failed_window()
             try:
@@ -1468,28 +1529,8 @@ class ClosableNotebook(ttk.Notebook):
             )
             return
 
-        if not moved_legacy_child:
-            try:
-                self.forget(tab_id)
-            except tk.TclError as exc:
-                _cleanup_failed_window()
-                try:
-                    self.select(tab_id)
-                except tk.TclError:
-                    pass
-                logger.exception(
-                    "Failed to mark detached tab after verification: title=%r "
-                    "original_path=%s original_class=%s detach_metadata=%r exception=%r",
-                    title,
-                    child_path,
-                    child_class,
-                    detach_metadata,
-                    exc,
-                )
-                return
-            self._safe_destroy(child)
-
         ClosableNotebook._tab_hosts[hosted_child] = win
+        self._floating_windows.append(win)
         try:
             win.deiconify()
             win.lift()

--- a/gui/utils/window_resizer.py
+++ b/gui/utils/window_resizer.py
@@ -280,6 +280,8 @@ class WindowResizeController:
         return True
 
     def _apply_resize(self, widget: tk.Widget, width: int, height: int) -> None:
+        if self._is_fixed_size_widget(widget):
+            return
         if self._should_configure_dimension(widget):
             self._configure_dimension(widget, "width", width)
             self._configure_dimension(widget, "height", height)
@@ -299,8 +301,13 @@ class WindowResizeController:
         except Exception:
             pass
 
+    def _is_fixed_size_widget(self, widget: tk.Widget) -> bool:
+        return bool(getattr(widget, "_fixed_size", False)) or type(widget).__name__ == "CapsuleButton"
+
     def _should_configure_dimension(self, widget: tk.Widget) -> bool:
         if widget is self.win:
+            return False
+        if self._is_fixed_size_widget(widget):
             return False
         if isinstance(widget, (tk.Tk, tk.Toplevel)):
             return False
@@ -311,6 +318,8 @@ class WindowResizeController:
     def _ensure_geometry(self, widget: tk.Widget) -> None:
         manager = self._manager(widget)
         if manager == "pack":
+            if widget is not self._primary:
+                return
             try:
                 widget.pack_configure(expand=True, fill="both")
             except Exception:

--- a/gui/windows/architecture.py
+++ b/gui/windows/architecture.py
@@ -3722,6 +3722,7 @@ class SysMLDiagramWindow(tk.Frame):
         else:
             diagram = self.repo.create_diagram(title, name=title, diag_id=diagram_id)
         self.diagram_id = diagram.diag_id
+        self._install_detach_factory(master)
 
         relation_tools = list(relation_tools or [])
         self.relation_tools = relation_tools
@@ -3956,6 +3957,34 @@ class SysMLDiagramWindow(tk.Frame):
         self.update_property_view()
         if not isinstance(self.master, tk.Toplevel):
             self.pack(fill=tk.BOTH, expand=True)
+
+
+    def _install_detach_factory(self, host: tk.Widget) -> None:
+        if isinstance(host, tk.Toplevel):
+            return
+
+        def _build_detached_architecture(parent, _title=None):
+            container = parent
+            if isinstance(parent, ttk.Notebook):
+                container = ttk.Frame(parent)
+            if self.app is not None:
+                try:
+                    self.app.diagram_tabs[self.diagram_id] = container
+                except Exception:
+                    pass
+            self.__class__(
+                container,
+                self.app,
+                diagram_id=self.diagram_id,
+                history=list(getattr(self, "diagram_history", [])),
+            )
+            container._detach_factory = _build_detached_architecture
+            return container
+
+        try:
+            host._detach_factory = _build_detached_architecture
+        except Exception:
+            pass
 
     def _on_focus_in(self, event=None):
         if self.app:
@@ -12237,6 +12266,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                     fr.destroy()
         self._toolbox_frames = {}
         self._frame_loaders: dict[str, Callable[[], object]] = {}
+        self._loaded_toolbox_frames: dict[str, object] = {}
         if hasattr(self.toolbox, "tk"):
             action_frame = ttk.Frame(self.toolbox)
             cmds = [
@@ -12361,35 +12391,37 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         self.toolbox_selector.configure(values=options)
         current = self.toolbox_var.get()
         if current not in options:
-            self.toolbox_var.set(options[0] if options else "")
-        # Defer the initial toolbox switch until the GUI event loop runs to
-        # avoid missing related element frames on first display.
-        if hasattr(self.toolbox, "after"):
-            self.toolbox.after(0, self._switch_toolbox)
-        else:  # pragma: no cover - non-tkinter fallback
-            self._switch_toolbox()
+            preferred = next(
+                (name for name in options if name not in {"Governance Core", "Safety & AI Lifecycle"}),
+                options[0] if options else "",
+            )
+            self.toolbox_var.set(preferred)
+        self._switch_toolbox()
+        self._schedule_toolbox_preload()
+
+    def _ensure_toolbox_frame(self, choice: str):
+        loaded = getattr(self, "_loaded_toolbox_frames", {})
+        if choice in loaded:
+            return loaded[choice]
+        loader = getattr(self, "_frame_loaders", {}).get(choice)
+        if not loader:
+            return None
+        frame = loader()
+        loaded[choice] = frame
+        self._loaded_toolbox_frames = loaded
+        frames = self._toolbox_frames.setdefault(choice, [])
+        if frame not in frames:
+            frames.append(frame)
+        return frame
 
     def _switch_toolbox(self) -> None:
         choice = self.toolbox_var.get()
-        self._cancel_toolbox_heartbeat()
         for frames in self._toolbox_frames.values():
             for frame in frames:
                 if frame and hasattr(frame, "pack_forget"):
                     frame.pack_forget()
+        self._ensure_toolbox_frame(choice)
         frames = self._toolbox_frames.setdefault(choice, [])
-        diag_id = getattr(self, "diagram_id", "0")
-        prefix = getattr(self, "_toolbox_prefix", f"{diag_id}:{id(self)}:toolbox:")
-        self._toolbox_prefix = prefix
-        key = f"{prefix}{choice}"
-        loader = getattr(self, "_frame_loaders", {}).get(choice)
-        if loader:
-            frame = memory_manager.lazy_load(key, loader)
-            if frame not in frames:
-                frames.append(frame)
-        else:
-            memory_manager.mark_active(key)
-        self._active_toolbox_key = key
-        self._schedule_toolbox_heartbeat()
         frames[:] = [
             f
             for f in frames
@@ -12398,6 +12430,27 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         for frame in frames:
             if frame and hasattr(frame, "pack"):
                 frame.pack(fill=tk.X, padx=2, pady=2)
+
+    def _schedule_toolbox_preload(self) -> None:
+        choices = [
+            choice
+            for choice in getattr(self, "_frame_loaders", {})
+            if choice not in getattr(self, "_loaded_toolbox_frames", {})
+        ]
+
+        def _load_next() -> None:
+            if not choices:
+                return
+            self._ensure_toolbox_frame(choices.pop(0))
+            if choices and hasattr(self.toolbox, "after"):
+                self.toolbox.after(1, _load_next)
+            elif choices:
+                _load_next()
+
+        if choices and hasattr(self.toolbox, "after"):
+            self.toolbox.after(1, _load_next)
+        elif choices:
+            _load_next()
 
     def _cancel_toolbox_heartbeat(self) -> None:
         timer = getattr(self, "_toolbox_active_timer", None)
@@ -12409,17 +12462,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         self._toolbox_active_timer = None
 
     def _schedule_toolbox_heartbeat(self) -> None:
-        key = getattr(self, "_active_toolbox_key", "")
-        if not key:
-            return
-        memory_manager.mark_active(key)
-        if hasattr(self.toolbox, "after"):
-            try:
-                self._toolbox_active_timer = self.toolbox.after(
-                    15000, self._schedule_toolbox_heartbeat
-                )
-            except Exception:  # pragma: no cover - safety for fake toolboxes
-                self._toolbox_active_timer = None
+        return
 
     class _SelectDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
         def __init__(self, parent, title: str, options: list[str]):

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -21,12 +21,9 @@ from __future__ import annotations
 import math
 import sys
 import json
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 import tkinter as tk
 import os, sys
-import threading
-import time
 base = os.path.dirname(__file__)
 if base not in sys.path:
     sys.path.append(base)
@@ -110,8 +107,7 @@ from mainappsrc.models.sysml.sysml_repository import SysMLRepository
 from ..managers.undo_manager import UndoRedoManager
 from analysis.scenario_description import template_phrases
 from mainappsrc.ui.app_lifecycle_ui import AppLifecycleUI
-from tools.crash_report_logger import install_best, watchdog_best
-from tools.thread_manager import manager as thread_manager
+from tools.crash_report_logger import install_best
 from gui.styles.editing_labels_styling import Editing_Labels_Styling
 import copy
 import tkinter.font as tkFont
@@ -3093,11 +3089,11 @@ class AutoMLApp(
 
 
 def load_user_data() -> tuple[dict, tuple[str, str]]:
-    """Load cached users and last user config concurrently."""
-    with ThreadPoolExecutor() as executor:
-        users_future = executor.submit(user_config_service.load_all_users)
-        config_future = executor.submit(user_config_service.load_user_config)
-        return users_future.result(), config_future.result()
+    """Load cached users and last user config sequentially on the main thread."""
+
+    users = user_config_service.load_all_users()
+    config = user_config_service.load_user_config()
+    return users, config
 
 
 def _shutdown_root(root: tk.Misc) -> None:
@@ -3152,29 +3148,9 @@ def _launch_app() -> None:
         _shutdown_root(root)
 
 
-def _watchdog_feeder(wd, stop_event, interval: float = 1.0) -> None:
-    while not stop_event.is_set():
-        time.sleep(interval)
-        try:
-            wd.feed()
-        except Exception:
-            break
-
-
 def main() -> None:
     install_best()
-    wd = watchdog_best(10.0)
-    stop_event = threading.Event()
-    thread_manager.register(
-        "watchdog",
-        _watchdog_feeder,
-        args=(wd, stop_event),
-        stop_event=stop_event,
-    )
-    try:
-        _launch_app()
-    finally:
-        thread_manager.stop_all()
+    _launch_app()
 
 if __name__ == "__main__":
     main()

--- a/mainappsrc/core/editors.py
+++ b/mainappsrc/core/editors.py
@@ -65,38 +65,42 @@ class Editors:
     # ------------------------------------------------------------------
     # Item definition
     # ------------------------------------------------------------------
-    def _build_item_definition_editor(
-        self, parent: tk.Widget
-    ) -> tk.Widget:  # pragma: no cover - UI code
-        """Build the item definition editor inside *parent*.
-
-        The returned widget owns its text fields and save callback so detached
-        copies can save their own contents without depending on the singleton
-        text-widget attributes used by the docked/original tab.
-        """
+    def show_item_definition_editor(self):  # pragma: no cover - UI code
+        """Open the docked Item Definition editor tab."""
 
         app = self.app
-        """Open editor for item description and assumptions."""
         if hasattr(app, "_item_def_tab") and app._item_def_tab.winfo_exists():
             app.doc_nb.select(app._item_def_tab)
-            return
+            return app._item_def_tab
         app._item_def_tab = app.lifecycle_ui._new_tab("Item Definition")
         app._item_def_tab._detach_factory = self._build_item_definition_editor
         self._build_item_definition_editor(app._item_def_tab)
+        return app._item_def_tab
 
     def _build_item_definition_editor(self, parent: tk.Widget) -> tk.Widget:
-        """Build the item definition form in *parent* for docked or detached tabs."""
+        """Build the item definition form in *parent*.
+
+        Detached tab windows pass a notebook as *parent*.  In that case, build
+        the editor inside a child frame so the caller can insert the populated
+        frame into the detached notebook instead of inserting the notebook into
+        itself.
+        """
 
         app = self.app
-        container = parent
+        container: tk.Widget = parent
         if isinstance(parent, ttk.Notebook):
             container = ttk.Frame(parent)
-        ttk.Label(container, text="Item Description:").pack(anchor="w")
+
+        container.grid_rowconfigure(1, weight=1)
+        container.grid_rowconfigure(3, weight=1)
+        container.grid_columnconfigure(0, weight=1)
+
+        ttk.Label(container, text="Item Description:").grid(row=0, column=0, sticky="w")
         desc_text = tk.Text(container, height=8, wrap="word")
-        desc_text.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
-        ttk.Label(container, text="Assumptions:").pack(anchor="w")
+        desc_text.grid(row=1, column=0, sticky="nsew", padx=5, pady=5)
+        ttk.Label(container, text="Assumptions:").grid(row=2, column=0, sticky="w")
         assum_text = tk.Text(container, height=8, wrap="word")
-        assum_text.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+        assum_text.grid(row=3, column=0, sticky="nsew", padx=5, pady=5)
         desc_text.insert("1.0", app.item_definition.get("description", ""))
         assum_text.insert("1.0", app.item_definition.get("assumptions", ""))
 
@@ -104,7 +108,9 @@ class Editors:
             app.item_definition["description"] = desc_text.get("1.0", "end").strip()
             app.item_definition["assumptions"] = assum_text.get("1.0", "end").strip()
 
-        ttk.Button(container, text="Save", command=save).pack(anchor="e", padx=5, pady=5)
+        save_btn = ttk.Button(container, text="Save", command=save, width=10)
+        save_btn._fixed_size = True
+        save_btn.grid(row=4, column=0, sticky="e", padx=5, pady=5)
         if container is getattr(app, "_item_def_tab", None):
             app._item_desc_text = desc_text
             app._item_assum_text = assum_text

--- a/mainappsrc/core/open_windows_features.py
+++ b/mainappsrc/core/open_windows_features.py
@@ -137,6 +137,16 @@ class Open_Windows_Features:
             app._safety_exp_tab = app.lifecycle_ui._new_tab(
                 "Safety & Security Management Explorer"
             )
+        def _build_safety_management_explorer(parent, _title=None):
+            container = parent
+            if isinstance(parent, ttk.Notebook):
+                container = ttk.Frame(parent)
+            explorer = SafetyManagementExplorer(container, app, app.safety_mgmt_toolbox)
+            explorer.pack(fill=tk.BOTH, expand=True)
+            container._detach_factory = _build_safety_management_explorer
+            return container
+
+        app._safety_exp_tab._detach_factory = _build_safety_management_explorer
         app._safety_exp_window = SafetyManagementExplorer(
             app._safety_exp_tab, app, app.safety_mgmt_toolbox
         )

--- a/mainappsrc/managers/safety_case_manager.py
+++ b/mainappsrc/managers/safety_case_manager.py
@@ -424,6 +424,16 @@ class SafetyCaseManager:
             app._safety_case_exp_tab = app.lifecycle_ui._new_tab(
                 "Safety & Security Case Explorer"
             )
+            def _build_safety_case_explorer(parent, _title=None):
+                container = parent
+                if isinstance(parent, ttk.Notebook):
+                    container = ttk.Frame(parent)
+                explorer = SafetyCaseExplorer(container, app, app.safety_case_library)
+                explorer.pack(fill=tk.BOTH, expand=True)
+                container._detach_factory = _build_safety_case_explorer
+                return container
+
+            app._safety_case_exp_tab._detach_factory = _build_safety_case_explorer
             app._safety_case_window = SafetyCaseExplorer(
                 app._safety_case_exp_tab, app, app.safety_case_library
             )

--- a/mainappsrc/services/service_loader.py
+++ b/mainappsrc/services/service_loader.py
@@ -26,12 +26,10 @@ context manager automates this pattern.
 
 from __future__ import annotations
 
-import threading
 from contextlib import contextmanager
 from typing import Any
 
 from tools.memory_manager import manager as memory_manager
-from tools.thread_manager import manager as thread_manager
 from mainappsrc import services
 
 
@@ -41,20 +39,9 @@ class LazyServiceRegistry:
     def __init__(self, app: Any, interval: float = 60.0) -> None:
         self._app = app
         self._interval = interval
-        self._stop = threading.Event()
-        self._name = f"service_registry_{id(self)}"
-        thread_manager.register(self._name, self._monitor, daemon=True)
-
-    def _monitor(self) -> None:
-        while not self._stop.is_set():
-            self._stop.wait(self._interval)
-            memory_manager.cleanup()
 
     def shutdown(self) -> None:
-        self._stop.set()
-        thread = thread_manager.unregister(self._name)
-        if thread:
-            thread.join()
+        memory_manager.cleanup()
 
     def get(self, name: str) -> Any:
         """Return service *name*, creating it if necessary."""

--- a/tests/test_user_data_threading.py
+++ b/tests/test_user_data_threading.py
@@ -16,30 +16,29 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import time
-
 import importlib
 
 
-# Import AutoML module for testing
-automl = importlib.import_module("mainappsrc.automl_core")
+# Import AutoML module for testing.
+automl = importlib.import_module("mainappsrc.core.automl_core")
 
 
-def test_load_user_data_parallel(monkeypatch):
+def test_load_user_data_is_sequential(monkeypatch):
+    calls: list[str] = []
+
     def fake_load_all_users():
-        time.sleep(0.2)
+        calls.append("users")
         return {"u": "e"}
 
     def fake_load_user_config():
-        time.sleep(0.2)
+        calls.append("config")
         return "name", "email"
 
-    monkeypatch.setattr(automl, "load_all_users", fake_load_all_users)
-    monkeypatch.setattr(automl, "load_user_config", fake_load_user_config)
+    monkeypatch.setattr(automl.user_config_service, "load_all_users", fake_load_all_users)
+    monkeypatch.setattr(automl.user_config_service, "load_user_config", fake_load_user_config)
 
-    start = time.time()
     users, config = automl.load_user_data()
-    elapsed = time.time() - start
+
     assert users == {"u": "e"}
     assert config == ("name", "email")
-    assert elapsed < 0.35
+    assert calls == ["users", "config"]

--- a/tools/memory_manager.py
+++ b/tools/memory_manager.py
@@ -30,14 +30,8 @@ import atexit
 import ctypes
 import gc
 import importlib
-import os
 import sys
-import threading
-from threading import current_thread, main_thread
-import time
 from typing import Any, Callable, Dict, Set
-
-from .thread_manager import manager as thread_manager
 
 try:  # pragma: no cover - optional dependency
     import psutil
@@ -46,11 +40,9 @@ except Exception:  # pragma: no cover - psutil may not be installed
 
 
 def _destroy_if_safe(obj: Any) -> None:
-    """Destroy Tk objects only from the main thread to avoid Tcl async crashes."""
+    """Destroy Tk objects from the sequential cleanup path."""
     destroy = getattr(obj, "destroy", None)
     if not callable(destroy):
-        return
-    if getattr(obj, "tk", None) is not None and current_thread() is not main_thread():
         return
     try:
         destroy()
@@ -63,104 +55,84 @@ class MemoryManager:
 
     Objects are loaded on demand via :meth:`lazy_load`.  Keys can be marked as
     active with :meth:`mark_active`; any remaining cached objects and processes
-    are discarded by :meth:`cleanup`.  A background thread periodically checks
-    memory pressure and invokes :meth:`cleanup` to free unused resources.
+    are discarded by explicit :meth:`cleanup` calls on the caller's thread.
     """
 
     def __init__(self, interval: float = 60.0, max_usage_percent: float = 70.0) -> None:
         self._cache: Dict[str, Any] = {}
         self._active: Set[str] = set()
         self._procs: Dict[str, Any] = {}
-        self._lock = threading.Lock()
         self._interval = interval
         self._max_usage = max_usage_percent
-        self._stop_event = threading.Event()
-        disable_thread = os.getenv("AUTOML_DISABLE_MEMORY_MANAGER", "").lower() in {
-            "1",
-            "true",
-            "yes",
-        }
-        self._thread = None
-        if not disable_thread:
-            self._thread = thread_manager.register(
-                "memory_manager",
-                self._monitor,
-                daemon=True,
-                stop_event=self._stop_event,
-            )
+        # Cleanup is intentionally caller-driven and sequential.
 
     def lazy_load(self, key: str, loader: Callable[[], Any]) -> Any:
         """Return cached object for *key*, loading it if necessary."""
-        with self._lock:
-            if key not in self._cache:
-                self._cache[key] = loader()
-            self._active.add(key)
-            return self._cache[key]
+        if key not in self._cache:
+            self._cache[key] = loader()
+        self._active.add(key)
+        return self._cache[key]
 
     def mark_active(self, key: str) -> None:
         """Mark *key* as currently needed."""
-        with self._lock:
-            self._active.add(key)
+        self._active.add(key)
 
     def register_process(self, key: str, proc: Any) -> None:
         """Register a subprocess keyed by *key* for later cleanup."""
         if psutil is not None and not isinstance(proc, psutil.Process):
             proc = psutil.Process(proc.pid)
-        with self._lock:
-            self._procs[key] = proc
-            self._active.add(key)
+        self._procs[key] = proc
+        self._active.add(key)
 
     def discard_prefix(self, prefix: str) -> None:
         """Remove cached entries and processes starting with *prefix*."""
-        with self._lock:
-            keys = [k for k in self._cache if k.startswith(prefix)]
-            for key in keys:
-                obj = self._cache.pop(key, None)
-                if obj is not None:
-                    _destroy_if_safe(obj)
-                    del obj
-            proc_keys = [k for k in self._procs if k.startswith(prefix)]
-            for key in proc_keys:
-                proc = self._procs.pop(key, None)
-                if proc is not None:
-                    try:
-                        if psutil is not None:
-                            if proc.is_running():
-                                proc.terminate()
-                                proc.wait(timeout=1)
-                        else:
+        keys = [k for k in self._cache if k.startswith(prefix)]
+        for key in keys:
+            obj = self._cache.pop(key, None)
+            if obj is not None:
+                _destroy_if_safe(obj)
+                del obj
+        proc_keys = [k for k in self._procs if k.startswith(prefix)]
+        for key in proc_keys:
+            proc = self._procs.pop(key, None)
+            if proc is not None:
+                try:
+                    if psutil is not None:
+                        if proc.is_running():
                             proc.terminate()
-                            proc.wait(1)
-                    except Exception:
-                        pass
-            self._active = {k for k in self._active if not k.startswith(prefix)}
+                            proc.wait(timeout=1)
+                    else:
+                        proc.terminate()
+                        proc.wait(1)
+                except Exception:
+                    pass
+        self._active = {k for k in self._active if not k.startswith(prefix)}
         self._trim_memory()
 
     def cleanup(self) -> None:
         """Drop inactive cached objects and terminate unused processes."""
-        with self._lock:
-            inactive = set(self._cache) - self._active
-            for key in inactive:
-                obj = self._cache.pop(key, None)
-                if obj is not None:
-                    _destroy_if_safe(obj)
-                    del obj
+        inactive = set(self._cache) - self._active
+        for key in inactive:
+            obj = self._cache.pop(key, None)
+            if obj is not None:
+                _destroy_if_safe(obj)
+                del obj
 
-            for key, proc in list(self._procs.items()):
-                if key not in self._active:
-                    try:
-                        if psutil is not None:
-                            if proc.is_running():
-                                proc.terminate()
-                                proc.wait(timeout=1)
-                        else:
+        for key, proc in list(self._procs.items()):
+            if key not in self._active:
+                try:
+                    if psutil is not None:
+                        if proc.is_running():
                             proc.terminate()
-                            proc.wait(1)
-                    except Exception:
-                        pass
-                    finally:
-                        self._procs.pop(key, None)
-            self._active.clear()
+                            proc.wait(timeout=1)
+                    else:
+                        proc.terminate()
+                        proc.wait(1)
+                except Exception:
+                    pass
+                finally:
+                    self._procs.pop(key, None)
+        self._active.clear()
         self._trim_memory()
 
     def _memory_percent(self) -> float:
@@ -179,19 +151,9 @@ class MemoryManager:
             except Exception:  # pragma: no cover - optional
                 pass
 
-    def _monitor(self) -> None:
-        """Background thread monitoring memory usage."""
-        while not self._stop_event.is_set():
-            time.sleep(self._interval)
-            if self._memory_percent() > self._max_usage:
-                self.cleanup()
-
     def shutdown(self) -> None:
-        """Stop the monitoring thread."""
-        self._stop_event.set()
-        thread = thread_manager.unregister("memory_manager") if self._thread else None
-        if thread and thread.is_alive():
-            thread.join(timeout=1)
+        """Clean up inactive resources without starting or joining threads."""
+        self.cleanup()
 
 
 def lazy_import(name: str) -> Any:


### PR DESCRIPTION
### Motivation
- Allow complex document tabs (architecture, explorers, editors) to be detached into resizable floating windows that can be docked back, improving multi-window workflows.
- Remove background monitor threads for memory and service registries to avoid threading issues with GUI/Tk and simplify lifecycle management.
- Make toolbox frames load lazily and preloaded incrementally to reduce UI startup hiccups and support detached notebooks.

### Description
- Added detach factory support and builder functions for architecture diagrams and explorers by wiring `_detach_factory` in `window_controllers.open_arch_window`, `SysMLDiagramWindow._install_detach_factory` (in `gui/windows/architecture.py`), and explorer managers (`open_windows_features.py`, `safety_case_manager.py`).
- Reworked `ClosableNotebook._detach_tab` (in `gui/utils/closable_notebook.py`) to create a resizable `tk.Toplevel` with a simple toolbar and Dock button, embed a target `ClosableNotebook`, integrate `WindowResizeController` for size synchronization, and handle docking back and cleanup.
- Enhanced `WindowResizeController` (in `gui/utils/window_resizer.py`) to skip fixed-size widgets (respecting `_fixed_size` and `CapsuleButton`) and to restrict `pack` geometry enforcement to the primary widget, improving resize behavior for detached content.
- Changed governance/architecture toolbox behavior (in `gui/windows/architecture.py`) to lazily build frames via `_frame_loaders`, ensure frames with `_ensure_toolbox_frame`, and asynchronously preload remaining toolboxes with `_schedule_toolbox_preload`, while removing the old heartbeat timer.
- Simplified memory and service registries by removing background threads and locks and making cleanup caller-driven in `tools/memory_manager.py` and `mainappsrc/services/service_loader.py`.
- Simplified application startup and threading: `mainappsrc/core/automl_core.py` now loads user data sequentially (removed `ThreadPoolExecutor`) and no longer starts a watchdog thread at launch.
- Improved the Item Definition editor and dialogs to support detachment by building content into a child `ttk.Frame` when parent is a notebook, switched to a grid layout, and marked the Save button as `_fixed_size` for resizing safety (in `mainappsrc/core/editors.py`).
- Updated tests and imports to reflect the `automl_core` module path and to assert sequential loading of user data (`tests/test_user_data_threading.py`).

### Testing
- Ran the updated unit test `tests/test_user_data_threading.py::test_load_user_data_is_sequential`, which passed and verifies `load_all_users` and `load_user_config` are called sequentially.
- Executed existing GUI-related unit tests where available (headless paths exercised), and no new automated failures were observed in the modified modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54074eefd4832590a08fedaf3b8bf5)