### PR TITLE
Keep GUI startup on the Tk interpreter owner thread

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -33,7 +33,7 @@ import subprocess
 import sys
 import types
 import threading
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor  # compatibility export; not used at startup
 from pathlib import Path
 from tkinter import ttk
 from typing import Any
@@ -288,8 +288,8 @@ def ensure_packages() -> None:
         memory_manager.register_process(pkg, proc)
         proc.wait()
 
-    with ThreadPoolExecutor() as executor:
-        executor.map(install, missing)
+    for package in missing:
+        install(package)
     memory_manager.cleanup()
 
 
@@ -314,13 +314,10 @@ def _bootstrap() -> object:
     automl._diagnostics_manager = _diagnostics_manager
     _model_cleanup_stop = automl.start_cleanup_thread()
     automl._model_cleanup_stop = _model_cleanup_stop
-    with automl.ThreadPoolExecutor() as executor:
-        futures = [
-            executor.submit(automl.ensure_packages),
-            executor.submit(automl.ensure_ghostscript),
-        ]
-        for f in futures:
-            f.result()
+    # Startup imports and initializers remain sequential because third-party
+    # packages may create Tk objects or a default root as an import side effect.
+    automl.ensure_packages()
+    automl.ensure_ghostscript()
     base_path = Path(getattr(sys, "_MEIPASS", Path(__file__).parent))
     # Insert both the launcher directory and the 'mainappsrc' module location to ensure
     # the project-specific AutoML module is discovered rather than any similarly

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,16 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
+## 0.2.300 - 2026-07-19
+
+- Keep splash-root creation, startup module loading, callback registration,
+  splash closure, interpreter destruction, application-root creation, and both
+  GUI event loops on the single thread that owns the splash Tcl interpreter.
+- Add development diagnostics for centralized Tk operations with owner/current
+  thread identifiers, operation and widget details, and the root creation site.
+- Execute dependency checks and application bootstrap initialization
+  sequentially to prevent Tk-capable imports from running on startup workers.
+
 ## 0.2.299 - 2026-05-03
 
 - Prefer moving the original tab widget into detached windows so undocked tabs

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.282"
+VERSION = "0.2.300"
 
 __all__ = ["VERSION"]

--- a/tests/test_splash_launcher.py
+++ b/tests/test_splash_launcher.py
@@ -19,6 +19,8 @@
 import importlib
 import builtins
 import sys
+import threading
+import types
 
 import tools.splash_launcher as splash_module
 
@@ -51,3 +53,96 @@ class TestSplashLauncher:
         importlib.reload(splash_module)
 
         assert splash_module.VERSION == "0.0.0"
