### PR TITLE
Add owner-thread Tk lifecycle registry

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
+## 0.2.304 - 2026-07-20
+
+- Add an owner-thread Tk lifecycle registry with deduplicated, auditable APIs
+  for timers, idle work, local/global bindings, traces, protocols, and Tcl
+  commands, plus guarded callbacks and deterministic component disposal.
+- Migrate tooltip, detached-window, and resize-controller lifetimes so their
+  registrations are drained explicitly before widget destruction.
+
 ## 0.2.303 - 2026-07-19
 
 - Replace cross-parent Tk widget transfer with deterministic visual

--- a/gui/utils/__init__.py
+++ b/gui/utils/__init__.py
@@ -31,6 +31,7 @@ from . import logger  # noqa: F401
 from .node_utils import resolve_original  # noqa: F401
 from .detached_window import DetachedWindow  # noqa: F401
 from .widget_transfer_manager import WidgetTransferManager  # noqa: F401
+from .tk_lifecycle_registry import TkLifecycleRegistry, TkRegistration  # noqa: F401
 from .dockable_diagram_window import (  # noqa: F401
     DiagramContext,
     DiagramVisual,
@@ -72,4 +73,6 @@ __all__ = [
     "DiagramVisualState",
     "DockableDiagramWindow",
     "ToolboxDefinition",
+    "TkLifecycleRegistry",
+    "TkRegistration",
 ]

--- a/gui/utils/detached_window.py
+++ b/gui/utils/detached_window.py
@@ -20,11 +20,13 @@
 from __future__ import annotations
 
 import tkinter as tk
+import threading
 from tkinter import ttk
 
 from .closable_notebook import ClosableNotebook, cancel_after_events
 from .window_controls import restore_window_buttons
 from .window_resizer import WindowResizeController
+from .tk_lifecycle_registry import TkLifecycleRegistry
 
 
 class DetachedWindow:
@@ -38,6 +40,8 @@ class DetachedWindow:
         self, root: tk.Misc, width: int, height: int, x: int, y: int
     ) -> None:
         self.root = root
+        self.active = True
+        self.lifecycle = TkLifecycleRegistry(root, threading.get_ident())
         self.win = tk.Toplevel(root)
         restore_window_buttons(self.win)
         self.win.geometry(f"{width}x{height}+{x}+{y}")
@@ -46,7 +50,7 @@ class DetachedWindow:
         self._resizer: WindowResizeController | None = None
         self._resizer = WindowResizeController(self.win, self.nb)
         self._visuals: list[object] = []
-        self.win.bind("<Destroy>", self._on_destroy)
+        self.lifecycle.bind(self, self.win, "<Destroy>", self._on_destroy)
 
     # ------------------------------------------------------------------
     # Window setup helpers
@@ -78,6 +82,12 @@ class DetachedWindow:
         """Cancel pending callbacks when the window is destroyed."""
         if _event.widget is not self.win:
             return
+        self.dispose()
+
+    def dispose(self) -> None:
+        """Drain window registrations and hosted visuals on the owner thread."""
+        if not self.active:
+            return
         cancel_after_events(self.win)
         for visual in tuple(self._visuals):
             visual.deactivate()
@@ -86,3 +96,5 @@ class DetachedWindow:
         if self._resizer is not None:
             self._resizer.shutdown()
         self._resizer = None
+        self.lifecycle.dispose_component(self)
+        self.active = False

