### PR TITLE
Make Tk window and Win32 hook disposal explicit

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
+## 0.2.305 - 2026-07-20
+
+- Replace resize-controller destructor and Win32 hook destructor/atexit cleanup
+  with explicit, idempotent, owner-thread disposal before window destruction.
+- Clear resize widgets and native hook references deterministically, with grouped
+  lifecycle regressions proving garbage collection performs no GUI cleanup.
+
 ## 0.2.304 - 2026-07-20
 
 - Add an owner-thread Tk lifecycle registry with deduplicated, auditable APIs

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
-version: 0.2.303
+version: 0.2.305
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 
 AutoML now uses a single-thread project lifecycle. Dependency checks complete

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -1348,7 +1348,7 @@ class ClosableNotebook(ttk.Notebook):
 
         def _cleanup_failed_window() -> None:
             if resizer is not None:
-                resizer.shutdown()
+                resizer.dispose()
             if win is not None:
                 if win in self._floating_windows:
                     self._floating_windows.remove(win)
@@ -1408,7 +1408,7 @@ class ClosableNotebook(ttk.Notebook):
             ClosableNotebook._tab_hosts.pop(hosted_child, None)
             hosted_child = None
             if resizer is not None:
-                resizer.shutdown()
+                resizer.dispose()
             if win in self._floating_windows:
                 self._floating_windows.remove(win)
             try:

--- a/gui/utils/detachable_tab_window.py
+++ b/gui/utils/detachable_tab_window.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import threading
 import tkinter as tk
 import typing as t
 
@@ -70,10 +71,34 @@ class DetachableTabWindow:
         self._hidden_in_origin = False
         self._moved_tab = False
         self.detached_successfully = False
+        self.owner_thread_id = threading.get_ident()
+        self.disposed = False
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+    def dispose(self) -> None:
+        """Dispose the floating host explicitly before destroying its window."""
+        if threading.get_ident() != self.owner_thread_id:
+            raise RuntimeError("detached tab disposal must run on its Tk owner thread")
+        if self.disposed:
+            return
+        window = self._window
+        if window is not None:
+            cancel_after_events(window)
+        self._shutdown_resizer()
+        if window is not None:
+            window.destroy()
+        self._window = None
+        self._notebook = None
+        self._cloned_widget = None
+        self.tab_widget = None
+        self.origin_notebook = None
+        self.root = None
+        self.on_dock = None
+        self.detached_successfully = False
+        self.disposed = True
+
     def detach(self) -> None:
         """Create a window and move the tab content into it."""
 
@@ -344,7 +369,7 @@ class DetachableTabWindow:
         if self._resizer is None:
             return
         try:
-            self._resizer.shutdown()
+            self._resizer.dispose()
         except Exception:
             pass
         self._resizer = None

--- a/gui/utils/detached_window.py
+++ b/gui/utils/detached_window.py
@@ -86,6 +86,8 @@ class DetachedWindow:
 
     def dispose(self) -> None:
         """Drain window registrations and hosted visuals on the owner thread."""
+        if threading.get_ident() != self.lifecycle.owner_thread_id:
+            raise RuntimeError("detached window disposal must run on its Tk owner thread")
         if not self.active:
             return
         cancel_after_events(self.win)
@@ -94,7 +96,7 @@ class DetachedWindow:
             visual.dispose()
         self._visuals.clear()
         if self._resizer is not None:
-            self._resizer.shutdown()
+            self._resizer.dispose()
         self._resizer = None
         self.lifecycle.dispose_component(self)
         self.active = False

--- a/gui/utils/tk_lifecycle_registry.py
+++ b/gui/utils/tk_lifecycle_registry.py
@@ -214,6 +214,8 @@ class TkLifecycleRegistry:
         elif entry.kind == "command":
             target.deletecommand(entry.detail)
         entry.disposed = True
+        entry.target = None
+        entry.previous = None
 
     cancel_after = cancel
     remove_binding = cancel

--- a/gui/utils/win32_hooks.py
+++ b/gui/utils/win32_hooks.py
@@ -19,12 +19,10 @@
 
 from __future__ import annotations
 
-import atexit
 import logging
 import sys
 import threading
 import typing as t
-import weakref
 
 LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +50,7 @@ if _IS_WINDOWS:  # pragma: win32-no-cover - exercised via integration on Windows
     import ctypes
     from ctypes import wintypes
 
-    _HOOKS: "weakref.WeakSet[_Win32WindowProcHook]" = weakref.WeakSet()
+    _HOOKS: set["_Win32WindowProcHook"] = set()
     _HOOK_LOCK = threading.RLock()
 
     LRESULT = wintypes.LPARAM