+
+
+class TestSplashLauncherThreadOwnership:
+    """Group thread-affinity tests for every centralized Tk startup operation."""
+
+    def test_complete_gui_startup_uses_root_owner_thread(self, monkeypatch):
+        events = []
+        owner_thread = threading.get_ident()
+
+        def record(operation, identity):
+            events.append((operation, identity, threading.get_ident()))
+
+        class FakeRoot:
+            def __init__(self):
+                record("splash-root creation", self)
+                self.callback = None
+
+            def withdraw(self):
+                record("splash withdrawal", self)
+
+            def after(self, delay, callback):
+                record("callback registration", self)
+                self.callback = callback
+
+            def mainloop(self):
+                record("splash event loop", self)
+                self.callback()
+
+            def destroy(self):
+                record("root destruction", self)
+
+        class FakeSplash:
+            def __init__(self, root, **kwargs):
+                self.on_close = kwargs["on_close"]
+
+            def close(self):
+                record("splash closure", self)
+                self.on_close()
+
+        class FakeApplicationRoot:
+            def __init__(self):
+                record("application-root creation", self)
+
+            def mainloop(self):
+                record("application event loop", self)
+
+        application_module = types.ModuleType("thread_affinity_application")
+
+        def application_main():
+            application_root = FakeApplicationRoot()
+            application_root.mainloop()
+
+        application_module.main = application_main
+        splash_screen_module = types.ModuleType("gui.windows.splash_screen")
+        splash_screen_module.SplashScreen = FakeSplash
+        monkeypatch.setitem(sys.modules, "gui.windows.splash_screen", splash_screen_module)
+        monkeypatch.setattr(splash_module.tk, "Tk", FakeRoot)
+
+        launcher = splash_module.SplashLauncher(loader=lambda: application_module)
+        launcher.launch()
+
+        required = {
+            "splash-root creation",
+            "callback registration",
+            "splash closure",
+            "root destruction",
+            "application-root creation",
+            "splash event loop",
+            "application event loop",
+        }
+        observed = {operation for operation, _, _ in events}
+        assert required <= observed
+        assert {thread_id for _, _, thread_id in events} == {owner_thread}
+        assert launcher._owner_thread_id == owner_thread
+
+    def test_thread_assertion_reports_actionable_context(self):
+        launcher = splash_module.SplashLauncher()
+        launcher._owner_thread_id = -1
+        launcher._root_creation_site = "test creation site"
+        window = object()
+
+        try:
+            launcher._assert_owner_thread("test operation", window)
+        except AssertionError as error:
+            diagnostic = str(error)
+        else:  # pragma: no cover - assertion is enabled in development tests
+            raise AssertionError("thread-affinity assertion did not run")
+
+        assert f"current_thread={threading.get_ident()!r}" in diagnostic
+        assert "owner_thread=-1" in diagnostic
+        assert "operation='test operation'" in diagnostic
+        assert f"widget={window!r}" in diagnostic
+        assert "creation_site='test creation site'" in diagnostic

--- a/tools/splash_launcher.py
+++ b/tools/splash_launcher.py
@@ -25,6 +25,7 @@ import importlib
 import sys
 from pathlib import Path
 import threading
+import traceback
 import tkinter as tk
 from types import ModuleType
 from typing import Callable, Optional
@@ -75,30 +76,49 @@ class SplashLauncher:
         self.module_name = module_name
         self.post_delay = post_delay
         self._module: Optional[ModuleType] = None
+        self._owner_thread_id: Optional[int] = None
+        self._root_creation_site = ""
 
     def _load_module(self) -> None:
-        """Initialise the application in a background thread."""
+        """Initialise the application on the splash interpreter's thread."""
+        self._assert_owner_thread("load application module", self._root)
         if self.loader:
             self._module = self.loader()
         else:
             self._module = importlib.import_module(self.module_name)
-        # Once loading is complete, close the splash screen on the main thread
-        self._root.after(self.post_delay, self._splash.close)
 
-    def launch(self) -> None:
-        """Display the splash screen and run the application's main function."""
-        try:
-            self._root = tk.Tk()
-        except tk.TclError:
-            # Headless environment; load module directly without splash
-            module = self.loader() if self.loader else importlib.import_module(self.module_name)
-            if module and hasattr(module, "main"):
-                module.main()
+    def _assert_owner_thread(self, operation: str, window: object) -> None:
+        """Assert in development builds that centralized Tk work is thread-safe."""
+        if not __debug__ or self._owner_thread_id is None:
             return
-        self._root.withdraw()
-        # Defer splash import to avoid circular initialization during package
-        # execution
+        current_thread_id = threading.get_ident()
+        assert current_thread_id == self._owner_thread_id, (
+            "Tk operation attempted outside the interpreter owner thread: "
+            f"current_thread={current_thread_id!r}, "
+            f"owner_thread={self._owner_thread_id!r}, operation={operation!r}, "
+            f"widget={window!r}, creation_site={self._root_creation_site!r}"
+        )
+
+    def _close_splash(self) -> None:
+        """Close the splash from its interpreter owner thread."""
+        self._assert_owner_thread("close splash", self._splash)
+        self._splash.close()
+
+    def _destroy_root(self) -> None:
+        """Destroy the splash Tcl interpreter from its owner thread."""
+        self._assert_owner_thread("destroy splash root", self._root)
+        self._root.destroy()
+
+    def _launch_headless(self) -> None:
+        """Load and launch without a splash when Tk cannot create a root."""
+        module = self.loader() if self.loader else importlib.import_module(self.module_name)
+        if module and hasattr(module, "main"):
+            module.main()
+
+    def _create_splash(self) -> None:
+        """Create the splash window and bind owner-thread destruction."""
         from gui.windows.splash_screen import SplashScreen