--- a/gui/utils/tk_lifecycle_registry.py
+++ b/gui/utils/tk_lifecycle_registry.py
@@ -1,0 +1,236 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Owner-thread registry for every externally retained Tk callback."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import inspect
+import threading
+from typing import Any, Callable
+
+
+@dataclass
+class TkRegistration:
+    """Auditable description of one Tk registration."""
+
+    identifier: Any
+    kind: str
+    component: object
+    target_identity: int
+    location: str
+    disposed: bool = False
+    target: object | None = None
+    detail: str = ""
+    previous: object | None = None
+
+
+def _callable_identity(callback: Callable[..., Any]) -> tuple[int, int]:
+    return (id(getattr(callback, "__self__", None)), id(getattr(callback, "__func__", callback)))
+
+
+class TkLifecycleRegistry:
+    """Register, deduplicate and deterministically remove Tk resources.
+
+    A registry belongs to one Tcl interpreter and may only be drained by the
+    thread that constructed that interpreter.  Components may share a registry;
+    disposing one component never suppresses callbacks owned by another.
+    """
+
+    def __init__(self, root: object, owner_thread_id: int) -> None:
+        self.root = root
+        self.owner_thread_id = owner_thread_id
+        self._entries: list[TkRegistration] = []
+        self._keys: dict[tuple[Any, ...], TkRegistration] = {}
+        self._active_components: dict[int, bool] = {}
+
+    @property
+    def registrations(self) -> tuple[TkRegistration, ...]:
+        return tuple(self._entries)
+
+    def _assert_owner(self) -> None:
+        if threading.get_ident() != self.owner_thread_id:
+            raise RuntimeError("Tk registrations must be removed on their owner thread")
+
+    def _location(self) -> str:
+        frame = inspect.currentframe()
+        own_file = __file__
+        while frame:
+            frame = frame.f_back
+            if frame and frame.f_code.co_filename != own_file:
+                return f"{frame.f_code.co_filename}:{frame.f_lineno}"
+        return "<unknown>"
+
+    def _active(self, component: object) -> bool:
+        explicit = self._active_components.get(id(component), True)
+        return explicit and bool(getattr(component, "active", getattr(component, "_active", True)))
+
+    def _wrapped(self, component: object, callback: Callable[..., Any], entry_box: list[Any]):
+        def guarded(*args: Any, **kwargs: Any) -> Any:
+            if entry_box and entry_box[0].disposed:
+                return None
+            if not self._active(component):
+                return None
+            return callback(*args, **kwargs)
+        return guarded
+
+    def _remember(self, key: tuple[Any, ...], entry: TkRegistration) -> Any:
+        self._keys[key] = entry
+        self._entries.append(entry)
+        self._active_components.setdefault(id(entry.component), True)
+        return entry.identifier
+
+    def after(self, component: object, target: object, milliseconds: int,
+              callback: Callable[..., Any]) -> Any:
+        key = ("after", id(component), id(target), milliseconds, _callable_identity(callback))
+        if key in self._keys and not self._keys[key].disposed:
+            return self._keys[key].identifier
+        box: list[Any] = []
+        guarded = self._wrapped(component, callback, box)
+        identifier = target.after(milliseconds, guarded)
+        entry = TkRegistration(identifier, "after", component, id(target), self._location(), target=target)
+        box.append(entry)
+        return self._remember(key, entry)
+
+    register_after = after
+
+    def after_idle(self, component: object, target: object, callback: Callable[..., Any]) -> Any:
+        key = ("after_idle", id(component), id(target), _callable_identity(callback))
+        if key in self._keys and not self._keys[key].disposed:
+            return self._keys[key].identifier
+        box: list[Any] = []
+        identifier = target.after_idle(self._wrapped(component, callback, box))
+        entry = TkRegistration(identifier, "after_idle", component, id(target), self._location(), target=target)
+        box.append(entry)
+        return self._remember(key, entry)
+
+    register_after_idle = after_idle
+
+    def bind(self, component: object, target: object, sequence: str,
+             callback: Callable[..., Any], add: str | bool = "+") -> Any:
+        return self._bind("bind", component, target, sequence, callback, add)
+
+    register_binding = bind
+
+    def bind_all(self, component: object, target: object, sequence: str,
+                 callback: Callable[..., Any], add: str | bool = "+") -> Any:
+        return self._bind("bind_all", component, target, sequence, callback, add)
+
+    register_global_binding = bind_all
+
+    def _bind(self, kind: str, component: object, target: object, sequence: str,
+              callback: Callable[..., Any], add: str | bool) -> Any:
+        key = (kind, id(component), id(target), sequence, _callable_identity(callback))
+        if key in self._keys and not self._keys[key].disposed:
+            return self._keys[key].identifier
+        box: list[Any] = []
+        binder = target.bind_all if kind == "bind_all" else target.bind
+        guarded = self._wrapped(component, callback, box)
+        try:
+            identifier = binder(sequence, guarded, add)
+        except TypeError:  # lightweight widget doubles may omit Tk's add flag
+            identifier = binder(sequence, guarded)
+        entry = TkRegistration(identifier, kind, component, id(target), self._location(), target=target, detail=sequence)
+        box.append(entry)
+        return self._remember(key, entry)
+
+    def trace_add(self, component: object, variable: object, mode: str,
+                  callback: Callable[..., Any]) -> Any:
+        key = ("trace", id(component), id(variable), mode, _callable_identity(callback))
+        if key in self._keys and not self._keys[key].disposed:
+            return self._keys[key].identifier
+        box: list[Any] = []
+        identifier = variable.trace_add(mode, self._wrapped(component, callback, box))
+        entry = TkRegistration(identifier, "trace", component, id(variable), self._location(), target=variable, detail=mode)
+        box.append(entry)
+        return self._remember(key, entry)
+
+    register_trace = trace_add
+
+    def protocol(self, component: object, window: object, name: str,
+                 callback: Callable[..., Any]) -> Any:
+        key = ("protocol", id(component), id(window), name, _callable_identity(callback))
+        if key in self._keys and not self._keys[key].disposed:
+            return self._keys[key].identifier
+        previous = window.protocol(name)
+        box: list[Any] = []
+        guarded = self._wrapped(component, callback, box)
+        identifier = window.protocol(name, guarded)
+        entry = TkRegistration(identifier or name, "protocol", component, id(window), self._location(), target=window, detail=name, previous=previous)
+        box.append(entry)
+        return self._remember(key, entry)
+
+    register_protocol = protocol
+
+    def create_command(self, component: object, name: str,
+                       callback: Callable[..., Any]) -> str:
+        key = ("command", id(component), id(self.root), name, _callable_identity(callback))
+        if key in self._keys and not self._keys[key].disposed:
+            return name
+        box: list[Any] = []
+        self.root.createcommand(name, self._wrapped(component, callback, box))
+        entry = TkRegistration(name, "command", component, id(self.root), self._location(), target=self.root, detail=name)
+        box.append(entry)
+        return self._remember(key, entry)
+
+    register_tcl_command = create_command
+
+    def cancel(self, identifier: Any) -> bool:
+        self._assert_owner()
+        entry = next((item for item in self._entries if item.identifier == identifier and not item.disposed), None)
+        if entry is None:
+            return False
+        self._cancel_entry(entry)
+        return True
+
+    def _cancel_entry(self, entry: TkRegistration) -> None:
+        """Remove an exact entry (Tk identifiers are not globally unique)."""
+        target = entry.target
+        if entry.kind in ("after", "after_idle"):
+            target.after_cancel(entry.identifier)
+        elif entry.kind == "bind":
+            target.unbind(entry.detail, entry.identifier)
+        elif entry.kind == "bind_all":
+            target.unbind_all(entry.detail)
+        elif entry.kind == "trace":
+            target.trace_remove(entry.detail, entry.identifier)
+        elif entry.kind == "protocol":
+            target.protocol(entry.detail, entry.previous or "")
+        elif entry.kind == "command":
+            target.deletecommand(entry.detail)
+        entry.disposed = True
+
+    cancel_after = cancel
+    remove_binding = cancel
+    remove_trace = cancel
+    remove_protocol = cancel
+    delete_command = cancel
+
+    def dispose_component(self, component: object) -> None:
+        self._assert_owner()
+        self._active_components[id(component)] = False
+        # LIFO ensures dependent callbacks/commands disappear before owners.
+        for entry in reversed(self._entries):
+            if entry.component is component and not entry.disposed:
+                self._cancel_entry(entry)
+
+    def dispose(self) -> None:
+        self._assert_owner()
+        for entry in reversed(self._entries):
+            if not entry.disposed:
+                self._cancel_entry(entry)