@@ -187,6 +185,8 @@ if _IS_WINDOWS:  # pragma: win32-no-cover - exercised via integration on Windows
             if not _WIN32_APIS_READY:
                 raise RuntimeError("Win32 hooks are not available")
             self.hwnd = wintypes.HWND(hwnd)
+            self.owner_thread_id = threading.get_ident()
+            self.disposed = False
             self._callback = callback
             self._original: int | None = None
             self._wnd_proc = WNDPROC(self._procedure)
@@ -200,14 +200,32 @@ if _IS_WINDOWS:  # pragma: win32-no-cover - exercised via integration on Windows
             previous = _set_window_proc(self.hwnd, proc_pointer)
             self._original = previous if previous else None
 
-        def uninstall(self) -> None:
+        def dispose(self) -> None:
+            """Restore the window procedure explicitly on its owner thread."""
+            if threading.get_ident() != self.owner_thread_id:
+                raise RuntimeError("window hook disposal must run on its Tk owner thread")
+            if self.disposed:
+                return
             if self._original is None:
+                self.disposed = True
+                self._callback = None
+                self._wnd_proc = None
+                self.hwnd = None
+                _discard_hook(self)
                 return
             try:
                 _set_window_proc(self.hwnd, self._original)
             finally:
                 self._original = None
                 _discard_hook(self)
+                self._callback = None
+                self._wnd_proc = None
+                self.hwnd = None
+                self.disposed = True
+
+        def uninstall(self) -> None:
+            """Compatibility alias for :meth:`dispose`."""
+            self.dispose()
 
         def _forward_to_original(self, hwnd, msg, wparam, lparam):  # noqa: ANN001
             original = self._original
@@ -264,28 +282,6 @@ if _IS_WINDOWS:  # pragma: win32-no-cover - exercised via integration on Windows
                 return None
             return int(windowpos.cx), int(windowpos.cy)
 
-        def __del__(self) -> None:  # pragma: no cover - defensive cleanup
-            if _python_is_finalizing():
-                _discard_hook(self)
-                return
-            try:
-                self.uninstall()
-            except Exception:
-                LOGGER.debug("Ignoring error while uninstalling Win32 hook", exc_info=True)
-                _discard_hook(self)
-
-    def _uninstall_registered_hooks() -> None:
-        begin_shutdown()
-        with _HOOK_LOCK:
-            hooks = list(_HOOKS)
-        for hook in hooks:
-            try:
-                hook.uninstall()
-            except Exception:
-                LOGGER.debug("Ignoring error during registered hook uninstall", exc_info=True)
-
-    if _WIN32_APIS_READY:
-        atexit.register(_uninstall_registered_hooks)
 else:  # pragma: no cover - exercised only on non-Windows platforms
 
     class _Win32WindowProcHook:  # type: ignore[no-redef]
@@ -296,6 +292,8 @@ else:  # pragma: no cover - exercised only on non-Windows platforms
 
         def uninstall(self) -> None:  # pragma: no cover - never invoked
             raise RuntimeError("Win32 hooks are not supported on this platform")
+
+        dispose = uninstall
 
 
 def create_window_size_hook(

--- a/gui/utils/window_resizer.py
+++ b/gui/utils/window_resizer.py
@@ -19,24 +19,13 @@
 
 from __future__ import annotations
 
-import sys
 import threading
 import tkinter as tk
 from tkinter import ttk
 import typing as t
 
-from gui.utils.tk_utils import dispatch_to_ui, is_main_thread
 from gui.utils.win32_hooks import create_window_size_hook
 from gui.utils.tk_lifecycle_registry import TkLifecycleRegistry
-
-
-def _python_is_finalizing() -> bool:
-    """Return ``True`` when the Python interpreter is shutting down."""
-
-    finalizing = getattr(sys, "is_finalizing", None)
-    if finalizing is None:
-        return False
-    return bool(finalizing())
 
 
 class WindowResizeController:
@@ -59,6 +48,8 @@ class WindowResizeController:
         self._win32_hook = None
         self._use_win32_hook = use_win32_hook
         self.active = True
+        self.disposed = False
+        self.owner_thread_id = threading.get_ident()
         toplevel = getattr(win, "winfo_toplevel", None)
         root = toplevel() if callable(toplevel) else win
         self.lifecycle = TkLifecycleRegistry(root, threading.get_ident())
@@ -136,39 +127,50 @@ class WindowResizeController:
     # ------------------------------------------------------------------
     # Shutdown helpers
     # ------------------------------------------------------------------
-    def shutdown(self) -> None:
-        """Release bindings and native hooks held by the controller."""
+    def dispose(self) -> None:
+        """Release every owned GUI resource on the Tk owner thread once."""
 
-        finalizing = _python_is_finalizing()
-        if not finalizing and not is_main_thread():
-            dispatch_to_ui(self.win, self.shutdown)
+        if threading.get_ident() != self.owner_thread_id:
+            raise RuntimeError("window resizer disposal must run on its Tk owner thread")
+        if self.disposed:
             return
 
         hook = self._win32_hook
         if hook is not None:
             try:
-                hook.uninstall()
+                release_hook = getattr(hook, "dispose", None)
+                if not callable(release_hook):
+                    release_hook = hook.uninstall
+                release_hook()
             except Exception:
                 pass
             self._win32_hook = None
 
-        if not finalizing:
-            self.lifecycle.dispose_component(self)
-            self.active = False
-            self._binding_id = None
-            self._destroy_binding_id = None
+        lifecycle = self.lifecycle
+        lifecycle.dispose_component(self)
+        self.active = False
+        self.disposed = True
+        self._binding_id = None
+        self._destroy_binding_id = None
 
         self._callback = None
         self._targets.clear()
         self._primary = None
         self._last_size = None
+        self.win = None
+        self.lifecycle = None
+
+    def shutdown(self) -> None:
+        """Compatibility alias for :meth:`dispose`."""
+
+        self.dispose()
 
     def _on_win_destroy(self, event: tk.Event) -> None:
         """Handle ``<Destroy>`` events from the tracked toplevel."""
 
         widget = getattr(event, "widget", None)
         if widget is self.win:
-            self.shutdown()
+            self.dispose()
 
     # ------------------------------------------------------------------
     # Windows integration
@@ -386,11 +388,3 @@ class WindowResizeController:
                 )
             except Exception:
                 pass