+
         self._splash = SplashScreen(
             self._root,
             version=VERSION,
@@ -106,9 +126,27 @@ class SplashLauncher:
             email=AUTHOR_EMAIL,
             linkedin=AUTHOR_LINKEDIN,
             duration=0,
-            on_close=self._root.destroy,
+            on_close=self._destroy_root,
         )
-        threading.Thread(target=self._load_module, daemon=True).start()
+
+    def launch(self) -> None:
+        """Display the splash screen and run the application's main function."""
+        try:
+            self._root = tk.Tk()
+        except tk.TclError:
+            self._launch_headless()
+            return
+        self._owner_thread_id = threading.get_ident()
+        self._root_creation_site = "".join(traceback.format_stack()[:-1])
+        self._assert_owner_thread("withdraw splash root", self._root)
+        self._root.withdraw()
+        # Defer splash import to avoid circular initialization during package execution.
+        self._create_splash()
+        self._load_module()
+        self._assert_owner_thread("register splash-close callback", self._root)
+        self._root.after(self.post_delay, self._close_splash)
+        self._assert_owner_thread("run splash event loop", self._root)
         self._root.mainloop()
         if self._module and hasattr(self._module, "main"):
+            self._assert_owner_thread("create application root and run event loop", self._root)
             self._module.main()


### PR DESCRIPTION
### Motivation
- Prevent Tk initialisation, callback registration, splash closure, and interpreter destruction from executing on background workers which can trigger `Tcl_AsyncDelete` and related threading issues.
- Ensure any imports or initialization that may create Tk variables, fonts, images, commands, or default roots run on the same thread that created the splash root.
- Provide actionable diagnostics during development when centralized Tk operations occur off the owner thread.

### Description
- Refactor `tools/splash_launcher.py` so `SplashLauncher.launch()` performs root creation, module loading, callback registration, splash closure, and interpreter destruction on the thread that created the splash root, and remove the background `threading.Thread` worker used to load the module.
- Introduce a development-mode assertion helper `SplashLauncher._assert_owner_thread()` which includes current/owner thread ids, the attempted operation, widget/window identity, and the captured root creation site when raising diagnostics.
- Centralize splash lifecycle operations behind `_create_splash()`, `_close_splash()`, and `_destroy_root()` to enforce owner-thread execution and to support headless startup via `_launch_headless()`.
- Refactor `AutoML.py` startup to run dependency checks and bootstrap steps sequentially (remove parallel startup invocation of `ensure_packages`/`ensure_ghostscript`), and keep a compatibility re-export of `ThreadPoolExecutor` to avoid breaking imports.
- Add grouped unit tests in `tests/test_splash_launcher.py` validating splash-root creation, callback registration, splash closure, root destruction, application-root creation, and that both event loops execute on the same identified thread, and a test verifying the thread-affinity assertion produces actionable diagnostics.
- Bump `mainappsrc/version.py` to `0.2.300` and document the change in `HISTORY.md`.

### Testing
- Ran targeted unit suites: `PYTHONPATH=. pytest -q tests/test_splash_launcher.py tests/test_diagnostics_manager.py` which passed (16 passed).
- Ran static complexity reporting: `python -m radon cc -j tools/splash_launcher.py AutoML.py` and captured JSON complexity output (modified functions rank A/A/B as noted in run logs).
- Checked bytecode/compilation: `python -m compileall -q tools/splash_launcher.py AutoML.py tests/test_splash_launcher.py` completed successfully.
- Ran repository-wide tests `PYTHONPATH=. pytest -q`; targeted changes passed, but the full repository run produced unrelated pre-existing failures/skips and terminated partway through (environment noise); the modified and affected test groups pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d0ce65f7c8327813c0cf314c6e78f)