--- a/gui/utils/tooltip.py
+++ b/gui/utils/tooltip.py
@@ -17,7 +17,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import tkinter as tk
+import threading
 from tkinter import ttk, font as tkfont
+
+from .tk_lifecycle_registry import TkLifecycleRegistry
 
 class ToolTip:
     """Simple tooltip for Tkinter widgets.
@@ -33,15 +36,19 @@ class ToolTip:
         self.delay = delay
         self.tipwindow = None
         self.id = None
+        self.active = True
+        toplevel = getattr(widget, "winfo_toplevel", None)
+        root = toplevel() if callable(toplevel) else widget
+        self.lifecycle = TkLifecycleRegistry(root, threading.get_ident())
         if automatic:
-            widget.bind("<Enter>", self._schedule)
+            self.lifecycle.bind(self, widget, "<Enter>", self._schedule)
         # Always hide the tooltip when the pointer leaves the widget so
         # tooltips shown manually disappear as expected.
-        widget.bind("<Leave>", self._hide)
+        self.lifecycle.bind(self, widget, "<Leave>", self._hide)
 
     def _schedule(self, _event=None):
         self._unschedule()
-        self.id = self.widget.after(self.delay, self._show)
+        self.id = self.lifecycle.after(self, self.widget, self.delay, self._show)
 
     def _show(self, x: int | None = None, y: int | None = None):
         if self.tipwindow or not self.text:
@@ -127,5 +134,13 @@ class ToolTip:
 
     def _unschedule(self):
         if self.id:
-            self.widget.after_cancel(self.id)
+            self.lifecycle.cancel(self.id)
             self.id = None
+
+    def dispose(self):
+        """Remove callbacks before the tooltip owner is destroyed."""
+        if not self.active:
+            return
+        self._hide()
+        self.active = False
+        self.lifecycle.dispose_component(self)

--- a/gui/utils/window_resizer.py
+++ b/gui/utils/window_resizer.py
@@ -20,12 +20,14 @@
 from __future__ import annotations
 
 import sys
+import threading
 import tkinter as tk
 from tkinter import ttk
 import typing as t
 
 from gui.utils.tk_utils import dispatch_to_ui, is_main_thread
 from gui.utils.win32_hooks import create_window_size_hook
+from gui.utils.tk_lifecycle_registry import TkLifecycleRegistry
 
 
 def _python_is_finalizing() -> bool:
@@ -56,6 +58,10 @@ class WindowResizeController:
         self._last_size: tuple[int, int] | None = None
         self._win32_hook = None
         self._use_win32_hook = use_win32_hook
+        self.active = True
+        toplevel = getattr(win, "winfo_toplevel", None)
+        root = toplevel() if callable(toplevel) else win
+        self.lifecycle = TkLifecycleRegistry(root, threading.get_ident())
         if primary is not None:
             self.set_primary_target(primary)
         self._bind()
@@ -118,13 +124,11 @@ class WindowResizeController:
 
         self._callback = _callback
         try:
-            self._binding_id = self.win.bind("<Configure>", _callback, add="+")
+            self._binding_id = self.lifecycle.bind(self, self.win, "<Configure>", _callback)
         except Exception:
             self._binding_id = None
         try:
-            self._destroy_binding_id = self.win.bind(
-                "<Destroy>", self._on_win_destroy, add="+"
-            )
+            self._destroy_binding_id = self.lifecycle.bind(self, self.win, "<Destroy>", self._on_win_destroy)
         except Exception:
             self._destroy_binding_id = None
         self._install_win32_hook()
@@ -149,20 +153,10 @@ class WindowResizeController:
             self._win32_hook = None
 
         if not finalizing:
-            unbind = getattr(self.win, "unbind", None)
-            if callable(unbind):
-                if self._binding_id is not None:
-                    try:
-                        unbind("<Configure>", self._binding_id)
-                    except Exception:
-                        pass
-                    self._binding_id = None
-                if self._destroy_binding_id is not None:
-                    try:
-                        unbind("<Destroy>", self._destroy_binding_id)
-                    except Exception:
-                        pass
-                    self._destroy_binding_id = None
+            self.lifecycle.dispose_component(self)
+            self.active = False
+            self._binding_id = None
+            self._destroy_binding_id = None
 
         self._callback = None
         self._targets.clear()

--- a/tests/gui/test_tk_lifecycle_registry.py
+++ b/tests/gui/test_tk_lifecycle_registry.py
@@ -1,0 +1,107 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Grouped lifecycle registry tests which do not require a display server."""
+
+import threading
+
+from gui.utils.tk_lifecycle_registry import TkLifecycleRegistry
+
+
+class FakeTk:
+    def __init__(self):
+        self.callbacks = {}
+        self.removed = []
+        self._next = 0
+
+    def _add(self, callback):
+        self._next += 1
+        name = f"id{self._next}"
+        self.callbacks[name] = callback
+        return name
+
+    def after(self, _delay, callback): return self._add(callback)
+    def after_idle(self, callback): return self._add(callback)
+    def after_cancel(self, name): self.removed.append(("after", name))
+    def bind(self, sequence, callback, add="+"): return self._add(callback)
+    def bind_all(self, sequence, callback, add="+"): return self._add(callback)
+    def unbind(self, sequence, name): self.removed.append((sequence, name))
+    def unbind_all(self, sequence): self.removed.append(("all", sequence))
+    def protocol(self, name, callback=None):
+        if callback is None: return "old"
+        self.callbacks[name] = callback
+    def createcommand(self, name, callback): self.callbacks[name] = callback
+    def deletecommand(self, name): self.removed.append(("command", name))
+
+
+class FakeVariable(FakeTk):
+    def trace_add(self, mode, callback): return self._add(callback)
+    def trace_remove(self, mode, name): self.removed.append((mode, name))
+
+
+class Component:
+    active = True
+
+
+class TestRegistrationAndDeduplication:
+    def test_duplicate_after_has_one_auditable_registration(self):
+        tk, owner = FakeTk(), Component()
+        registry = TkLifecycleRegistry(tk, threading.get_ident())
+        callback = lambda: None
+        assert registry.after(owner, tk, 1, callback) == registry.after(owner, tk, 1, callback)
+        assert len(registry.registrations) == 1
+        assert "test_tk_lifecycle_registry.py:" in registry.registrations[0].location
+
+
+class TestCancellationAndRemoval:
+    def test_component_disposal_is_reverse_registration_order(self):
+        tk, owner = FakeTk(), Component()
+        registry = TkLifecycleRegistry(tk, threading.get_ident())
+        first = registry.after(owner, tk, 1, lambda: None)
+        second = registry.after(owner, tk, 2, lambda: None)
+        registry.dispose_component(owner)
+        assert tk.removed == [("after", second), ("after", first)]
+
+    def test_trace_and_global_binding_are_removed(self):
+        tk, variable, owner = FakeTk(), FakeVariable(), Component()
+        registry = TkLifecycleRegistry(tk, threading.get_ident())
+        registry.trace_add(owner, variable, "write", lambda *_: None)
+        registry.bind_all(owner, tk, "<Escape>", lambda _event: None)
+        registry.dispose_component(owner)
+        assert ("all", "<Escape>") in tk.removed
+        assert any(item[0] == "write" for item in variable.removed)
+
+
+class TestCallbackSafetyAndIsolation:
+    def test_callback_is_suppressed_after_owner_disposal(self):
+        tk, owner, calls = FakeTk(), Component(), []
+        registry = TkLifecycleRegistry(tk, threading.get_ident())
+        identifier = registry.after(owner, tk, 1, lambda: calls.append(True))
+        callback = tk.callbacks[identifier]
+        registry.dispose_component(owner)
+        callback()
+        assert calls == []
+
+    def test_disposing_one_window_does_not_suppress_another(self):
+        tk, first, second, calls = FakeTk(), Component(), Component(), []
+        registry = TkLifecycleRegistry(tk, threading.get_ident())
+        one = registry.after(first, tk, 1, lambda: calls.append("first"))
+        two = registry.after(second, tk, 1, lambda: calls.append("second"))
+        registry.dispose_component(first)
+        tk.callbacks[one]()
+        tk.callbacks[two]()
+        assert calls == ["second"]