-
-    def __del__(self) -> None:  # pragma: no cover - defensive cleanup
-        if _python_is_finalizing():
-            return
-        try:
-            self.shutdown()
-        except Exception:
-            pass

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.303"
+VERSION = "0.2.305"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/window/test_window_resizer_finalization.py
+++ b/tests/detachment/window/test_window_resizer_finalization.py
@@ -16,39 +16,85 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Finalization safety for the window resize controller."""
+"""Grouped explicit-disposal and post-Tk garbage-collection regressions."""
 
 from __future__ import annotations
+
+import gc
+import weakref
 
 import gui.utils.window_resizer as window_resizer
 
 
 class _StubWindow:
     def __init__(self) -> None:
-        self.unbind_calls: list[tuple[tuple[str, str], dict[str, str]]] = []
+        self.operations: list[str] = []
 
-    def wm_resizable(self, *_args, **_kwargs) -> None:  # pragma: no cover - noop
-        return None
+    def winfo_toplevel(self):
+        return self
 
-    def bind(self, *args, **_kwargs) -> str:  # pragma: no cover - basic stub
-        return f"bind-{args[0]}"
+    def wm_resizable(self, *_args) -> None:
+        self.operations.append("resizable")
 
-    def unbind(self, *args, **kwargs) -> None:  # pragma: no cover - tracking only
-        self.unbind_calls.append((args, kwargs))
+    def bind(self, sequence, _callback, *_args) -> str:
+        self.operations.append(f"bind:{sequence}")
+        return f"bind-{sequence}"
 
-    def winfo_id(self) -> None:  # pragma: no cover - disable Win32 hook install
-        return None
+    def unbind(self, sequence, identifier) -> None:
+        self.operations.append(f"unbind:{sequence}:{identifier}")
+
+    def winfo_id(self) -> int:
+        return 42
+
+    def destroy(self) -> None:
+        self.operations.append("destroy")
 
 
-def test_shutdown_skips_finalizing(monkeypatch) -> None:
-    """Ensure shutdown avoids Tk/Win32 work during interpreter finalization."""
+class _StubHook:
+    def __init__(self) -> None:
+        self.dispose_calls = 0
 
-    win = _StubWindow()
-    monkeypatch.setattr(window_resizer, "_python_is_finalizing", lambda: False)
-    controller = window_resizer.WindowResizeController(win)
-    monkeypatch.setattr(window_resizer, "_python_is_finalizing", lambda: True)
+    def dispose(self) -> None:
+        self.dispose_calls += 1
 
-    controller.shutdown()
 
-    assert win.unbind_calls == []
+class TestExplicitResizeControllerDisposal:
+    """Idempotence and deterministic resource release."""
 
+    def test_dispose_unregisters_owned_resources_exactly_once(self, monkeypatch) -> None:
+        window = _StubWindow()
+        hook = _StubHook()
+        monkeypatch.setattr(window_resizer, "create_window_size_hook", lambda *_args: hook)
+        controller = window_resizer.WindowResizeController(window)
+
+        controller.dispose()
+        controller.dispose()
+
+        assert hook.dispose_calls == 1
+        assert sum(item.startswith("unbind:<Configure>") for item in window.operations) == 1
+        assert sum(item.startswith("unbind:<Destroy>") for item in window.operations) == 1
+        assert controller.disposed is True
+        assert controller.win is None
+        assert controller.tracked_widgets == ()
+
+
+class TestPostRootDestructionGarbageCollection:
+    """Garbage collection is deliberately free of Tk and native-hook work."""
+
+    def test_gc_after_root_destroy_performs_no_lifecycle_operation(self, monkeypatch) -> None:
+        window = _StubWindow()
+        hook = _StubHook()
+        monkeypatch.setattr(window_resizer, "create_window_size_hook", lambda *_args: hook)
+        controller = window_resizer.WindowResizeController(window)
+        controller.dispose()
+        window.destroy()
+        operation_count = len(window.operations)
+        hook_call_count = hook.dispose_calls
+        reference = weakref.ref(controller)
+
+        del controller
+        gc.collect()
+
+        assert reference() is None
+        assert len(window.operations) == operation_count
+        assert hook.dispose_calls == hook_call_count

--- a/tests/lifecycle/test_application_lifecycle_controller.py
+++ b/tests/lifecycle/test_application_lifecycle_controller.py
@@ -78,6 +78,26 @@ class TestShutdownRequests:
         with pytest.raises(RuntimeError, match="shutdown has started"):
             lifecycle.require_running()
 
+    def test_detached_window_is_disposed_once_before_root_destruction(self):
+        root = FakeRoot()
+
+        class DetachedWindow:
+            calls = 0
+
+            def dispose(self):
+                assert "destroy" not in root.calls
+                self.calls += 1
+
+        window = DetachedWindow()
+        app = FakeApp()
+        app.lifecycle_ui._detached_tab_windows["tab"] = window
+        lifecycle = ApplicationLifecycleController(root)
+        lifecycle.attach(app)
+
+        assert lifecycle.shutdown() is True
+        assert lifecycle.shutdown() is False
+        assert window.calls == 1
+
 
 class TestOwnerThreadPolicy:
     """Every shutdown entry point is constrained to the Tk owner thread."""


### PR DESCRIPTION
### Motivation

- Prevent Tcl/Tk and native Win32 work from running implicitly during interpreter finalization by removing GUI/Tcl access from destructors and `atexit` paths. 
- Provide deterministic, idempotent lifecycle semantics so window-resizer and native hook cleanup is explicit, owner-thread bound, and auditable. 
- Ensure detached-window teardown and central application shutdown call into explicit disposal APIs to avoid hidden widget/Tcl interactions at GC or process shutdown. 

### Description

- Add an owner-thread, idempotent `dispose()` to `WindowResizeController` that asserts the owner thread, unregisters lifecycle bindings, releases the native hook via a safe alias, clears widget and callback references, and marks the controller disposed, with `shutdown()` preserved as a compatibility alias (`gui/utils/window_resizer.py`).
- Replace Win32 hook destructor/atexit teardown with an explicit `dispose()` (and keep `uninstall()` as an alias) that restores the original window procedure on the owner thread and clears internal references and registry entries (`gui/utils/win32_hooks.py`).
- Route detached-window and detachable-tab cleanup to call the explicit disposal APIs (use `dispose()` on resizers and detachable hosts) and add owner-thread assertions and idempotence to those hosts (`gui/utils/detached_window.py`, `gui/utils/detachable_tab_window.py`, `gui/utils/closable_notebook.py`).
- Harden lifecycle registry cleanup to null out retained `target` and `previous` references after cancellation so cancelled registrations do not retain Tk objects (`gui/utils/tk_lifecycle_registry.py`).
- Add grouped lifecycle regression tests that verify explicit `dispose()` is called exactly once and that forcing garbage collection after root/window destruction results in no further Tk or native-hook activity (`tests/detachment/window/test_window_resizer_finalization.py`, updated lifecycle tests in `tests/lifecycle/test_application_lifecycle_controller.py`).
- Update repository documentation and version to reflect the change (`HISTORY.md`, `README.md`, `mainappsrc/version.py`).

### Testing

- Ran targeted tests: `pytest -q tests/detachment/window/test_window_resizer_finalization.py tests/detachment/window/test_window_resizer.py tests/lifecycle/test_application_lifecycle_controller.py tests/test_version_sync.py` resulting in 18 passed.
- Ran project complexity analysis with `radon cc` over the modified files producing JSON results with average complexity `3.61`, maximum `13`, and ranks `{A:70, B:16, C:1}`.
- Verified byte-compilation for changed modules and performed `git diff --check` to ensure no whitespace or trivial errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d69eb895c83278e054f775045355c)