### PR DESCRIPTION
### Motivation

- Provide deterministic, owner-thread lifecycle management for Tk callbacks to avoid off-thread teardown and unsafe widget access.
- Make registrations auditable and deduplicated so repeated installs do not leak timers, bindings, traces, protocols, or Tcl commands.
- Ensure widgets and visual hosts explicitly drain their callbacks before destruction so disposed components cannot be invoked.

### Description

- Add `gui/utils/tk_lifecycle_registry.py` implementing `TkLifecycleRegistry` and `TkRegistration` with APIs for `after`, `after_idle`, `bind`/`bind_all`, `trace_add`, `protocol`, and Tcl command creation, plus guarded callbacks, deduplication, exact-entry cancellation, and reverse-order disposal.
- Migrate `ToolTip` (`gui/utils/tooltip.py`), `WindowResizeController` (`gui/utils/window_resizer.py`), and `DetachedWindow` (`gui/utils/detached_window.py`) to use the registry and add explicit disposal hooks where appropriate.
- Re-export the registry types from `gui/utils/__init__.py` and document the change as release `0.2.304` in `HISTORY.md`.
- Add grouped tests `tests/gui/test_tk_lifecycle_registry.py` that cover duplicate registration, cancellation order, trace/global-binding removal, callback suppression after disposal, and isolation between independent owners.

### Testing

- Ran targeted tests: `PYTHONPATH=. python -m pytest -q tests/gui/test_tk_lifecycle_registry.py tests/detachment/window/test_window_resizer.py tests/detachment/window/test_window_resizer_finalization.py tests/test_tooltip_leave.py` — 16 passed.
- Verified module compilation with `python -m compileall -q gui/utils` which succeeded.
- Generated code metrics with `python tools/metrics_generator.py --path gui/utils --output /tmp/tk-metrics.json` producing an average cyclomatic complexity of 5.6.
- Ran repository-wide tests: `PYTHONPATH=. python -m pytest -q` which completed (1039 passed, 283 skipped, 259 failures); the failures are pre-existing and outside the changed modules while the directly affected suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d663d80d483279ab4bbac31f06f02)